### PR TITLE
Remove use of deprecated std::binary_function

### DIFF
--- a/code/include/swoc/DiscreteRange.h
+++ b/code/include/swoc/DiscreteRange.h
@@ -319,7 +319,11 @@ public:
       The first pair of elements that are not equal determine the ordering
       of the overall tuples.
    */
-  struct lexicographic_order : public std::binary_function<self_type, self_type, bool> {
+  struct lexicographic_order {
+    using first_argument_type = self_type;
+    using second_argument_type = self_type;
+    using result_type = bool;
+
     //! Functor operator.
     bool operator()(self_type const &lhs, self_type const &rhs) const;
   };


### PR DESCRIPTION
std::binary_function is deprecated and will be removed in c++17. This replaces
the use of that interface with the corresponding using directives.