### PR TITLE
Fix IPSpace blending issue, add ex_netdb example.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(INSTALL_DIR ${CMAKE_HOME_DIRECTORY})
 # Fortunately this has no external dependencies so the set up can be simple.
 add_subdirectory(swoc++)
 add_subdirectory(unit_tests)
+add_subdirectory(example)
 add_subdirectory(doc EXCLUDE_FROM_ALL)
 
 # Find all of the directories subject to clang formatting and make a target to do the format.

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "LibSWOC++"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "1.1.1"
+PROJECT_NUMBER         = "1.1.2"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doc/code/IPSpace.en.rst
+++ b/doc/code/IPSpace.en.rst
@@ -170,7 +170,7 @@ Blending Bitsets
 
    Some details are omitted for brevity and because they aren't directly relevant. The full
    implementation, which is run as a unit test to verify its correctness,
-   `is available here <https://github.com/SolidWallOfCode/libswoc/blob/1.1.1/unit_tests/ex_ipspace_properties.cc>`__.
+   `is available here <https://github.com/SolidWallOfCode/libswoc/blob/1.1.2/unit_tests/ex_ipspace_properties.cc>`__.
    You can compile and step through the code to see how it works in more detail, or experiment
    with changing some of the example data.
 

--- a/doc/code/TextView.en.rst
+++ b/doc/code/TextView.en.rst
@@ -275,7 +275,7 @@ separated by commas.
 
 .. sidebar:: Verification
 
-   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.1.1/unit_tests/ex_TextView.cc#L67>`__.
+   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.1.2/unit_tests/ex_TextView.cc#L67>`__.
 
 If :arg:`value` was :literal:`bob  ,dave, sam` then :arg:`token` would be successively
 :literal:`bob`, :literal:`dave`, :literal:`sam`. After :literal:`sam` was extracted :arg:`value`
@@ -297,7 +297,7 @@ for values that are boolean.
 
 .. sidebar:: Verification
 
-   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.1.1/unit_tests/ex_TextView.cc#L74>`__.
+   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.1.2/unit_tests/ex_TextView.cc#L74>`__.
 
 The basic list processing is the same as the previous example, with each element being treated as
 a "list" with ``=`` as the separator. Note if there is no ``=`` character then all of the list
@@ -348,7 +348,7 @@ do not, so a flag to strip quotes from the resulting elements is needed. The fin
 
 .. sidebar:: Verification
 
-   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.1.1/unit_tests/ex_TextView.cc#L90>`__.
+   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.1.2/unit_tests/ex_TextView.cc#L90>`__.
 
 This takes a :code:`TextView&` which is the source view which will be updated as tokens are removed
 (therefore the caller must do the empty view check). The other arguments are the separator character

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -80,7 +80,7 @@ project = u'Solid Wall Of C++'
 copyright = u'{}, amc@apache.org'.format(date.today().year)
 
 # The full version, including alpha/beta/rc tags.
-release = "1.1.1"
+release = "1.1.2"
 # The short X.Y version.
 version = '.'.join(release.split('.', 2)[:2])
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.12)
+project(libswoc_examples CXX)
+set(CMAKE_CXX_STANDARD 17)
+
+add_executable(ex_netdb
+    ex_netdb.cc
+    )
+
+target_link_libraries(ex_netdb PUBLIC swoc++)
+set_target_properties(ex_netdb PROPERTIES CLANG_FORMAT_DIRS ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_options(ex_netdb PRIVATE -Wall -Wextra -Werror -Wno-unused-parameter -Wno-format-truncation -Wno-stringop-overflow -Wno-invalid-offsetof)

--- a/example/ex_netdb.cc
+++ b/example/ex_netdb.cc
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2014 Network Geographics
+
+/** @file
+
+    Example tool to process network DB files.
+
+    This generates an executable that processes a list of network files in a specific format.
+    Tokens are (variable) space separated. Example lines look like
+
+    4441:34F8:1E40:1EF:0:0:A0:0/108  partner:ngeo  raz     ?_  prod,dmz         "shared space"
+    4441:34F8:1E40:1EF:0:0:B0:0/108  yahoo  raz     ?_  prod,dmz         "local routing"
+
+    There is
+    - an IP address network
+    - type/owner field. If "yahoo", it's type "yahoo" and owner "yahoo". Otherwise it's a
+      partner network, with "partner:" followed by the partner name.
+    - pod / colo code
+    - Useless column marker
+    - Network property flags
+    - Comment in double quotes
+
+    The goal is to transform this in a standard CSV file, dropping the useless column, and
+    tweaking the flags to use ';' instead of ',' as a separator (to avoid confusing the CSV).
+    Adjacent networks with identical properties should also be merged to reduce the data set size.
+    The comments may or not be kept - currently the implement discards them to get better
+    network coalescence. One of the goals of the over all work is to make it easy to build
+    variants of this code to output CSV files tuned to specific uses.
+*/
+
+#include <unordered_set>
+#include <fstream>
+
+#include <swoc/TextView.h>
+#include <swoc/swoc_ip.h>
+#include <swoc/bwf_ip.h>
+#include <swoc/bwf_std.h>
+#include <swoc/bwf_ex.h>
+#include <swoc/swoc_file.h>
+#include <swoc/Lexicon.h>
+
+using namespace std::literals;
+using namespace swoc::literals;
+
+using swoc::TextView;
+using swoc::IPEndpoint;
+
+using swoc::IP4Addr;
+using swoc::IP4Range;
+
+using swoc::IP6Addr;
+using swoc::IP6Range;
+
+using swoc::IPAddr;
+using swoc::IPRange;
+
+using swoc::IPMask;
+
+/// Type for temporary buffer writer output.
+using W = swoc::LocalBufferWriter<512>;
+
+/// Network properties.
+enum class Flag {
+  INVALID = -1, ///< Value for initialization, invalid.
+  INTERNAL = 0, ///< Internal network.
+  PROD, ///< Production network.
+  DMZ, ///< DMZ
+  SECURE, ///< Secure network
+  NONE ///< No flags - useful because the input uses "-" sometimes to mark no properties.
+};
+
+namespace std {
+/// Make the enum size look like a tuple size.
+template <> struct tuple_size<Flag> : public std::integral_constant<size_t, static_cast<size_t>(Flag::NONE)> {};
+} // namespace std
+
+/// Bit set for network property flags.
+using FlagSet = std::bitset<std::tuple_size<Flag>::value>;
+
+/// Pod type.
+enum class PodType {
+  INVALID, ///< Initialization value.
+  YAHOO, ///< Yahoo! pod.
+  PARTNER ///< Partner pod.
+};
+
+/// Mapping of names and property flags.
+swoc::Lexicon<Flag> FlagNames {{
+                                   {Flag::NONE, {"-", "NONE"}}
+                                   , {Flag::INTERNAL, { "internal" }}
+                                   , {Flag::PROD, {"prod"}}
+                                   , {Flag::DMZ, {"dmz"}}
+                                   , {Flag::SECURE, {"secure"}}
+                               }};
+
+/// Mapping of names and pod types.
+swoc::Lexicon<PodType> PodTypeNames {{
+                                   {PodType::YAHOO, "yahoo"}
+                                   , {PodType::PARTNER, "partner"}
+                               }};
+
+// Create BW formatters for the types so they can be used for output.
+namespace swoc {
+
+BufferWriter& bwformat(BufferWriter& w, bwf::Spec const& spec, PodType pt) {
+  return w.write(PodTypeNames[pt]);
+}
+
+BufferWriter& bwformat(BufferWriter& w, bwf::Spec const& spec, FlagSet const& flags) {
+  bool first_p = true; // Track to get separators correct.
+  // Loop through the indices and write the flag name if it's set.
+  for ( unsigned idx = 0 ; idx < std::tuple_size<Flag>::value ; ++idx) {
+    if (flags[idx]) {
+      if (!first_p) {
+        w.write(';');
+      }
+      w.write(FlagNames[static_cast<Flag>(idx)]);
+      first_p = false;
+    }
+  }
+  return w;
+}
+
+} // namespace swoc
+
+// These are used to keep pointers for the same string identical so the payloads
+// can be directly compared.
+std::unordered_set<TextView, std::hash<std::string_view>> PodNames;
+std::unordered_set<TextView, std::hash<std::string_view>> OwnerNames;
+std::unordered_set<TextView, std::hash<std::string_view>> Descriptions;
+
+/// The "color" for the IPSpace.
+struct Payload {
+  PodType _type = PodType::INVALID; ///< Type of ownership.
+  TextView _owner; ///< Corporate owner.
+  TextView _pod; ///< Pod / colocation.
+  TextView _descr; ///< Description / comment
+  FlagSet _flags; ///< Flags.
+
+  /// @return @c true if @a this is equal to @a that.
+  bool operator == (Payload const& that) {
+    return _type == that._type &&
+    _owner == that._owner &&
+    _pod == that._pod &&
+    _flags == that._flags &&
+    _descr == that._descr;
+  }
+
+  /// @return @c true if @a this is not equal to @a that.
+  bool operator != (Payload const& that) {
+    return ! (*this == that);
+  }
+};
+
+
+/// IPSpace for mapping address to @c Payload
+using Space = swoc::IPSpace<Payload>;
+
+/// Place to store strings parsed from the input files.
+swoc::MemArena Storage;
+
+/// Convert a parsed string into a stored string to make the pointer persistent.
+TextView store(TextView const& text) {
+  auto span = Storage.alloc(text.size()).rebind<char>();
+  memcpy(span, text);
+  return span.view();
+}
+
+/// Process the @a content of a file in to @a space.
+void process(Space& space, TextView content) {
+  int line_no = 0; /// Track for error reporting.
+
+  // For each line in @a content
+  for  (TextView line ; ! (line = content.take_prefix_at('\n')).empty() ; ) {
+    ++line_no;
+    line.trim_if(&isspace);
+    // Allow empty lines and '#' comments without error.
+    if (line.empty() || '#' == *line) {
+      continue;
+    }
+
+    // Get the range, make sure it's a valid range.
+    auto range_token = line.take_prefix_if(&isspace);
+    IPRange range{range_token};
+    if (range.empty()) {
+      std::cerr << W().print("Invalid range '{}' on line {}\n", range_token, line_no);
+      continue;
+    }
+
+    // Get the owner / type.
+    auto owner_token = line.ltrim_if(&isspace).take_prefix_if(&isspace);
+    PodType pod_type = PodType::YAHOO; // default to this if no owner specifier found.
+    if (auto type_token = owner_token.split_prefix_at(':') ; ! type_token.empty()) {
+      pod_type = PodTypeNames[type_token];
+      if (PodType::INVALID == pod_type) {
+        std::cerr << W().print("Invalid type '{}' on line {}\n", type_token, line_no);
+        continue;
+      }
+    }
+
+    // normalize owner
+    if ( auto spot = OwnerNames.find(owner_token) ; spot == OwnerNames.end()) {
+      owner_token = store(owner_token);
+      OwnerNames.insert(owner_token);
+    } else {
+      owner_token = *spot;
+    }
+
+    // Get the pod code.
+    auto pod_token = line.ltrim_if(&isspace).take_prefix_if(&isspace);
+
+    // normalize
+    if ( auto spot = PodNames.find(pod_token) ; spot == PodNames.end()) {
+      pod_token = store(pod_token);
+      PodNames.insert(pod_token);
+    } else {
+      pod_token = *spot;
+    }
+
+    line.ltrim_if(&isspace).take_prefix_if(&isspace); // skip bogus column.
+
+    // Work on the flags.
+    auto flag_token = line.ltrim_if(&isspace).take_prefix_if(&isspace);
+    FlagSet flags;
+    // Loop over the token, picking out comma separated keys.
+    for ( TextView key ; ! (key = flag_token.take_prefix_at(',')).empty() ; ) {
+      auto idx = FlagNames[key]; // look up the key.
+      if (Flag::INVALID == idx) {
+        std::cerr << W().print("Invalid flag '{}' on line {}\n", key, line_no);
+        continue;
+      }
+      if (idx != Flag::NONE) { // "NONE" means the input was marked explicitly as no flags.
+        flags[int(idx)] = true;
+      }
+    }
+
+    #if 0
+    // The description is what's left, trim the spaces and then the quotes.
+    auto descr_token = line.trim_if(&isspace).trim('"');
+    // normalize
+    if ( auto spot = Descriptions.find(descr_token) ; spot == Descriptions.end()) {
+      descr_token = store(descr_token);
+      Descriptions.insert(descr_token);
+    } else {
+      descr_token = *spot;
+    }
+    #endif
+
+    // Everything went OK, create the payload and put it in the space.
+    Payload payload{pod_type, owner_token, pod_token, {}, flags};
+    space.blend(range, payload, [&](Payload & lhs, Payload const& rhs) {
+      // It's an error if there's overlap that's not consistent.
+      if (lhs._type != PodType::INVALID && lhs != rhs) {
+        std::cerr << W().print("Range collision while blending {} on line {}\n", range, line_no);
+      }
+      lhs = rhs;
+      return true;
+    });
+  }
+}
+
+int main(int argc, char *argv[]) {
+  Space space;
+
+  // Set the defaults so bogus input doesn't throw.
+  PodTypeNames.set_default(PodType::INVALID);
+  FlagNames.set_default(Flag::INVALID);
+
+  // Open the output file.
+  std::ofstream output;
+  output.open("vz_netdb.csv", std::ofstream::out | std::ofstream::trunc);
+  if (! output.is_open()) {
+    std::cerr << W().print("Unable to open output file: {}", swoc::bwf::Errno{errno});
+  }
+
+  // Process the files in the command line.
+  for ( int idx = 1 ; idx < argc ; ++idx ) {
+    swoc::file::path path(argv[idx]);
+    std::error_code ec;
+    std::string content = swoc::file::load(path, ec);
+    if (! ec) {
+      std::cout << W().print("Processing {}, {} bytes\n", path, content.size());
+      process(space, content);
+    }
+  }
+
+  // Dump the resulting space.
+  std::cout << W().print("{} ranges\n", space.count());
+  for ( auto && [ r, p] : space) {
+    // Note - if description is to be used, it needs to be added here.
+    output << W().print("{},{},{},{},{}\n", r, p._type, p._owner, p._pod, p._flags);
+  }
+
+  return 0;
+}

--- a/swoc++/CMakeLists.txt
+++ b/swoc++/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(lib-swoc++ CXX)
-set(LIBSWOC_VERSION "1.1.1")
+set(LIBSWOC_VERSION "1.1.2")
 set(CMAKE_CXX_STANDARD 17)
 include(GNUInstallDirs)
 

--- a/swoc++/include/swoc/BufferWriter.h
+++ b/swoc++/include/swoc/BufferWriter.h
@@ -243,7 +243,7 @@ public:
    * - A conversion to @c bool that indicates if there is data left.
    * - A function of the signature <tt>bool ex(std::string_view& lit, bwf::Spec & spec)</tt>
    *
-   * The latter must return whether a specificer was parsed, while filling in @a lit and @a spec
+   * The latter must return whether a specifier was parsed, while filling in @a lit and @a spec
    * as appropriate for the next chunk of format string. No literal is represented by a empty
    * @a lit.
    *

--- a/swoc++/include/swoc/swoc_version.h
+++ b/swoc++/include/swoc/swoc_version.h
@@ -39,5 +39,5 @@ namespace swoc
 {
 static constexpr unsigned MAJOR_VERSION = 1;
 static constexpr unsigned MINOR_VERSION = 1;
-static constexpr unsigned POINT_VERSION = 1;
+static constexpr unsigned POINT_VERSION = 2;
 } // namespace swoc

--- a/swoc++/swoc++.part
+++ b/swoc++/swoc++.part
@@ -1,6 +1,6 @@
 Import("*")
 PartName("libswoc")
-PartVersion("1.1.1")
+PartVersion("1.1.2")
 
 src_files = [
     "src/ArenaWriter.cc",

--- a/unit_tests/ex_ipspace_properties.cc
+++ b/unit_tests/ex_ipspace_properties.cc
@@ -51,7 +51,7 @@ TEST_CASE("IPSpace bitset blending", "[libswoc][ipspace][bitset][blending]") {
   // Declare the IPSpace.
   using Space = swoc::IPSpace<PAYLOAD>;
   // Example data type.
-  using Data = std::tuple<TextView, std::initializer_list<unsigned>>;
+  using Data = std::tuple<TextView, PAYLOAD>;
 
   // Dump the ranges to stdout.
   auto dump = [](Space&space) -> void {
@@ -64,10 +64,10 @@ TEST_CASE("IPSpace bitset blending", "[libswoc][ipspace][bitset][blending]") {
   };
 
   // Convert a list of bit indices into a bitset.
-  auto make_bits = [](std::initializer_list<unsigned> idx) -> PAYLOAD {
+  auto make_bits = [](std::initializer_list<unsigned> indices) -> PAYLOAD {
     PAYLOAD bits;
-    for (auto bit : idx) {
-      bits[bit] = true;
+    for (auto idx : indices) {
+      bits[idx] = true;
     }
     return bits;
   };
@@ -81,8 +81,8 @@ TEST_CASE("IPSpace bitset blending", "[libswoc][ipspace][bitset][blending]") {
   // Example marking functor.
   auto marker = [&](Space & space, swoc::MemSpan<Data> ranges) -> void {
     // For each test range, compute the bitset from the list of bit indices.
-    for (auto &&[text, bit_list] : ranges) {
-      space.blend(IPRange{text}, make_bits(bit_list), blender);
+    for (auto &&[text, bits] : ranges) {
+      space.blend(IPRange{text}, bits, blender);
     }
   };
 
@@ -91,13 +91,13 @@ TEST_CASE("IPSpace bitset blending", "[libswoc][ipspace][bitset][blending]") {
 
   // test ranges 1
   std::array<Data, 7> ranges_1 = {{
-        { "100.0.0.0-100.0.0.255", { 0 } }
-      , { "100.0.1.0-100.0.1.255", { 1 } }
-      , { "100.0.2.0-100.0.2.255", { 2 } }
-      , { "100.0.3.0-100.0.3.255", { 3 } }
-      , { "100.0.4.0-100.0.4.255", { 4 } }
-      , { "100.0.5.0-100.0.5.255", { 5 } }
-      , { "100.0.6.0-100.0.6.255", { 6 } }
+        { "100.0.0.0-100.0.0.255", make_bits({ 0 }) }
+      , { "100.0.1.0-100.0.1.255", make_bits({ 1 }) }
+      , { "100.0.2.0-100.0.2.255", make_bits({ 2 }) }
+      , { "100.0.3.0-100.0.3.255", make_bits({ 3 }) }
+      , { "100.0.4.0-100.0.4.255", make_bits({ 4 }) }
+      , { "100.0.5.0-100.0.5.255", make_bits({ 5 }) }
+      , { "100.0.6.0-100.0.6.255", make_bits({ 6 }) }
   }};
 
   marker(space, MemSpan<Data>{ranges_1.data(), ranges_1.size()});
@@ -105,9 +105,9 @@ TEST_CASE("IPSpace bitset blending", "[libswoc][ipspace][bitset][blending]") {
 
   // test ranges 2
   std::array<Data, 3> ranges_2 = {{
-      { "100.0.0.0-100.0.0.255", { 31 } }
-    , { "100.0.1.0-100.0.1.255", { 30 } }
-    , { "100.0.2.128-100.0.3.127", { 29 }}
+      { "100.0.0.0-100.0.0.255", make_bits({ 31 }) }
+    , { "100.0.1.0-100.0.1.255", make_bits({ 30 }) }
+    , { "100.0.2.128-100.0.3.127", make_bits({ 29 }) }
   }};
 
   marker(space, MemSpan<Data>{ranges_2.data(), ranges_2.size()});
@@ -115,7 +115,7 @@ TEST_CASE("IPSpace bitset blending", "[libswoc][ipspace][bitset][blending]") {
 
   // test ranges 3
   std::array<Data, 1> ranges_3 = {{
-      { "100.0.2.0-100.0.4.255", { 2, 3, 29 }}
+      { "100.0.2.0-100.0.4.255", make_bits({ 2, 3, 29 })}
   }};
 
   marker(space, MemSpan<Data>{ranges_3.data(), ranges_3.size()});

--- a/unit_tests/test_bw_format.cc
+++ b/unit_tests/test_bw_format.cc
@@ -32,6 +32,7 @@
 #include "catch.hpp"
 
 using namespace std::literals;
+using namespace swoc::literals;
 using swoc::TextView;
 using swoc::bwprint;
 
@@ -58,56 +59,44 @@ TEST_CASE("bwprint basics", "[bwprint]")
 
   bw.print(fmt1);
   REQUIRE(bw.view() == fmt1);
-  bw.clear();
-  bw.print("Arg {}", 1);
+  bw.clear().print("Some text"); // check that a literal string works as expected.
+  REQUIRE(bw.view() == fmt1);
+  bw.clear().print("Some text"_tv); // check that a literal TextView works.
+  REQUIRE(bw.view() == fmt1);
+  bw.clear().print("Arg {}", 1);
   REQUIRE(bw.view() == "Arg 1");
-  bw.clear();
-  bw.print("arg 1 {1} and 2 {2} and 0 {0}", "zero", "one", "two");
+  bw.clear().print("arg 1 {1} and 2 {2} and 0 {0}", "zero", "one", "two");
   REQUIRE(bw.view() == "arg 1 one and 2 two and 0 zero");
-  bw.clear();
-  bw.print("args {2}{0}{1}", "zero", "one", "two");
+  bw.clear().print("args {2}{0}{1}", "zero", "one", "two");
   REQUIRE(bw.view() == "args twozeroone");
-  bw.clear();
-  bw.print("left |{:<10}|", "text");
+  bw.clear().print("left |{:<10}|", "text");
   REQUIRE(bw.view() == "left |text      |");
-  bw.clear();
-  bw.print("right |{:>10}|", "text");
+  bw.clear().print("right |{:>10}|", "text");
   REQUIRE(bw.view() == "right |      text|");
-  bw.clear();
-  bw.print("right |{:.>10}|", "text");
+  bw.clear().print("right |{:.>10}|", "text");
   REQUIRE(bw.view() == "right |......text|");
-  bw.clear();
-  bw.print("center |{:.^10}|", "text");
+  bw.clear().print("center |{:.^10}|", "text");
   REQUIRE(bw.view() == "center |...text...|");
-  bw.clear();
-  bw.print("center |{:.^11}|", "text");
+  bw.clear().print("center |{:.^11}|", "text");
   REQUIRE(bw.view() == "center |...text....|");
-  bw.clear();
-  bw.print("center |{:^^10}|", "text");
+  bw.clear().print("center |{:^^10}|", "text");
   REQUIRE(bw.view() == "center |^^^text^^^|");
-  bw.clear();
-  bw.print("center |{:%3A^10}|", "text");
+  bw.clear().print("center |{:%3A^10}|", "text");
   REQUIRE(bw.view() == "center |:::text:::|");
-  bw.clear();
-  bw.print("left >{0:<9}< right >{0:>9}< center >{0:^9}<", 956);
+  bw.clear().print("left >{0:<9}< right >{0:>9}< center >{0:^9}<", 956);
   REQUIRE(bw.view() == "left >956      < right >      956< center >   956   <");
 
-  bw.clear();
-  bw.print("Format |{:>#010x}|", -956);
+  bw.clear().print("Format |{:>#010x}|", -956);
   REQUIRE(bw.view() == "Format |0000-0x3bc|");
-  bw.clear();
-  bw.print("Format |{:<#010x}|", -956);
+  bw.clear().print("Format |{:<#010x}|", -956);
   REQUIRE(bw.view() == "Format |-0x3bc0000|");
-  bw.clear();
-  bw.print("Format |{:#010x}|", -956);
+  bw.clear().print("Format |{:#010x}|", -956);
   REQUIRE(bw.view() == "Format |-0x00003bc|");
 
-  bw.clear();
-  bw.print("{{BAD_ARG_INDEX:{} of {}}}", 17, 23);
+  bw.clear().print("{{BAD_ARG_INDEX:{} of {}}}", 17, 23);
   REQUIRE(bw.view() == "{BAD_ARG_INDEX:17 of 23}");
 
-  bw.clear();
-  bw.print("Arg {0} Arg {3}", 0, 1);
+  bw.clear().print("Arg {0} Arg {3}", 0, 1);
   REQUIRE(bw.view() == "Arg 0 Arg {BAD_ARG_INDEX:3 of 2}");
 
   bw.clear().print("{{stuff}} Arg {0} Arg {}", 0, 1, 2);


### PR DESCRIPTION
`IPSpace::blend` was not always coalescing when possible. The results were correct but suboptimal.

The `ex_netdb` program was added as a working example of using libswoc and IPSpace in particular for handling network data.