### PR TITLE
Release 1.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@
 *.out
 *.app
 
-.idea
+.idea/
 cmake-build-debug
 doc/_build
 doc/doxygen

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,0 @@
-<component name="ProjectCodeStyleConfiguration">
-  <state>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
-  </state>
-</component>

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(Lib-SWOC CXX)
-set(LIBSWOC_VERSION "1.2.1")
+set(LIBSWOC_VERSION "1.2.2")
 set(CMAKE_CXX_STANDARD 17)
 include(GNUInstallDirs)
 

--- a/code/include/swoc/swoc_ip.h
+++ b/code/include/swoc/swoc_ip.h
@@ -1648,9 +1648,9 @@ public:
    */
   iterator find(IPAddr const& addr) {
     if (addr.is_ip4()) {
-      return iterator(_ip4.find(IP4Addr{addr}), _ip6.begin());
+      return this->find(addr.ip4());
     } else if (addr.is_ip6()) {
-      return iterator(_ip4.end(), _ip6.find(IP6Addr{addr}));
+      return this->find(addr.ip6());
     }
     return this->end();
   }

--- a/code/include/swoc/swoc_version.h
+++ b/code/include/swoc/swoc_version.h
@@ -22,11 +22,11 @@
 #pragma once
 
 #if !defined(SWOC_VERSION_NS)
-#  define SWOC_VERSION_NS _1_2_1
+#  define SWOC_VERSION_NS _1_2_2
 #endif
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 static constexpr unsigned MAJOR_VERSION = 1;
 static constexpr unsigned MINOR_VERSION = 2;
-static constexpr unsigned POINT_VERSION = 1;
+static constexpr unsigned POINT_VERSION = 2;
 }} // namespace SWOC_VERSION_NS

--- a/code/libswoc.part
+++ b/code/libswoc.part
@@ -1,6 +1,6 @@
 Import("*")
 PartName("libswoc")
-PartVersion("1.2.1")
+PartVersion("1.2.2")
 
 src_files = [
     "src/ArenaWriter.cc",

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "LibSWOC++"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "1.2.1"
+PROJECT_NUMBER         = "1.2.2"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doc/code/IPSpace.en.rst
+++ b/doc/code/IPSpace.en.rst
@@ -170,7 +170,7 @@ Blending Bitsets
 
    Some details are omitted for brevity and because they aren't directly relevant. The full
    implementation, which is run as a unit test to verify its correctness,
-   `is available here <https://github.com/SolidWallOfCode/libswoc/blob/1.2.1/unit_tests/ex_ipspace_properties.cc>`__.
+   `is available here <https://github.com/SolidWallOfCode/libswoc/blob/1.2.2/unit_tests/ex_ipspace_properties.cc>`__.
    You can compile and step through the code to see how it works in more detail, or experiment
    with changing some of the example data.
 

--- a/doc/code/TextView.en.rst
+++ b/doc/code/TextView.en.rst
@@ -275,7 +275,7 @@ separated by commas.
 
 .. sidebar:: Verification
 
-   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.1/unit_tests/ex_TextView.cc#L67>`__.
+   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.2/unit_tests/ex_TextView.cc#L67>`__.
 
 If :arg:`value` was :literal:`bob  ,dave, sam` then :arg:`token` would be successively
 :literal:`bob`, :literal:`dave`, :literal:`sam`. After :literal:`sam` was extracted :arg:`value`
@@ -297,7 +297,7 @@ for values that are boolean.
 
 .. sidebar:: Verification
 
-   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.1/unit_tests/ex_TextView.cc#L74>`__.
+   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.2/unit_tests/ex_TextView.cc#L74>`__.
 
 The basic list processing is the same as the previous example, with each element being treated as
 a "list" with ``=`` as the separator. Note if there is no ``=`` character then all of the list
@@ -348,7 +348,7 @@ do not, so a flag to strip quotes from the resulting elements is needed. The fin
 
 .. sidebar:: Verification
 
-   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.1/unit_tests/ex_TextView.cc#L90>`__.
+   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.2/unit_tests/ex_TextView.cc#L90>`__.
 
 This takes a :code:`TextView&` which is the source view which will be updated as tokens are removed
 (therefore the caller must do the empty view check). The other arguments are the separator character

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -80,7 +80,7 @@ project = u'Solid Wall Of C++'
 copyright = u'{}, amc@apache.org'.format(date.today().year)
 
 # The full version, including alpha/beta/rc tags.
-release = "1.2.1"
+release = "1.2.2"
 # The short X.Y version.
 version = '.'.join(release.split('.', 2)[:2])
 

--- a/example/ex_netcompact.cc
+++ b/example/ex_netcompact.cc
@@ -10,7 +10,7 @@
 
     4441:34F8:1E40:1EF:0:0:A0:0/108
     192.168.12.1
-    10.0.23.0/23
+    10.0.23.0-10.0.14.255
 
     The output is the same set of addresses in as few networks as possible.
 */
@@ -30,7 +30,6 @@ using namespace swoc::literals;
 
 using swoc::TextView;
 
-using swoc::IPAddr;
 using swoc::IPRange;
 
 /// Type for temporary buffer writer output.
@@ -69,11 +68,12 @@ int main(int argc, char *argv[]) {
   Space space;
 
   if (argc < 2) {
-    std::cerr << W().print("Input file name required.");
+    std::cerr << W().print("Input file name required.\n");
     exit(1);
   }
 
-  auto t0 = std::chrono::system_clock::now();
+  auto t0 = std::chrono::system_clock::now(); // timing
+  // Load the file.
   swoc::file::path path{argv[1]};
   std::error_code ec;
   std::string content = swoc::file::load(path, ec);
@@ -81,9 +81,10 @@ int main(int argc, char *argv[]) {
     std::cerr << W().print(R"(Failed to open file "{}" - {}\n)", path, ec);
     exit(1);
   }
+  // Paint the IPSpace.
   auto n_ranges = process(space, content);
 
-  // Dump the resulting space.
+  // Dump the results.
   unsigned n_nets = 0;
   for ( auto && [range, payload] : space ) {
     for ( auto && net : range.networks() ) {

--- a/example/ex_netdb.cc
+++ b/example/ex_netdb.cc
@@ -103,7 +103,7 @@ swoc::Lexicon<PodType> PodTypeNames {{
 namespace swoc {
 
 BufferWriter& bwformat(BufferWriter& w, bwf::Spec const& spec, PodType pt) {
-  return w.write(PodTypeNames[pt]);
+  return bwformat(w, spec, (PodTypeNames[pt]);
 }
 
 BufferWriter& bwformat(BufferWriter& w, bwf::Spec const& spec, FlagSet const& flags) {
@@ -114,7 +114,7 @@ BufferWriter& bwformat(BufferWriter& w, bwf::Spec const& spec, FlagSet const& fl
       if (!first_p) {
         w.write(';');
       }
-      w.write(FlagNames[static_cast<Flag>(idx)]);
+      bwformat(w, spec, FlagNames[static_cast<Flag>(idx)]);
       first_p = false;
     }
   }

--- a/tools/update-version.sh
+++ b/tools/update-version.sh
@@ -6,15 +6,15 @@ if [ -z "$3" ] ; then
 fi
 
 # Header
-sed -i -E swoc++/include/swoc/swoc_version.h --expr "s/SWOC_VERSION_NS _[0-9]+_[0-9]+_[0-9]+/SWOC_VERSION_NS _$1_$2_$3/"wqq
-sed -i swoc++/include/swoc/swoc_version.h --expr "s/\(MAJOR_VERSION *= *\).*\$/\\1$1;/"
-sed -i swoc++/include/swoc/swoc_version.h --expr "s/\(MINOR_VERSION *= *\).*\$/\\1$2;/"
-sed -i swoc++/include/swoc/swoc_version.h --expr "s/\(POINT_VERSION *= *\).*\$/\\1$3;/"
+sed -i -E code/include/swoc/swoc_version.h --expr "s/SWOC_VERSION_NS _[0-9]+_[0-9]+_[0-9]+/SWOC_VERSION_NS _$1_$2_$3/"wqq
+sed -i code/include/swoc/swoc_version.h --expr "s/\(MAJOR_VERSION *= *\).*\$/\\1$1;/"
+sed -i code/include/swoc/swoc_version.h --expr "s/\(MINOR_VERSION *= *\).*\$/\\1$2;/"
+sed -i code/include/swoc/swoc_version.h --expr "s/\(POINT_VERSION *= *\).*\$/\\1$3;/"
 
 sed -i doc/conf.py --expr "s/release = .*\$/release = \"$1.$2.$3\"/"
 sed -i doc/Doxyfile --expr "s/\(PROJECT_NUMBER *= *\).*\$/\\1\"$1.$2.$3\"/"
 find doc -name "*.en.rst" -exec sed -i {} --expr "s!/libswoc/blob/[0-9.]*/unit_tests/!/libswoc/blob/$1.$2.$3/unit_tests/!" \;
 
-sed -i swoc++/CMakeLists.txt --expr "s/\(LIBSWOC_VERSION *\)\"[^\"]*\"/\\1\"$1.$2.$3\"/"
-sed -i swoc++/swoc++.part --expr "s/PartVersion(\"[0-9.]*\")/PartVersion(\"$1.$2.$3\")/"
+sed -i code/CMakeLists.txt --expr "s/\(LIBSWOC_VERSION *\)\"[^\"]*\"/\\1\"$1.$2.$3\"/"
+sed -i code/libswoc.part --expr "s/PartVersion(\"[0-9.]*\")/PartVersion(\"$1.$2.$3\")/"
 

--- a/unit_tests/test_ip.cc
+++ b/unit_tests/test_ip.cc
@@ -768,6 +768,12 @@ TEST_CASE("IPSpace bitset", "[libswoc][ipspace][bitset]") {
     space.mark(IPRange{text}, bits);
   }
   REQUIRE(space.count() == ranges.size());
+
+  // Check that if an IPv4 lookup misses, it doesn't pass on to the first IPv6
+  auto && [ r1, p1 ] = *(space.find(IP4Addr{"172.28.56.100"}));
+  REQUIRE(true == r1.empty());
+  auto && [ r2, p2 ] = *(space.find(IPAddr{"172.28.56.100"}));
+  REQUIRE(true == r2.empty());
 }
 
 TEST_CASE("IPSpace docJJ", "[libswoc][ipspace][docJJ]") {


### PR DESCRIPTION
* Fix bug in `IPSpace::find` where an IPv6 range could be returned on an IPv4 find.
* Better comments and code in the "ex_netcompact.cc" example.