### PR TITLE
Release 1.2.7 update.

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(Lib-SWOC CXX)
-set(LIBSWOC_VERSION "1.2.6")
+set(LIBSWOC_VERSION "1.2.7")
 set(CMAKE_CXX_STANDARD 17)
 include(GNUInstallDirs)
 

--- a/code/include/swoc/DiscreteRange.h
+++ b/code/include/swoc/DiscreteRange.h
@@ -912,6 +912,12 @@ template<typename METRIC, typename PAYLOAD>
 auto DiscreteSpace<METRIC, PAYLOAD>::lower_bound(METRIC const& target) -> Node * {
   Node *n = _root;   // current node to test.
   Node *zret = nullptr; // best node so far.
+
+  // Fast check for sequential insertion
+  if (auto ln = _list.tail() ; ln != nullptr && ln->max() < target) {
+    return ln;
+  }
+
   while (n) {
     if (target < n->min()) {
       n = left(n);

--- a/code/include/swoc/Errata.h
+++ b/code/include/swoc/Errata.h
@@ -114,7 +114,10 @@ public:
     self_type *_prev{nullptr};
     /// @}}
     /// Intrusive list link descriptor.
-    using Linkage = IntrusiveLinkage<self_type, &self_type::_next, &self_type::_prev>;
+    /// @note Must explicitly use defaults because ICC and clang consider them inaccessible
+    /// otherwise. I consider it a bug in the compiler that a default identical to an explicit
+    /// value has different behavior.
+    using Linkage = swoc::IntrusiveLinkage<self_type, &self_type::_next, &self_type::_prev>;
 
     friend class Errata;
   };

--- a/code/include/swoc/IntrusiveDList.h
+++ b/code/include/swoc/IntrusiveDList.h
@@ -77,8 +77,10 @@ public:
   // Get the result of calling the pointer access function, then strip off reference and pointer
   // qualifiers. @c nullptr is used instead of the pointer type because this is done precisely
   // to find that type.
-  using value_type = typename std::remove_pointer<
-      typename std::remove_reference<typename std::invoke_result<decltype(L::next_ptr), std::nullptr_t>::type>::type>::type;
+  using value_type =
+      typename std::remove_pointer<
+        typename std::remove_reference<
+          typename std::invoke_result<decltype(L::next_ptr), std::nullptr_t>::type>::type>::type;
 
   /// Const iterator.
   class const_iterator {

--- a/code/include/swoc/MemArena.h
+++ b/code/include/swoc/MemArena.h
@@ -169,14 +169,28 @@ public:
    */
   MemSpan<void> alloc(size_t n);
 
-  /** Allocate and initialize a block of memory.
+  /** ALlocate a span of memory sufficient for @a n instance of @a T.
+   *
+   * @tparam T Element type.
+   * @param n Number of instances.
+   * @return A span large enough to hold @a n instances of @a T.
+   *
+   * The instances are @b not initialized / constructed. This only allocates the memory.
+   * This is handy for types that don't need initialization, such as built in types like @c int.
+   * @code
+   *   auto vec = arena.alloc_span<int>(20); // allocate space for 20 ints
+   * @endcode
+   */
+  template <typename T> MemSpan<T> alloc_span(size_t n);
+
+  /** Allocate and initialize a block of memory as an instance of @a T
 
       The template type specifies the type to create and any arguments are forwarded to the
       constructor. Example:
 
       @code
       struct Thing { ... };
-      Thing* thing = arena.make<Thing>(...constructor args...);
+      auto thing = arena.make<Thing>(...constructor args...);
       @endcode
 
       Do @b not call @c delete an object created this way - that will attempt to free the memory and
@@ -405,6 +419,11 @@ inline MemSpan<void> MemArena::Block::alloc(size_t n) {
   MemSpan<void> zret = this->remnant().prefix(n);
   allocated += n;
   return zret;
+}
+
+template<typename T>
+MemSpan<T> MemArena::alloc_span(size_t n) {
+  return this->alloc(sizeof(T) * n).rebind<T>();
 }
 
 template<typename T, typename... Args> T *MemArena::make(Args&& ... args) {

--- a/code/include/swoc/swoc_ip.h
+++ b/code/include/swoc/swoc_ip.h
@@ -2211,9 +2211,11 @@ inline auto IP6Addr::operator=(in6_addr const& addr) -> self_type& {
 
 inline auto IP6Addr::operator=(sockaddr_in6 const *addr) -> self_type& {
   if (addr) {
-    return *this = addr->sin6_addr;
+    *this = addr->sin6_addr;
+  } else {
+    this->clear();
   }
-  this->clear();
+  return *this;
 }
 
 inline IP6Addr&

--- a/code/include/swoc/swoc_ip.h
+++ b/code/include/swoc/swoc_ip.h
@@ -2069,7 +2069,7 @@ IPEndpoint::port(sockaddr *sa) {
     case AF_INET6:return reinterpret_cast<sockaddr_in6 *>(sa)->sin6_port;
   }
   // Force a failure upstream by returning a null reference.
-  return *static_cast<in_port_t *>(nullptr);
+  throw std::domain_error("sockaddr is not a valid IP address");
 }
 
 inline in_port_t

--- a/code/include/swoc/swoc_version.h
+++ b/code/include/swoc/swoc_version.h
@@ -22,11 +22,11 @@
 #pragma once
 
 #if !defined(SWOC_VERSION_NS)
-#  define SWOC_VERSION_NS _1_2_6
+#  define SWOC_VERSION_NS _1_2_7
 #endif
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 static constexpr unsigned MAJOR_VERSION = 1;
 static constexpr unsigned MINOR_VERSION = 2;
-static constexpr unsigned POINT_VERSION = 6;
+static constexpr unsigned POINT_VERSION = 7;
 }} // namespace SWOC_VERSION_NS

--- a/code/libswoc.part
+++ b/code/libswoc.part
@@ -1,6 +1,6 @@
 Import("*")
 PartName("libswoc")
-PartVersion("1.2.6")
+PartVersion("1.2.7")
 
 src_files = [
     "src/ArenaWriter.cc",

--- a/code/src/MemArena.cc
+++ b/code/src/MemArena.cc
@@ -10,11 +10,6 @@
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 
-void
-MemArena::Block::operator delete(void *ptr) {
-  ::free(ptr);
-}
-
 // Need to break these out because the default implementation doesn't clear the
 // integral values in @a that.
 

--- a/code/src/swoc_ip.cc
+++ b/code/src/swoc_ip.cc
@@ -810,7 +810,7 @@ void IP4Range::NetSource::search_wider() {
 void IP4Range::NetSource::search_narrower() {
   while (!this->is_valid(_mask)) {
     _mask._addr >>= 1;
-    _mask._addr |= 1 << (IP4Addr::WIDTH - 1); // put top bit back.
+    _mask._addr |= 1U << (IP4Addr::WIDTH - 1); // put top bit back.
     ++_cidr;
   }
 }

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "LibSWOC++"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "1.2.6"
+PROJECT_NUMBER         = "1.2.7"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doc/code/IPSpace.en.rst
+++ b/doc/code/IPSpace.en.rst
@@ -172,7 +172,7 @@ Blending Bitsets
 
    Some details are omitted for brevity and because they aren't directly relevant. The full
    implementation, which is run as a unit test to verify its correctness,
-   `is available here <https://github.com/SolidWallOfCode/libswoc/blob/1.2.6/unit_tests/ex_ipspace_properties.cc>`__.
+   `is available here <https://github.com/SolidWallOfCode/libswoc/blob/1.2.7/unit_tests/ex_ipspace_properties.cc>`__.
    You can compile and step through the code to see how it works in more detail, or experiment
    with changing some of the example data.
 

--- a/doc/code/TextView.en.rst
+++ b/doc/code/TextView.en.rst
@@ -278,7 +278,7 @@ separated by commas.
 
 .. sidebar:: Verification
 
-   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.6/unit_tests/ex_TextView.cc#L67>`__.
+   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.7/unit_tests/ex_TextView.cc#L67>`__.
 
 If :arg:`value` was :literal:`bob  ,dave, sam` then :arg:`token` would be successively
 :literal:`bob`, :literal:`dave`, :literal:`sam`. After :literal:`sam` was extracted :arg:`value`
@@ -300,7 +300,7 @@ for values that are boolean.
 
 .. sidebar:: Verification
 
-   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.6/unit_tests/ex_TextView.cc#L74>`__.
+   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.7/unit_tests/ex_TextView.cc#L74>`__.
 
 The basic list processing is the same as the previous example, with each element being treated as
 a "list" with ``=`` as the separator. Note if there is no ``=`` character then all of the list
@@ -351,7 +351,7 @@ do not, so a flag to strip quotes from the resulting elements is needed. The fin
 
 .. sidebar:: Verification
 
-   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.6/unit_tests/ex_TextView.cc#L90>`__.
+   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.7/unit_tests/ex_TextView.cc#L90>`__.
 
 This takes a :code:`TextView&` which is the source view which will be updated as tokens are removed
 (therefore the caller must do the empty view check). The other arguments are the separator character

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -80,7 +80,7 @@ project = u'Solid Wall Of C++'
 copyright = u'{}, amc@apache.org'.format(date.today().year)
 
 # The full version, including alpha/beta/rc tags.
-release = "1.2.6"
+release = "1.2.7"
 # The short X.Y version.
 version = '.'.join(release.split('.', 2)[:2])
 


### PR DESCRIPTION
Mostly cleanup after working with the ICC and AOCC compilers.
Added MemSpan::alloc_span to more conveniently allocate blocks of the same type.
Performance tweak for IPSpace when loading ordered data.