### PR TITLE
Tweaks:

### DIFF
--- a/swoc++/include/swoc/BufferWriter.h
+++ b/swoc++/include/swoc/BufferWriter.h
@@ -253,7 +253,7 @@ public:
    * @see NameBinding
    */
   template <typename Binding, typename Extractor>
-  BufferWriter &print_nfv(Binding const &names, Extractor &&ex, bwf::ArgPack const &args);
+  BufferWriter &print_nfv(Binding &&names, Extractor &&ex, bwf::ArgPack const &args);
 
   /** Write formatted output of @a args to @a this buffer.
    *

--- a/swoc++/include/swoc/MemArena.h
+++ b/swoc++/include/swoc/MemArena.h
@@ -167,7 +167,7 @@ public:
    * must be explicitly called, which will clean up all of the allocated memory. See the
    * documentation for further details.
    */
-  static self_type *make(size_t n = DEFAULT_BLOCK_SIZE);
+  static self_type *construct_self_contained(size_t n = DEFAULT_BLOCK_SIZE);
 
   /** Allocate @a n bytes of storage.
 

--- a/swoc++/include/swoc/bwf_base.h
+++ b/swoc++/include/swoc/bwf_base.h
@@ -838,7 +838,7 @@ namespace bwf
 
 template <typename Binding, typename Extractor>
 BufferWriter &
-BufferWriter::print_nfv(Binding const &names, Extractor &&ex, bwf::ArgPack const &args)
+BufferWriter::print_nfv(Binding &&names, Extractor &&ex, bwf::ArgPack const &args)
 {
   using namespace std::literals;
   // This gets the actual specifier type from the Extractor - it must be a subclass of @c bwf::Spec

--- a/swoc++/include/swoc/bwf_fwd.h
+++ b/swoc++/include/swoc/bwf_fwd.h
@@ -1,0 +1,34 @@
+/** @file
+
+    Forward declarations for BufferWriter formatting.
+
+    @section license License
+
+    Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+    agreements.  See the NOTICE file distributed with this work for additional information regarding
+    copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with the License.  You may
+    obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+    express or implied. See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#pragma once
+
+namespace swoc
+{
+class BufferWriter;
+class FixedBufferWriter;
+template < size_t N > class LocalBufferWriter;
+
+namespace bwf
+{
+  struct Spec;
+  class Format;
+} // namespace bwf
+} // namespace swoc

--- a/swoc++/src/MemArena.cc
+++ b/swoc++/src/MemArena.cc
@@ -47,7 +47,7 @@ MemArena::MemArena(swoc::MemArena::self_type &&that)
 }
 
 MemArena *
-MemArena::make(size_t n)
+MemArena::construct_self_contained(size_t n)
 {
   MemArena tmp;
   return tmp.make<MemArena>(std::move(tmp));

--- a/unit_tests/test_MemArena.cc
+++ b/unit_tests/test_MemArena.cc
@@ -284,12 +284,12 @@ TEST_CASE("MemArena esoterica", "[libswoc][MemArena]")
   REQUIRE(a1.remaining() >= 384);
 
   {
-    MemArena *arena = MemArena::make();
+    MemArena *arena = MemArena::construct_self_contained();
     arena->~MemArena();
   }
 
   {
-    std::unique_ptr<MemArena, void (*)(MemArena *)> arena(MemArena::make(), [](MemArena *arena) -> void { arena->~MemArena(); });
+    std::unique_ptr<MemArena, void (*)(MemArena *)> arena(MemArena::construct_self_contained(), [](MemArena *arena) -> void { arena->~MemArena(); });
     static constexpr unsigned MAX = 512;
     std::uniform_int_distribution<unsigned> length_gen{6, MAX};
     char buffer[MAX];


### PR DESCRIPTION
*  Binding is && instead of const& for BufferWriter::print_nfv
*  MemArena::make (static) is make_self_contained, to avoid confusion with MemArena::make
*  Add bwf_fwd.h for simple forward declares.