### PR TITLE
[swoc_meta] Add helper variable template for is_any_of

### DIFF
--- a/swoc++/include/swoc/swoc_meta.h
+++ b/swoc++/include/swoc/swoc_meta.h
@@ -149,6 +149,10 @@ template<typename T, typename... Types> struct is_any_of {
   static constexpr bool value = std::disjunction<std::is_same<T, Types>...>::value;
 };
 
+/// Helper variable template for is_any_of
+template <typename T, typename... Types>
+inline constexpr bool is_any_of_v = is_any_of<T, Types...>::value;
+
 /** Type list support class.
  *
  * @tparam Types List of types.

--- a/unit_tests/test_meta.cc
+++ b/unit_tests/test_meta.cc
@@ -53,6 +53,9 @@ TEST_CASE("Meta Example", "[meta][example]")
   REQUIRE(true == swoc::meta::is_any_of<A, A>::value);
   REQUIRE(false == swoc::meta::is_any_of<A, D>::value);
   REQUIRE(false == swoc::meta::is_any_of<A>::value); // verify degenerate use case.
+
+  REQUIRE(true == swoc::meta::is_any_of_v<A, A, B, C>);
+  REQUIRE(false == swoc::meta::is_any_of_v<D, A, B, C>);
 }
 
 // Start of ts::meta testing.


### PR DESCRIPTION
Add a helper variable template for is_any_of. This is a convenient way to *not* use `::value`, make it less verbose