### PR TITLE
Adding Rv::note(Errata) overloads.

### DIFF
--- a/code/include/swoc/Errata.h
+++ b/code/include/swoc/Errata.h
@@ -456,6 +456,20 @@ public:
    */
   template <typename... Args> self_type &note(Severity level, std::string_view fmt, Args &&... args);
 
+  /** Copy messages from @a that to @a this.
+   *
+   * @param that Source object from which to copy.
+   * @return @a *this
+   */
+  self_type &note(Errata const &that);
+
+  /** Copy messages from @a that to @a this, then clear @a that.
+   *
+   * @param that Source object from which to copy.
+   * @return @a *this
+   */
+  self_type &note(Errata &&that);
+
   /// Overload for @c DIAG severity notes.
   template <typename... Args> self_type &diag(std::string_view fmt, Args &&... args) &;
   template <typename... Args> self_type diag(std::string_view fmt, Args &&... args) &&;
@@ -880,6 +894,21 @@ template <typename... Args>
 Rv<R> &
 Rv<R>::note(Severity level, std::string_view fmt, Args &&... args) {
   _errata.note_v(level, fmt, std::forward_as_tuple(args...));
+  return *this;
+}
+
+template <typename R>
+inline Rv<R> &
+Rv<R>::note(Errata const &that) {
+  this->_errata.note(that);
+  return *this;
+}
+
+template <typename R>
+inline Rv<R> &
+Rv<R>::note(Errata &&that) {
+  this->_errata.note(std::move(that));
+  that.clear();
   return *this;
 }
 

--- a/unit_tests/test_Errata.cc
+++ b/unit_tests/test_Errata.cc
@@ -138,6 +138,19 @@ TEST_CASE("Rv", "[libswoc][Errata]")
   test(Severity::WARN, Rv<int>{56}.warn("Test rvalue warn"));
   test(Severity::ERROR, Rv<int>{56}.error("Test rvalue error"));
 
+  // Test the note overload that takes an Errata.
+  zret.clear();
+  REQUIRE(zret.result() == 56);
+  REQUIRE(zret.errata().count() == 0);
+  Errata errata;
+  errata.info("Information");
+  zret.note(errata);
+  test(Severity::INFO, zret);
+  REQUIRE(errata.count() == 1);
+  zret.note(std::move(errata));
+  REQUIRE(zret.errata().count() == 2);
+  REQUIRE(errata.count() == 0);
+
   // Now try it on a non-copyable object.
   ThingHandle handle{new Thing};
   Rv<ThingHandle> thing_rv;


### PR DESCRIPTION
Enable:

`zret.note(errata);
`
Instead of requiring:

`zret.errata().note(errata);`