### PR TITLE
Add static block support to MemArena.

### DIFF
--- a/code/include/swoc/MemArena.h
+++ b/code/include/swoc/MemArena.h
@@ -167,6 +167,16 @@ public:
    */
   explicit MemArena(size_t n = DEFAULT_BLOCK_SIZE);
 
+  /** Construct using static block.
+   *
+   * @param static_block A block of memory that is non-deletable.
+   *
+   * @a static_block is used as the first block for allocation and is never deleted. This makes
+   * it possible to have an instance that allocates from stack memory and only allocates from the
+   * heap if the static block becomes full.
+   */
+  explicit MemArena(MemSpan<void> static_block);
+
   /// no copying
   MemArena(self_type const& that) = delete;
 
@@ -378,6 +388,9 @@ protected:
 
   BlockList _frozen; ///< Previous generation, frozen memory.
   BlockList _active; ///< Current generation. Allocate here.
+
+  /// Static block, if any.
+  Block* _static_block = nullptr;
 
   // Note on _active block list - blocks that become full are moved to the end of the list.
   // This means that when searching for a block with space, the first full block encountered

--- a/code/include/swoc/Scalar.h
+++ b/code/include/swoc/Scalar.h
@@ -293,10 +293,10 @@ public:
   constexpr Counter count() const;
 
   /// The scaled value.
-  constexpr intmax_t value() const;
+  constexpr Counter value() const;
 
   /// User conversion to scaled value.
-  constexpr operator intmax_t() const;
+  constexpr operator Counter() const;
 
   /// Addition operator.
   /// The value is scaled from @a that to @a this.
@@ -416,12 +416,12 @@ Scalar<N, C, T>::count() const -> Counter {
 }
 
 template<intmax_t N, typename C, typename T>
-constexpr intmax_t
+constexpr C
 Scalar<N, C, T>::value() const {
   return _n * SCALE;
 }
 
-template<intmax_t N, typename C, typename T> constexpr Scalar<N, C, T>::operator intmax_t() const {
+template<intmax_t N, typename C, typename T> constexpr Scalar<N, C, T>::operator C() const {
   return _n * SCALE;
 }
 


### PR DESCRIPTION
Add ability to use a static block of memory in `MemArena`. This enables avoid an allocation if the memory needed is less than the size of the static (or stack allocated) block.