### PR TITLE
1.2.12 release.

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(Lib-SWOC CXX)
-set(LIBSWOC_VERSION "1.2.11")
+set(LIBSWOC_VERSION "1.2.12")
 set(CMAKE_CXX_STANDARD 17)
 include(GNUInstallDirs)
 

--- a/code/include/swoc/DiscreteRange.h
+++ b/code/include/swoc/DiscreteRange.h
@@ -1376,7 +1376,7 @@ DiscreteSpace<METRIC, PAYLOAD>::blend(DiscreteSpace::range_type const& range, U 
         }
       } else if (pred_plain_colored_p) { // can pull @a pred right to cover.
         pred->assign_max(remaining.max());
-      } else if (!remaining.empty()) { // Must add new range.
+      } else if (!remaining.empty() && plain_color_p) { // Must add new range if plain color valid.
         this->insert_before(n, _fa.make(remaining.min(), remaining.max(), plain_color));
       }
       return *this;

--- a/code/include/swoc/Scalar.h
+++ b/code/include/swoc/Scalar.h
@@ -100,7 +100,6 @@ scale_conversion_round_down(C c) {
 template<typename C> struct scalar_unit_round_up_t {
   C _n;
 
-  //    template <typename I> constexpr operator scalar_unit_round_up_t<I>() { return {static_cast<I>(_count)}; }
   template<intmax_t N, typename I>
   constexpr I
   scale() const {
@@ -112,7 +111,6 @@ template<typename C> struct scalar_unit_round_up_t {
 template<typename C> struct scalar_unit_round_down_t {
   C _n;
 
-  //    template <typename I> operator scalar_unit_round_down_t<I>() { return {static_cast<I>(_count)}; }
   template<intmax_t N, typename I>
   constexpr I
   scale() const {
@@ -137,6 +135,7 @@ template<intmax_t N, typename C, typename T> struct scalar_round_down_t {
     return Scalar<S, I, T>(scale_conversion_round_down<S, N>(_n));
   }
 };
+
 /// @endcond
 } // namespace detail
 
@@ -192,27 +191,38 @@ public:
   /// @note Requires that @c S be an integer multiple of @c SCALE.
   template<intmax_t S, typename I> constexpr Scalar(Scalar<S, I, T> const& that);
 
-  /// Conversion constructor.
+  /// @cond INTERNAL_DETAIL
+  // Assignment from internal rounding structures.
+  // Conversion constructor.
   constexpr Scalar(detail::scalar_round_up_t<N, C, T> const& that);
 
-  /// Conversion constructor.
+  // Conversion constructor.
   constexpr Scalar(detail::scalar_round_down_t<N, C, T> const& that);
 
-  /// Conversion constructor.
+  // Conversion constructor.
   template<typename I> constexpr Scalar(detail::scalar_unit_round_up_t<I> v);
 
-  /// Conversion constructor.
+  // Conversion constructor.
   template<typename I> constexpr Scalar(detail::scalar_unit_round_down_t<I> v);
+  /// @endcond
 
-  /// Assignment operator.
-  /// The value @a that is scaled appropriately.
-  /// @note Requires the scale of @a that be an integer multiple of the scale of @a this. If this isn't the case then
-  /// the @c round_up or @c round_down must be used to indicate the rounding direction.
+  /** Assign value from @a that.
+   *
+   * @tparam S Scale.
+   * @tparam I Integral type.
+   * @param that Source value.
+   * @return @a this.
+   *
+   * @note Requires the scale of @a that be an integer multiple of the scale of @a this. If this
+   * isn't the case then the @c round_up or @c round_down must be used to indicate the rounding
+   * direction.
+   */
   template<intmax_t S, typename I> self_type& operator=(Scalar<S, I, T> const& that);
 
-  /// Assignment from same scale.
+  /// Self type assignment.
   self_type& operator=(self_type const& that);
 
+  /// @cond INTERNAL_DETAIL
   /** Internal method to assign a unit value to be rounded up to the internal @c SCALE.
    *
    * @tparam I The underlying scale type.
@@ -248,6 +258,7 @@ public:
    * it to the local scale.
    */
   self_type& operator=(detail::scalar_round_down_t<N, C, T> v);
+  /// @endcond
 
   /** Set the scaled count to @a n.
    *
@@ -266,7 +277,7 @@ public:
   /// direction.
   template<intmax_t S, typename I> self_type& assign(Scalar<S, I, T> const& that);
 
-  // Conversion assignments.
+  /// @cond INTERNAL_DETAIL
   template<typename I> self_type& assign(detail::scalar_unit_round_up_t<I> n);
 
   template<typename I> self_type& assign(detail::scalar_unit_round_down_t<I> n);
@@ -274,6 +285,7 @@ public:
   self_type& assign(detail::scalar_round_up_t<N, C, T> v);
 
   self_type& assign(detail::scalar_round_down_t<N, C, T> v);
+  /// @endcond
 
   /// The number of scale units.
   constexpr Counter count() const;
@@ -292,6 +304,7 @@ public:
 
   template<intmax_t S, typename I> self_type& operator+=(Scalar<S, I, T> const& that);
 
+  /// @cond INTERNAL_DETAIL
   template<typename I> self_type& operator+=(detail::scalar_unit_round_up_t<I> n);
 
   template<typename I> self_type& operator+=(detail::scalar_unit_round_down_t<I> n);
@@ -299,6 +312,7 @@ public:
   self_type& operator+=(detail::scalar_round_up_t<N, C, T> v);
 
   self_type& operator+=(detail::scalar_round_down_t<N, C, T> v);
+  /// @endcond
 
   /// Increment - increase count by 1.
   self_type& operator++();
@@ -326,6 +340,7 @@ public:
 
   template<intmax_t S, typename I> self_type& operator-=(Scalar<S, I, T> const& that);
 
+  /// @cond INTERNAL_DETAIL
   template<typename I> self_type& operator-=(detail::scalar_unit_round_up_t<I> n);
 
   template<typename I> self_type& operator-=(detail::scalar_unit_round_down_t<I> n);
@@ -333,6 +348,7 @@ public:
   self_type& operator-=(detail::scalar_round_up_t<N, C, T> v);
 
   self_type& operator-=(detail::scalar_round_down_t<N, C, T> v);
+  /// @endcond
 
   /// Multiplication - multiple the count by @a n.
   self_type& operator*=(C n);

--- a/code/include/swoc/bwf_ex.h
+++ b/code/include/swoc/bwf_ex.h
@@ -94,7 +94,7 @@ template<typename... Args> struct SubText {
   arg_pack _args;                       ///< Arguments to format string.
 
   /// Construct with a specific @a fmt and @a args.
-  SubText(TextView fmt, arg_pack const& args) : _fmt(fmt), _args(args) {};
+  SubText(TextView const& fmt, arg_pack const& args) : _fmt(fmt), _args(args) {};
 
   /// Check for output not enabled.
   bool operator!() const;

--- a/code/include/swoc/swoc_ip.h
+++ b/code/include/swoc/swoc_ip.h
@@ -831,6 +831,14 @@ public:
    */
   bool load(string_view text);
 
+  /** Compute the mask for @a this as a network.
+   *
+   * @return If @a this is a network, the mask for that network. Otherwise an invalid mask.
+   *
+   * @see IPMask::is_valid
+   */
+  IPMask network_mask() const;
+
   class NetSource;
 
   /** Generate a list of networks covering @a this range.
@@ -873,6 +881,9 @@ public:
 
   iterator begin() const; ///< First network.
   iterator end() const; ///< Past last network.
+
+  /// Return @c true if there are valid networks, @c false if not.
+  bool empty() const;
 
   /// @return The current network.
   IP4Net operator*() const;
@@ -955,6 +966,14 @@ public:
    */
   bool load(string_view text);
 
+  /** Compute the mask for @a this as a network.
+   *
+   * @return If @a this is a network, the mask for that network. Otherwise an invalid mask.
+   *
+   * @see IPMask::is_valid
+   */
+  IPMask network_mask() const;
+
   class NetSource;
 
   /** Generate a list of networks covering @a this range.
@@ -997,6 +1016,9 @@ public:
 
   iterator begin() const; ///< First network.
   iterator end() const; ///< Past last network.
+
+  /// Return @c true if there are valid networks, @c false if not.
+  bool empty() const;
 
   /// @return The current network.
   IP6Net operator*() const;
@@ -1105,6 +1127,14 @@ public:
   IP4Range const& ip4() const { return _range._ip4; }
 
   IP6Range const& ip6() const { return _range._ip6; }
+
+  /** Compute the mask for @a this as a network.
+   *
+   * @return If @a this is a network, the mask for that network. Otherwise an invalid mask.
+   *
+   * @see IPMask::is_valid
+   */
+  IPMask network_mask() const;
 
   class NetSource;
 
@@ -2627,6 +2657,10 @@ inline IP4Range::NetSource::iterator IP4Range::NetSource::end() const {
   return self_type{range_type{}};
 }
 
+inline bool IP4Range::NetSource::empty() const {
+  return _range.empty();
+}
+
 inline IPMask IP4Range::NetSource::mask() const { return IPMask{_cidr}; }
 
 inline auto IP4Range::NetSource::operator->() -> self_type * { return this; }
@@ -2648,6 +2682,10 @@ inline auto IP6Range::NetSource::begin() const -> iterator {
 
 inline auto IP6Range::NetSource::end() const -> iterator {
   return self_type{range_type{}};
+}
+
+inline bool IP6Range::NetSource::empty() const {
+  return _range.empty();
 }
 
 inline IP6Net IP6Range::NetSource::operator*() const {

--- a/code/include/swoc/swoc_version.h
+++ b/code/include/swoc/swoc_version.h
@@ -22,11 +22,11 @@
 #pragma once
 
 #if !defined(SWOC_VERSION_NS)
-#  define SWOC_VERSION_NS _1_2_11
+#  define SWOC_VERSION_NS _1_2_12
 #endif
 
 namespace swoc { inline namespace SWOC_VERSION_NS {
 static constexpr unsigned MAJOR_VERSION = 1;
 static constexpr unsigned MINOR_VERSION = 2;
-static constexpr unsigned POINT_VERSION = 11;
+static constexpr unsigned POINT_VERSION = 12;
 }} // namespace SWOC_VERSION_NS

--- a/code/libswoc.part
+++ b/code/libswoc.part
@@ -1,6 +1,6 @@
 Import("*")
 PartName("libswoc")
-PartVersion("1.2.11")
+PartVersion("1.2.12")
 
 src_files = [
     "src/ArenaWriter.cc",

--- a/code/src/bw_ip_format.cc
+++ b/code/src/bw_ip_format.cc
@@ -262,6 +262,19 @@ bwformat(BufferWriter& w, Spec const& spec, IP4Range const& range) {
   if (range.empty()) {
     w.write("*-*"_tv);
   } else {
+    // Compact means output as singleton or CIDR if that's possible.
+    if (spec._ext.find('c') != spec._ext.npos) {
+      if (range.is_singleton()) {
+        return bwformat(w, spec, range.min());
+      }
+      auto mask { range.network_mask() };
+      if (mask.is_valid()) {
+        bwformat(w, spec, range.min());
+        w.write('/');
+        bwformat(w, bwf::Spec::DEFAULT, mask);
+        return w;
+      }
+    }
     bwformat(w, spec, range.min());
     w.write('-');
     bwformat(w, spec, range.max());
@@ -274,6 +287,19 @@ bwformat(BufferWriter& w, Spec const& spec, IP6Range const& range) {
   if (range.empty()) {
     w.write("*-*"_tv);
   } else {
+    // Compact means output as singleton or CIDR if that's possible.
+    if (spec._ext.find('c') != spec._ext.npos) {
+      if (range.is_singleton()) {
+        return bwformat(w, spec, range.min());
+      }
+      auto mask { range.network_mask() };
+      if (mask.is_valid()) {
+        bwformat(w, spec, range.min());
+        w.write('/');
+        bwformat(w, bwf::Spec::DEFAULT, mask);
+        return w;
+      }
+    }
     bwformat(w, spec, range.min());
     w.write('-');
     bwformat(w, spec, range.max());

--- a/code/src/swoc_ip.cc
+++ b/code/src/swoc_ip.cc
@@ -771,6 +771,14 @@ bool IP4Range::load(string_view text) {
   return false;
 }
 
+IPMask IP4Range::network_mask() const {
+  NetSource nets { *this };
+  if (! nets.empty() && (*nets).as_range() == *this) {
+    return nets->mask();
+  }
+  return {}; // default constructed (invalid) mask.
+}
+
 IP4Range::NetSource::NetSource(IP4Range::NetSource::range_type const& range) : _range(range) {
   if (!_range.empty()) {
     this->search_wider();
@@ -924,6 +932,23 @@ bool IPRange::empty() const {
     default: break;
   }
   return true;
+}
+
+IPMask IPRange::network_mask() const {
+  switch (_family) {
+    case AF_INET: return _range._ip4.network_mask();
+    case AF_INET6: return _range._ip6.network_mask();
+    default: break;
+  }
+  return {};
+}
+
+IPMask IP6Range::network_mask() const {
+  NetSource nets { *this };
+  if (! nets.empty() && (*nets).as_range() == *this) {
+    return nets->mask();
+  }
+  return {}; // default constructed (invalid) mask.
 }
 
 IP6Range::NetSource::NetSource(IP6Range::NetSource::range_type const& range) : _range(range) {

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "LibSWOC++"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "1.2.11"
+PROJECT_NUMBER         = "1.2.12"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doc/code/IPSpace.en.rst
+++ b/doc/code/IPSpace.en.rst
@@ -83,6 +83,20 @@ properly formatted, otherwise the range will be default constructed to an invali
 also the :libswoc:`swoc::IPRange::load` method which returns a :code:`bool` to indicate if the
 parsing was successful.
 
+This class has formatting support in "bwf_ip.h". In addition to all of the formatting supported for
+:code:`sockaddr`, the additional extension code 'c' can be used to indicate compact range formatting.
+Compact means a singleton range will be written as just the single address, and if the range is
+also a network it will be printed in CIDR format.
+
+======================= =======================
+Range                   Compact
+======================= =======================
+10.1.0.0-10.1.0.127     10.1.0.0/25
+10.2.0.1-10.2.0.127     10.2.0.1-10.2.0.127
+10.3.0.0-10.3.0.126     10.3.0.0-10.3.0.126
+10.4.1.1-10.4.1.1       10.4.1.1
+======================= =======================
+
 .. _ip-space:
 
 IPSpace

--- a/doc/code/IPSpace.en.rst
+++ b/doc/code/IPSpace.en.rst
@@ -172,7 +172,7 @@ Blending Bitsets
 
    Some details are omitted for brevity and because they aren't directly relevant. The full
    implementation, which is run as a unit test to verify its correctness,
-   `is available here <https://github.com/SolidWallOfCode/libswoc/blob/1.2.11/unit_tests/ex_ipspace_properties.cc>`__.
+   `is available here <https://github.com/SolidWallOfCode/libswoc/blob/1.2.12/unit_tests/ex_ipspace_properties.cc>`__.
    You can compile and step through the code to see how it works in more detail, or experiment
    with changing some of the example data.
 

--- a/doc/code/TextView.en.rst
+++ b/doc/code/TextView.en.rst
@@ -278,7 +278,7 @@ separated by commas.
 
 .. sidebar:: Verification
 
-   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.11/unit_tests/ex_TextView.cc#L67>`__.
+   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.12/unit_tests/ex_TextView.cc#L67>`__.
 
 If :arg:`value` was :literal:`bob  ,dave, sam` then :arg:`token` would be successively
 :literal:`bob`, :literal:`dave`, :literal:`sam`. After :literal:`sam` was extracted :arg:`value`
@@ -300,7 +300,7 @@ for values that are boolean.
 
 .. sidebar:: Verification
 
-   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.11/unit_tests/ex_TextView.cc#L74>`__.
+   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.12/unit_tests/ex_TextView.cc#L74>`__.
 
 The basic list processing is the same as the previous example, with each element being treated as
 a "list" with ``=`` as the separator. Note if there is no ``=`` character then all of the list
@@ -351,7 +351,7 @@ do not, so a flag to strip quotes from the resulting elements is needed. The fin
 
 .. sidebar:: Verification
 
-   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.11/unit_tests/ex_TextView.cc#L90>`__.
+   `Test code for example <https://github.com/SolidWallOfCode/libswoc/blob/1.2.12/unit_tests/ex_TextView.cc#L90>`__.
 
 This takes a :code:`TextView&` which is the source view which will be updated as tokens are removed
 (therefore the caller must do the empty view check). The other arguments are the separator character

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -80,7 +80,7 @@ project = u'Solid Wall Of C++'
 copyright = u'{}, amc@apache.org'.format(date.today().year)
 
 # The full version, including alpha/beta/rc tags.
-release = "1.2.11"
+release = "1.2.12"
 # The short X.Y version.
 version = '.'.join(release.split('.', 2)[:2])
 

--- a/unit_tests/test_ip.cc
+++ b/unit_tests/test_ip.cc
@@ -321,6 +321,37 @@ TEST_CASE("IP Formatting", "[libswoc][ip][bwformat]") {
   REQUIRE(w.view() == "0000:0000:0000:0000:0000:0000:0000:0001");
   w.clear().print("{:: =a}", ep);
   REQUIRE(w.view() == "   0:   0:   0:   0:   0:   0:   0:   1");
+
+  std::string_view r_1{"10.1.0.0-10.1.0.127"};
+  std::string_view r_2{"10.2.0.1-10.2.0.127"}; // not a network - bad start
+  std::string_view r_3{"10.3.0.0-10.3.0.126"}; // not a network - bad end
+  std::string_view r_4{"10.4.1.1-10.4.1.1"}; // singleton
+
+  IPRange r;
+
+  r.load(r_1);
+  w.clear().print("{}", r);
+  REQUIRE(w.view() == r_1);
+  w.clear().print("{::c}", r);
+  REQUIRE(w.view() == "10.1.0.0/25");
+
+  r.load(r_2);
+  w.clear().print("{}", r);
+  REQUIRE(w.view() == r_2);
+  w.clear().print("{::c}", r);
+  REQUIRE(w.view() == r_2);
+
+  r.load(r_3);
+  w.clear().print("{}", r);
+  REQUIRE(w.view() == r_3);
+  w.clear().print("{::c}", r);
+  REQUIRE(w.view() == r_3);
+
+  r.load(r_4);
+  w.clear().print("{}", r);
+  REQUIRE(w.view() == r_4);
+  w.clear().print("{::c}", r);
+  REQUIRE(w.view() == "10.4.1.1");
 }
 
 TEST_CASE("IP ranges and networks", "[libswoc][ip][net][range]") {
@@ -565,7 +596,7 @@ TEST_CASE("IP ranges and networks", "[libswoc][ip][net][range]") {
     ++r5_net;
   }
 
-  // Try it again, using @c IPRange.
+  // Try it again, using @c IPNet.
   r5_net = r_5_nets.begin();
   for ( auto const&[addr, mask] : IPRange{r_5}.networks()) {
     REQUIRE(r5_net != r_5_nets.end());


### PR DESCRIPTION
*  Fix blend bug for empty ranges on `false` blender return.
*  Add additional network support to IPRange classes.
*  Add "compact" range BWF extension ('c' in format specifier extension).