### PR TITLE
Fix build on macOS

### DIFF
--- a/code/include/swoc/swoc_ip.h
+++ b/code/include/swoc/swoc_ip.h
@@ -10,6 +10,7 @@
 #include <netinet/in.h>
 #include <string_view>
 #include <variant>
+#include <array>
 
 #include "swoc/swoc_version.h"
 #include "swoc/TextView.h"


### PR DESCRIPTION
Include <array> in swoc_ip.h to fix a build failure.