### PR TITLE
Release 1.2.10

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(Lib-SWOC CXX)
-set(LIBSWOC_VERSION "1.2.9")
+set(LIBSWOC_VERSION "1.2.10")
 set(CMAKE_CXX_STANDARD 17)
 include(GNUInstallDirs)
 

--- a/code/include/swoc/TextView.h
+++ b/code/include/swoc/TextView.h
@@ -125,20 +125,6 @@ public:
    */
   template <size_t N> constexpr TextView(const char (&s)[N]);
 
-  /** Construct from character buffer.
-
-      Construct directly from an array of characters with an explicit size. This is useful to
-      - Construct from a temporary buffer which may be larger than the actual string.
-      - To force the inclusion of a terminating null byte.
-
-      @code
-        char buffer[N];
-        // Fill @a k characters in @a buffer.
-        TextView a(buffer, k);
-      @endcode
-   */
-  template <size_t N> constexpr TextView(const char (&s)[N], size_t n);
-
   /** Construct from nullptr.
       This implicitly makes the length 0.
   */
@@ -866,7 +852,7 @@ inline constexpr TextView::TextView(std::nullptr_t) : super_type(nullptr, 0) {}
 inline TextView::TextView(std::string const &str) : super_type(str) {}
 inline constexpr TextView::TextView(super_type const &that) : super_type(that) {}
 template <size_t N> constexpr TextView::TextView(const char (&s)[N]) : super_type(s, s[N - 1] ? N : N - 1) {}
-template <size_t N> constexpr TextView::TextView(const char (&s)[N], size_t n) : super_type(s, n) {}
+//template <size_t N> constexpr TextView::TextView(const char (&s)[N], size_t n) : super_type(s, n) {}
 
 inline void
 TextView::init_delimiter_set(std::string_view const &delimiters, std::bitset<256> &set) {

--- a/code/include/swoc/TextView.h
+++ b/code/include/swoc/TextView.h
@@ -318,8 +318,10 @@ public:
   /** Get a view of a prefix bounded by a character in @a delimiters.
    *
    * @param delimiters A set of characters.
-   * @return A view of the prefix bounded by any character in @a delimiters, or all of @a this if
-   * none are found.
+   *
+   * @return A view of the prefix bounded by any character in @a delimiters, or empty if none are
+   * found.
+   *
    * @note The delimiter character is not included in the returned view.
    */
   self_type prefix_at(std::string_view const &delimiters) const;
@@ -331,8 +333,10 @@ public:
    * pred is @c true.
    *
    * @param pred A character predicate.
-   * @return A view of the prefix bounded by @a pred or all of @a this if
-   * @a pred is not @c true for any characer.
+   *
+   * @return A view of the prefix bounded by @a pred or empty if @a pred is not @c true for any
+   * characer.
+   *
    * @note The deliminting character is not included in the returned view.
    */
   template <typename F> self_type prefix_if(F const &pred) const;
@@ -355,7 +359,7 @@ public:
    *
    * @param c Delimiter character.
    * @return @a this.
-   * @note The first occurence of character @a c is removed along with all preceeding characters, or
+   * @note The first occurrence of character @a c is removed along with all preceding characters, or
    * the view is cleared if @a c is not found.
    */
   self_type &remove_prefix_at(char c);
@@ -364,7 +368,7 @@ public:
    *
    * @param delimiters Characters to match.
    * @return @a this.
-   * @note The first occurence of any character in @a delimiters is removed along with all preceeding
+   * @note The first occurrence of any character in @a delimiters is removed along with all preceding
    * characters, or the view is cleared if none are found.
    */
   self_type &remove_prefix_at(std::string_view const &delimiters);
@@ -508,8 +512,10 @@ public:
   /** Get a view of a suffix bounded by a character in @a delimiters.
    *
    * @param delimiters A set of characters.
-   * @return A view of the suffix bounded by any character in @a delimiters, or all of @a this if
-   * none are found.
+   *
+   * @return A view of the suffix bounded by any character in @a delimiters, or mepty if none are
+   * found.
+   *
    * @note The delimiter character is not included in the returned view.
    */
   self_type suffix_at(std::string_view const &delimiters) const;
@@ -521,9 +527,11 @@ public:
    * pred is @c true.
    *
    * @param pred A character predicate.
-   * @return A view of the suffix bounded by @a pred or all of @a this if
-   * @a pred is not @c true for any characer.
-   * @note The deliminting character is not included in the returned view.
+   *
+   * @return A view of the suffix bounded by @a pred or empty if @a pred is not @c true for any
+   * character.
+   *
+   * @note The delimiting character is not included in the returned view.
    */
   template <typename F> self_type suffix_if(F const &pred) const;
 
@@ -531,7 +539,8 @@ public:
    *
    * @param c Delimiter character.
    * @return @a this.
-   * @note The last occurence of character @a c is removed along with all succeeding characters, or
+   *
+   * @note The last occurrence of character @a c is removed along with all succeeding characters, or
    * the view is cleared if @a c is not found.
    */
   self_type &remove_suffix_at(char c);
@@ -540,7 +549,7 @@ public:
    *
    * @param delimiters Characters to match.
    * @return @a this.
-   * @note The first occurence of any character in @a delimiters is removed along with all preceeding
+   * @note The first occurrence of any character in @a delimiters is removed along with all preceding
    * characters, or the view is cleared if none are found.
    */
   self_type &remove_suffix_at(std::string_view const &delimiters);

--- a/code/include/swoc/TextView.h
+++ b/code/include/swoc/TextView.h
@@ -94,14 +94,17 @@ class TextView : public std::string_view {
 
 public:
   /// Default constructor (empty buffer).
-  constexpr TextView() = default;
+  constexpr TextView() noexcept = default;
 
   /** Construct from pointer and size.
    *
    * @param ptr Pointer to first character.
    * @param n Number of characters.
+   *
+   * If @a n is @c npos then @c ptr is presumed to be a C string and checked for length. If @c ptr
+   * is @c nullptr the length is 0. Otherwise @c strlen is used to calculate the length.
    */
-  constexpr TextView(const char *ptr, size_t n);
+  constexpr TextView(const char *ptr, size_t n) noexcept;
 
   /** Construct from a half open range [first, last).
    *
@@ -110,7 +113,7 @@ public:
    *
    * The character at @a first will be in the view, but the character at @a last will not.
    */
-  constexpr TextView(char const *first, char const *last);
+  constexpr TextView(char const *first, char const *last) noexcept;
 
   /** Construct from literal string.
 
@@ -123,22 +126,22 @@ public:
       @endcode
       The last character in @a a will be 'g'.
    */
-  template <size_t N> constexpr TextView(const char (&s)[N]);
+  template <size_t N> constexpr TextView(const char (&s)[N]) noexcept;
 
   /** Construct from nullptr.
       This implicitly makes the length 0.
   */
-  constexpr TextView(std::nullptr_t);
+  constexpr TextView(std::nullptr_t) noexcept;
 
   /// Construct from a @c std::string_view.
   /// @note This provides an user defined conversion from @c std::string_view to @c TextView. The
   /// reverse conversion is implicit in @c TextView being a subclass of @c std::string_view.
-  constexpr TextView(super_type const &that);
+  constexpr TextView(super_type const &that) noexcept;
 
   /// Construct from @c std::string, referencing the entire string contents.
   /// @internal This can't be @c constexpr because this uses methods in @c std::string that may
   /// not be @c constexpr.
-  TextView(std::string const &str);
+  TextView(std::string const &str) noexcept;
 
   /// Assign a super class instance, @c std::string_view  to @a this.
   self_type &operator=(super_type const &that);
@@ -181,7 +184,7 @@ public:
       @return The first byte in the view, or a nul character if the view is empty.
   */
   /// @return The first byte in the view.
-  char operator*() const;
+  constexpr char operator*() const;
 
   /** Discard the first byte of the view.
    *
@@ -204,11 +207,11 @@ public:
 
   /// Check for empty view.
   /// @return @c true if the view has a nullptr @b or zero size.
-  bool operator!() const;
+  constexpr bool operator!() const noexcept;
 
   /// Check for non-empty view.
   /// @return @c true if the view refers to a non-empty range of bytes.
-  explicit operator bool() const;
+  explicit constexpr operator bool() const noexcept;
 
   /// Clear the view (become an empty view).
   self_type &clear();
@@ -291,7 +294,7 @@ public:
    * @param n Number of chars in the prefix.
    * @return A view of the first @a n characters in @a this, bounded by the size of @a this.
    */
-  self_type prefix(size_t n) const;
+  constexpr self_type prefix(size_t n) const noexcept;
 
   /** Get a view of a prefix bounded by @a c.
    *
@@ -485,7 +488,7 @@ public:
    * @param n Number of chars in the prefix.
    * @return A view of the last @a n characters in @a this, bounded by the size of @a this.
    */
-  self_type suffix(size_t n) const;
+  constexpr self_type suffix(size_t n) const noexcept;
 
   /** Get a view of a suffix bounded by @a c.
    *
@@ -663,7 +666,7 @@ public:
    * @note This is provided primarily for co-variance, i.e. the returned view is a @c TextView
    * instead of a @c std::string_view.
    */
-  self_type substr(size_type pos = 0, size_type count = npos) const;
+  constexpr self_type substr(size_type pos = 0, size_type count = npos) const noexcept;
 
   /** Check if the view begins with a specific @a prefix.
    *
@@ -671,7 +674,7 @@ public:
    * @return @c true if <tt>this->prefix(prefix.size()) == prefix</tt>, @c false otherwise.
    * @internal C++20 preview.
    */
-  bool starts_with(std::string_view const &prefix) const;
+  bool starts_with(std::string_view const &prefix) const noexcept;
 
   /** Check if the view begins with a specific @a prefix, ignoring case.
    *
@@ -679,7 +682,7 @@ public:
    * @return @c true if <tt>this->prefix(prefix.size()) == prefix</tt> without regard to case, @c false otherwise.
    * @internal C++20 preview.
    */
-  bool starts_with_nocase(std::string_view const &prefix) const;
+  bool starts_with_nocase(std::string_view const &prefix) const noexcept;
 
   /** Check if the view ends with a specific @a suffix.
    *
@@ -687,7 +690,7 @@ public:
    * @return @c true if <tt>this->suffix(suffix.size()) == suffix</tt>, @c false otherwise.
    * @internal C++20 preview.
    */
-  bool ends_with(std::string_view const &suffix) const;
+  bool ends_with(std::string_view const &suffix) const noexcept;
 
   /** Check if the view starts with a specific @a prefix, ignoring case.
    *
@@ -695,13 +698,13 @@ public:
    * @return @c true if <tt>this->suffix(suffix.size()) == suffix</tt> without regard to case, @c false otherwise.
    * @internal C++20 preview.
    */
-  bool ends_with_nocase(std::string_view const &suffix) const;
+  bool ends_with_nocase(std::string_view const &suffix) const noexcept;
 
   // Functors for using this class in STL containers.
   /// Ordering functor, lexicographic comparison.
   struct LessThan {
     bool
-    operator()(self_type const &lhs, self_type const &rhs) {
+    operator()(self_type const &lhs, self_type const &rhs) const noexcept {
       return -1 == strcmp(lhs, rhs);
     }
   };
@@ -709,7 +712,7 @@ public:
   /// Ordering functor, case ignoring lexicographic comparison.
   struct LessThanNoCase {
     bool
-    operator()(self_type const &lhs, self_type const &rhs) {
+    operator()(self_type const &lhs, self_type const &rhs) const noexcept {
       return -1 == strcasecmp(lhs, rhs);
     }
   };
@@ -721,7 +724,7 @@ public:
    * This is effectively @c std::string_view::end() except it explicit returns a pointer and not
    * (potentially) an iterator class, to match up with @c data().
    */
-  char const *data_end() const;
+  constexpr char const *data_end() const noexcept;
 
   /// Specialized stream operator implementation.
   /// @note Use the standard stream operator unless there is a specific need for this, which is unlikely.
@@ -733,10 +736,10 @@ public:
   /// @cond OVERLOAD
   // These methods are all overloads of other methods, defined in order to make the API more
   // convenient to use. Mostly these overload @c int for @c size_t so naked numbers work as expected.
-  self_type prefix(int n) const;
+  constexpr self_type prefix(int n) const noexcept;
   self_type take_suffix(int n);
   self_type split_prefix(int n);
-  self_type suffix(int n) const;
+  constexpr self_type suffix(int n) const noexcept;
   self_type split_suffix(int n);
   /// @endcond
 
@@ -846,13 +849,13 @@ double svtod(swoc::TextView text, swoc::TextView * parsed = nullptr);
 // definition and the reference documentation is messed up. Sigh.
 
 // === TextView Implementation ===
-inline constexpr TextView::TextView(const char *ptr, size_t n) : super_type(ptr, n) {}
-inline constexpr TextView::TextView(char const *first, char const *last) : super_type(first, last - first) {}
-inline constexpr TextView::TextView(std::nullptr_t) : super_type(nullptr, 0) {}
-inline TextView::TextView(std::string const &str) : super_type(str) {}
-inline constexpr TextView::TextView(super_type const &that) : super_type(that) {}
-template <size_t N> constexpr TextView::TextView(const char (&s)[N]) : super_type(s, s[N - 1] ? N : N - 1) {}
-//template <size_t N> constexpr TextView::TextView(const char (&s)[N], size_t n) : super_type(s, n) {}
+inline constexpr TextView::TextView(const char *ptr, size_t n) noexcept
+  : super_type(ptr, n == npos ? ( ptr ? ::strlen(ptr) : 0 ) : n) {}
+inline constexpr TextView::TextView(char const *first, char const *last) noexcept : super_type(first, last - first) {}
+inline constexpr TextView::TextView(std::nullptr_t) noexcept : super_type(nullptr, 0) {}
+inline TextView::TextView(std::string const &str) noexcept : super_type(str) {}
+inline constexpr TextView::TextView(super_type const &that) noexcept : super_type(that) {}
+template <size_t N> constexpr TextView::TextView(const char (&s)[N]) noexcept : super_type(s, s[N - 1] ? N : N - 1) {}
 
 inline void
 TextView::init_delimiter_set(std::string_view const &delimiters, std::bitset<256> &set) {
@@ -867,15 +870,15 @@ TextView::clear() {
   return *this;
 }
 
-inline char TextView::operator*() const {
+inline constexpr char TextView::operator*() const {
   return this->empty() ? char(0) : *(this->data());
 }
 
-inline bool TextView::operator!() const {
+inline constexpr bool TextView::operator!() const noexcept {
   return this->empty();
 }
 
-inline TextView::operator bool() const {
+inline constexpr TextView::operator bool() const noexcept {
   return !this->empty();
 }
 
@@ -939,13 +942,13 @@ TextView::assign(char const *b, char const *e) {
   return *this;
 }
 
-inline TextView
-TextView::prefix(size_t n) const {
+inline constexpr TextView
+TextView::prefix(size_t n) const noexcept {
   return {this->data(), std::min(n, this->size())};
 }
 
-inline TextView
-TextView::prefix(int n) const {
+inline constexpr TextView
+TextView::prefix(int n) const noexcept {
   return {this->data(), std::min<size_t>(n, this->size())};
 }
 
@@ -1070,14 +1073,14 @@ TextView::take_prefix_if(F const &pred) {
   return this->take_prefix(this->find_if(pred));
 }
 
-inline TextView
-TextView::suffix(size_t n) const {
+inline constexpr TextView
+TextView::suffix(size_t n) const noexcept {
   n = std::min(n, this->size());
   return {this->data_end() - n, n};
 }
 
-inline TextView
-TextView::suffix(int n) const {
+inline constexpr TextView
+TextView::suffix(int n) const noexcept {
   return this->suffix(size_t(n));
 }
 
@@ -1332,13 +1335,13 @@ TextView::trim_if(F const &pred) {
   return this->ltrim_if(pred).rtrim_if(pred);
 }
 
-inline char const *
-TextView::data_end() const {
+constexpr inline char const *
+TextView::data_end() const noexcept {
   return this->data() + this->size();
 }
 
-inline TextView
-TextView::substr(size_type pos, size_type count) const {
+inline constexpr TextView
+TextView::substr(size_type pos, size_type count) const noexcept {
   if (pos >= this->size())
   {
     return {};
@@ -1348,22 +1351,22 @@ TextView::substr(size_type pos, size_type count) const {
 }
 
 inline bool
-TextView::starts_with(std::string_view const &prefix) const {
+TextView::starts_with(std::string_view const &prefix) const noexcept {
   return this->size() >= prefix.size() && 0 == ::memcmp(this->data(), prefix.data(), prefix.size());
 }
 
 inline bool
-TextView::starts_with_nocase(std::string_view const &prefix) const {
+TextView::starts_with_nocase(std::string_view const &prefix) const noexcept {
   return this->size() >= prefix.size() && 0 == ::strncasecmp(this->data(), prefix.data(), prefix.size());
 }
 
 inline bool
-TextView::ends_with(std::string_view const &suffix) const {
+TextView::ends_with(std::string_view const &suffix) const noexcept {
   return this->size() >= suffix.size() && 0 == ::memcmp(this->data_end() - suffix.size(), suffix.data(), suffix.size());
 }
 
 inline bool
-TextView::ends_with_nocase(std::string_view const &suffix) const {
+TextView::ends_with_nocase(std::string_view const &suffix) const noexcept {
   return this->size() >= suffix.size() && 0 == ::strncasecmp(this->data_end() - suffix.size(), suffix.data(), suffix.size());
 }
 

--- a/code/include/swoc/bwf_base.h
+++ b/code/include/swoc/bwf_base.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <tuple>
 #include <any>
+#include <array>
 
 #include "swoc/swoc_version.h"
 #include "swoc/TextView.h"

--- a/code/include/swoc/bwf_ex.h
+++ b/code/include/swoc/bwf_ex.h
@@ -179,7 +179,7 @@ Optional(meta::CaseTag<0>, TextView fmt, T&& t) -> SubText<T> {
  * @a charlie, each of which could be null, which should be output with space separators,
  * this would be
  * @code
- * w.print("Leading text{}{}{}.", Optiona(" {}", alpha)
+ * w.print("Leading text{}{}{}.", Optional(" {}", alpha)
  *                              , Optional(" {}", bravo)
  *                              , Optional(" {}", charlie));
  * @endcode

--- a/code/include/swoc/swoc_ip.h
+++ b/code/include/swoc/swoc_ip.h
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <limits.h>
 #include <netinet/in.h>
 #include <string_view>
 #include <variant>
@@ -14,7 +15,6 @@
 #include "swoc/TextView.h"
 #include "swoc/DiscreteRange.h"
 #include "swoc/RBTree.h"
-#include <values.h>
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 
@@ -196,7 +196,7 @@ class IP4Addr {
 
 public:
   static constexpr size_t SIZE = sizeof(in_addr_t); ///< Size of IPv4 address in bytes.
-  static constexpr size_t WIDTH = BITSPERBYTE * SIZE; ///< # of bits in an address.
+  static constexpr size_t WIDTH = std::numeric_limits<unsigned char>::digits * SIZE; ///< # of bits in an address.
   static const self_type MIN; ///< Minimum value.
   static const self_type MAX; ///< Maximum value.
   static constexpr sa_family_t AF_value = AF_INET; ///< Address family type.
@@ -349,7 +349,7 @@ class IP6Addr {
 
 public:
   static constexpr size_t WIDTH = 128; ///< Number of bits in the address.
-  static constexpr size_t SIZE = WIDTH / BITSPERBYTE;    ///< Size of address in bytes.
+  static constexpr size_t SIZE = WIDTH / std::numeric_limits<unsigned char>::digits;    ///< Size of address in bytes.
   static constexpr sa_family_t AF_value = AF_INET6; ///< Address family type.
 
   using quad_type                      = uint16_t;            ///< Size of one segment of an IPv6 address.
@@ -364,7 +364,7 @@ public:
   using quad_store_type = std::array<quad_type, N_QUADS>;
 
   /// Number of bits per quad.
-  static constexpr size_t QUAD_WIDTH = BITSPERBYTE * sizeof(quad_type);
+  static constexpr size_t QUAD_WIDTH = std::numeric_limits<unsigned char>::digits * sizeof(quad_type);
 
   /// A bit mask of all 1 bits the size of a quad.
   static constexpr quad_type QUAD_MASK = ~quad_type{0};
@@ -375,7 +375,7 @@ public:
   static constexpr size_t WORD_SIZE = sizeof(word_type);
 
   /// Number of bits per word.
-  static constexpr size_t WORD_WIDTH = BITSPERBYTE * WORD_SIZE;
+  static constexpr size_t WORD_WIDTH = std::numeric_limits<unsigned char>::digits * WORD_SIZE;
 
   /// Number of words used for basic address storage.
   static constexpr size_t N_STORE = SIZE / sizeof(word_type);
@@ -1952,7 +1952,7 @@ IPAddr::isCompatibleWith(self_type const& that) {
 inline bool
 IPAddr::is_loopback() const {
   return (AF_INET == _family && 0x7F == _addr._octet[0]) ||
-         (AF_INET6 == _family && IN6_IS_ADDR_LOOPBACK(&_addr._ip6));
+         (AF_INET6 == _family && _addr._ip6.is_loopback());
 }
 
 inline IPAddr&

--- a/code/include/swoc/swoc_version.h
+++ b/code/include/swoc/swoc_version.h
@@ -22,11 +22,11 @@
 #pragma once
 
 #if !defined(SWOC_VERSION_NS)
-#  define SWOC_VERSION_NS _1_2_9
+#  define SWOC_VERSION_NS _1_2_10
 #endif
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 static constexpr unsigned MAJOR_VERSION = 1;
 static constexpr unsigned MINOR_VERSION = 2;
-static constexpr unsigned POINT_VERSION = 9;
+static constexpr unsigned POINT_VERSION = 10;
 }} // namespace SWOC_VERSION_NS

--- a/code/libswoc.part
+++ b/code/libswoc.part
@@ -1,6 +1,6 @@
 Import("*")
 PartName("libswoc")
-PartVersion("1.2.9")
+PartVersion("1.2.10")
 
 src_files = [
     "src/ArenaWriter.cc",

--- a/code/src/swoc_file.cc
+++ b/code/src/swoc_file.cc
@@ -10,6 +10,13 @@
 #include "swoc/swoc_file.h"
 #include "swoc/bwf_base.h"
 
+// Some portability defines for Apple's stat structure. See stat(2) man page.
+#if __APPLE__
+#define st_atim st_atimespec
+#define st_ctim st_ctimespec
+#define st_mtim st_mtimespec
+#endif
+
 using namespace swoc::literals;
 
 namespace swoc { inline namespace SWOC_VERSION_NS {

--- a/code/src/swoc_ip.cc
+++ b/code/src/swoc_ip.cc
@@ -178,7 +178,7 @@ IPEndpoint::size() const {
 }
 
 std::string_view
-IPEndpoint::family_name(uint16_t family) {
+IPEndpoint::family_name(sa_family_t family) {
   switch (family) {
     case AF_INET:return "ipv4"_sv;
     case AF_INET6:return "ipv6"_sv;
@@ -587,7 +587,7 @@ IPAddr::cmp(self_type const &that) const
 bool
 IPAddr::is_multicast() const {
   return (AF_INET == _family && 0xe == (_addr._octet[0] >> 4)) ||
-         (AF_INET6 == _family && IN6_IS_ADDR_MULTICAST(&_addr._ip6));
+         (AF_INET6 == _family && _addr._ip6.is_multicast());
 }
 
 IPEndpoint::IPEndpoint(std::string_view const& text) {

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "LibSWOC++"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "1.2.9"
+PROJECT_NUMBER         = "1.2.10"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doc/code/IPSpace.en.rst
+++ b/doc/code/IPSpace.en.rst
@@ -172,7 +172,7 @@ Blending Bitsets
 
    Some details are omitted for brevity and because they aren't directly relevant. The full
    implementation, which is run as a unit test to verify its correctness,
-   `is available here <https://github.com/SolidWallOfCode/libswoc/blob/1.2.9/unit_tests/ex_ipspace_properties.cc>`__.
+   `is available here <https://github.com/SolidWallOfCode/libswoc/blob/1.2.10/unit_tests/ex_ipspace_properties.cc>`__.
    You can compile and step through the code to see how it works in more detail, or experiment
    with changing some of the example data.
 

--- a/doc/code/TextView.en.rst
+++ b/doc/code/TextView.en.rst
@@ -278,7 +278,7 @@ separated by commas.
 
 .. sidebar:: Verification
 
-   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.9/unit_tests/ex_TextView.cc#L67>`__.
+   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.10/unit_tests/ex_TextView.cc#L67>`__.
 
 If :arg:`value` was :literal:`bob  ,dave, sam` then :arg:`token` would be successively
 :literal:`bob`, :literal:`dave`, :literal:`sam`. After :literal:`sam` was extracted :arg:`value`
@@ -300,7 +300,7 @@ for values that are boolean.
 
 .. sidebar:: Verification
 
-   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.9/unit_tests/ex_TextView.cc#L74>`__.
+   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.10/unit_tests/ex_TextView.cc#L74>`__.
 
 The basic list processing is the same as the previous example, with each element being treated as
 a "list" with ``=`` as the separator. Note if there is no ``=`` character then all of the list
@@ -351,7 +351,7 @@ do not, so a flag to strip quotes from the resulting elements is needed. The fin
 
 .. sidebar:: Verification
 
-   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.9/unit_tests/ex_TextView.cc#L90>`__.
+   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.10/unit_tests/ex_TextView.cc#L90>`__.
 
 This takes a :code:`TextView&` which is the source view which will be updated as tokens are removed
 (therefore the caller must do the empty view check). The other arguments are the separator character

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -80,7 +80,7 @@ project = u'Solid Wall Of C++'
 copyright = u'{}, amc@apache.org'.format(date.today().year)
 
 # The full version, including alpha/beta/rc tags.
-release = "1.2.9"
+release = "1.2.10"
 # The short X.Y version.
 version = '.'.join(release.split('.', 2)[:2])
 

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(test_libswoc
     ex_Lexicon.cc
     ex_MemArena.cc
     ex_TextView.cc
+    ex_UnitParser.cc
     )
 
 target_link_libraries(test_libswoc PUBLIC libswoc)

--- a/unit_tests/ex_UnitParser.cc
+++ b/unit_tests/ex_UnitParser.cc
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Verizon Media 2020
+/** @file
+
+    Example parser for parsing strings that are counts with attached unit tokens.
+*/
+
+#include <ctype.h>
+#include <chrono>
+
+#include "swoc/Lexicon.h"
+#include "swoc/Errata.h"
+#include "catch.hpp"
+
+using swoc::TextView;
+using swoc::Lexicon;
+using swoc::Errata;
+using swoc::Rv;
+
+namespace {
+
+// Shortcut for creating an @c Errata with a single error message.
+template < typename ... Args > Errata Error(TextView const& fmt, Args && ... args) {
+  return Errata{}.note_v(swoc::Severity::ERROR, fmt, std::forward_as_tuple(args...));
+}
+
+/** Extract and remove the next token.
+ *
+ * @tparam PRED Predicate function type - @c bool(char)
+ * @param src Input text.
+ * @param pred Predicate function.
+ * @return The token.
+ *
+ * The token is the prefix of @a src for which @a pred is true.
+ */
+template < typename PRED > inline TextView take_token_if(TextView &src, PRED const& pred) {
+  size_t idx = 0;
+  for (auto spot = src.data(), limit = spot + src.size() ; spot < limit && pred(*spot); ++spot, ++idx )
+    ; // empty
+  TextView token = src.prefix(idx);
+  src.remove_prefix(idx);
+  return token;
+}
+
+} // namespace
+
+/** Parse a string that consists of counts and units.
+ *
+ * Give a set of units, each of which is a list of names and a multiplier, parse a string. The
+ * string contents must consist of (optional whitespace) with alternating counts and units,
+ * starting with a count. Each count is multiplied by the value of the subsequent unit. Optionally
+ * the parser can be set to allow counts without units, which are not multiplied.
+ *
+ * For example, if the units were [ "X", 10 ] , [ "L", 50 ] , [ "C", 100 ] , [ "M", 1000 ]
+ * then the following strings would be parsed as
+ *
+ * - "1X" : 10
+ * - "1L3X" : 80
+ * - "2C" : 200
+ * - "1M 4C 4X" : 1,440
+ * - "3M 5 C3 X" : 3,530
+ */
+class UnitParser {
+  using self_type = UnitParser; ///< Self reference type.
+public:
+  using value_type = uintmax_t; ///< Integral type returned.
+  using Units = swoc::Lexicon<value_type>; ///< Unit definition type.
+
+  /** Constructor.
+   *
+   * @param units A @c Lexicon of unit definitions.
+   */
+  UnitParser(Units && units) noexcept;
+
+  /** Set whether a unit is required.
+   *
+   * @param flag @c true if a unit is required, @c false if not.
+   * @return @a this.
+   */
+  self_type & unit_required(bool flag);
+
+  /** Parse a string.
+   *
+   * @param src Input string.
+   * @return The computed value if the input it valid, or an error report.
+   */
+  Rv<value_type> operator() (swoc::TextView const& src) const noexcept;
+protected:
+  bool _unit_required_p = true; ///< Whether unitless values are allowed.
+  Units _units; ///< Unit definitions.
+};
+
+UnitParser::UnitParser(UnitParser::Units&& units) noexcept : _units(std::move(units)) {
+  _units.set_default(value_type{0}); // Used to check for bad unit names.
+}
+
+UnitParser::self_type& UnitParser::unit_required(bool flag) {
+  _unit_required_p = false;
+  return *this;
+}
+
+auto UnitParser::operator()(swoc::TextView const& src) const noexcept -> Rv<value_type> {
+  value_type zret = 0;
+  TextView text = src; // Keep @a src around to report error offsets.
+
+  while (text.ltrim_if(&isspace)) {
+    // Get a count first.
+    auto ptr = text.data(); // save for error reporting.
+    auto count = take_token_if(text, &isdigit);
+    if (count.empty()) {
+      return { 0 , Error("Required count not found at offset {}", ptr - src.data()) };
+    }
+    // Should always parse correctly as @a count is a non-empty sequence of digits.
+    auto n = svtou(count);
+
+    // Next, the unit.
+    ptr = text.ltrim_if(&isspace).data(); // save for error reporting.
+    // Everything up to the next digit or whitespace.
+    auto unit = take_token_if(text, [](char c) { return !(isspace(c) || isdigit(c)); } );
+    if (unit.empty()) {
+      if (_unit_required_p) {
+        return { 0, Error("Required unit not found at offset {}", ptr - src.data()) };
+      }
+      zret += n; // no metric -> unit metric.
+    } else {
+      auto mult = _units[unit]; // What's the multiplier?
+      if (mult == 0) {
+        return {0, Error("Unknown unit \"{}\" at offset {}", unit, ptr - src.data())};
+      }
+      zret += mult * n;
+    }
+  }
+  return zret;
+}
+
+// --- Tests ---
+
+TEST_CASE("UnitParser Bytes", "[Lexicon][UnitParser]") {
+  UnitParser bytes{
+      UnitParser::Units{
+          {
+              {1, {"B", "bytes"}}
+              , {1024, {"K", "KB", "kilo", "kilobyte"}}
+              , {1048576, {"M", "MB", "mega", "megabyte"}}
+              , {1 << 30, {"G", "GB", "giga", "gigabytes"}}
+          }}
+  };
+  bytes.unit_required(false);
+
+  REQUIRE(bytes("56 bytes") == 56);
+  REQUIRE(bytes("3 kb") == 3 * (1 << 10));
+  REQUIRE(bytes("6k128bytes") == 6 * (1 << 10) + 128);
+  REQUIRE(bytes("111") == 111);
+  REQUIRE(bytes("4K") == 4 * (1 << 10));
+  auto result = bytes("56delain");
+  REQUIRE(result.is_ok() == false);
+  REQUIRE(result.errata().front().text() == "Unknown unit \"delain\" at offset 2");
+  result = bytes("12K delain");
+  REQUIRE(result.is_ok() == false);
+  REQUIRE(result.errata().front().text() == "Required count not found at offset 4");
+}
+
+TEST_CASE("UnitParser Time", "[Lexicon][UnitParser]") {
+  using namespace std::chrono;
+  UnitParser time {
+      UnitParser::Units{
+          {
+              {nanoseconds{1}.count(), {"ns", "nanosec", "nanoseconds" }}
+              , {nanoseconds{microseconds{1}}.count(), {"us", "microsec", "microseconds"}}
+              , {nanoseconds{milliseconds{1}}.count(), {"ms", "millisec", "milliseconds"}}
+              , {nanoseconds{seconds{1}}.count(), {"s", "sec", "seconds"}}
+              , {nanoseconds{minutes{1}}.count(), {"m", "min", "minutes"}}
+              , {nanoseconds{hours{1}}.count(), {"h", "hours"}}
+              , {nanoseconds{hours{24}}.count(), {"d", "days"}}
+              , {nanoseconds{hours{168}}.count(), {"w", "weeks"}}
+          }}
+  };
+
+  REQUIRE(nanoseconds{time("2s")} == seconds{2});
+  REQUIRE(nanoseconds{time("1w 2days 12 hours")} == hours{168} + hours{2*24} + hours{12});
+  REQUIRE(nanoseconds{time("300ms")} == milliseconds{300});
+  REQUIRE(nanoseconds{time("1h30m")} == hours{1} + minutes{30});
+
+  auto result = time("1h30m10");
+  REQUIRE(result.is_ok() == false);
+  REQUIRE(result.errata().front().text() == "Required unit not found at offset 7");
+}

--- a/unit_tests/test_TextView.cc
+++ b/unit_tests/test_TextView.cc
@@ -287,6 +287,30 @@ TEST_CASE("TextView Affixes", "[libswoc][TextView]")
   s = "file.cc.org";
   s.remove_prefix_at('!');
   REQUIRE(s == "file.cc.org");
+
+  static constexpr TextView ctv {"http://delain.nl/albums/Lucidity.html"};
+  static constexpr TextView ctv_scheme{ctv.prefix(4)};
+  static constexpr TextView ctv_stem{ctv.suffix(4)};
+  static constexpr TextView ctv_host{ctv.substr(7, 9)};
+  REQUIRE(ctv.starts_with("http"_tv) == true);
+  REQUIRE(ctv.ends_with(".html") == true);
+  REQUIRE(ctv.starts_with("https"_tv) == false);
+  REQUIRE(ctv.ends_with(".jpg") == false);
+  REQUIRE(ctv.starts_with_nocase("HttP"_tv) == true);
+  REQUIRE(ctv.ends_with_nocase("htML"_tv) == true);
+
+  REQUIRE(ctv_scheme == "http"_tv);
+  REQUIRE(ctv_stem == "html"_tv);
+  REQUIRE(ctv_host == "delain.nl"_tv);
+
+  // Checking that constexpr works for this constructor as long as npos isn't used.
+  static constexpr TextView ctv2 {"http://delain.nl/albums/Interlude.html", 38};
+  TextView ctv4 {"http://delain.nl/albums/Interlude.html", 38};
+  // This doesn't compile because it causes strlen to be called which isn't constexpr compatible.
+  //static constexpr TextView ctv3 {"http://delain.nl/albums/Interlude.html", TextView::npos};
+  // This works because it's not constexpr.
+  TextView ctv3 {"http://delain.nl/albums/Interlude.html", TextView::npos};
+  REQUIRE(ctv2 == ctv3);
 };
 
 TEST_CASE("TextView Formatting", "[libswoc][TextView]")

--- a/unit_tests/test_ip.cc
+++ b/unit_tests/test_ip.cc
@@ -72,6 +72,23 @@ TEST_CASE("Basic IP", "[libswoc][ip]") {
   CHECK(alpha == IP4Addr{IPAddr{"172.96.12.134"}});
   CHECK(alpha == IPAddr{IPEndpoint{"172.96.12.134:80"}});
 
+  IP4Addr lo{"127.0.0.1"};
+  REQUIRE(lo.is_loopback() == true);
+  REQUIRE(lo.is_any() == false);
+  IP4Addr any{"0.0.0.0"};
+  REQUIRE(any.is_loopback() == false);
+  REQUIRE(any.is_any() == true);
+  IP6Addr lo6{"::1"};
+  REQUIRE(lo6.is_loopback() == true);
+  REQUIRE(lo6.is_any() == false);
+  REQUIRE(lo6.is_multicast() == false);
+  IP6Addr any6{"::"};
+  REQUIRE(any6.is_loopback() == false);
+  REQUIRE(any6.is_any() == true);
+  IP6Addr multi6{"FF02::1"};
+  REQUIRE(multi6.is_loopback() == false);
+  REQUIRE(multi6.is_multicast() == true);
+
   // Do a bit of IPv6 testing.
   IP6Addr a6_null;
   IP6Addr a6_1{"fe80:88b5:4a:20c:29ff:feae:5587:1c33"};
@@ -105,6 +122,8 @@ TEST_CASE("Basic IP", "[libswoc][ip]") {
   IP4Addr ip4_loopback{INADDR_LOOPBACK};
 
   REQUIRE(a4_loopback == ip4_loopback);
+  REQUIRE(a4_loopback.is_loopback() == true);
+  REQUIRE(ip4_loopback.is_loopback() == true);
 
   REQUIRE(a4_1 != a4_null);
   REQUIRE(a4_1 != a4_2);
@@ -168,6 +187,23 @@ TEST_CASE("Basic IP", "[libswoc][ip]") {
   REQUIRE(r4.max() == IP4Addr("2.2.2.2"));
   REQUIRE(r4.load("2.2.2.2.2") == false);
   REQUIRE(r4.load("2.2.2.2-fe80:20c::29ff:feae:5587::1c33") == false);
+
+  IPEndpoint ep;
+  ep.set_to_any(AF_INET);
+  REQUIRE(ep.is_loopback() == false);
+  REQUIRE(ep.is_any() == true);
+  ep.set_to_loopback(AF_INET6);
+  REQUIRE(ep.is_loopback() == true);
+  REQUIRE(ep.is_any() == false);
+  ep.set_to_any(AF_INET6);
+  REQUIRE(ep.is_loopback() == false);
+  REQUIRE(ep.is_any() == true);
+  ep.set_to_loopback(AF_INET);
+  REQUIRE(ep.is_loopback() == true);
+  REQUIRE(ep.is_any() == false);
+  IP4Addr a4 { &ep.sa4 };
+  REQUIRE(a4.is_loopback() == true);
+  REQUIRE(a4.is_any() == false);
 };
 
 TEST_CASE("IP Formatting", "[libswoc][ip][bwformat]") {


### PR DESCRIPTION
*  IP support library clean up, minor bug fixes.
*  Added better IP library support for loopback and multicast address checking.
*  Added "unit parser" example code.
*  `TextView` updates
   *  Added `constexpr` and `noexcept` to various methods.
   *  Removed array and size constructor - since `substr` is now `constexpr` it can be used instead.
*  Added support for building on MAC OS (thanks to @bneradt)