### PR TITLE
Add copy assignment operator for MemSpan.

### DIFF
--- a/code/include/swoc/MemSpan.h
+++ b/code/include/swoc/MemSpan.h
@@ -277,6 +277,9 @@ public:
   /// Copy constructor.
   constexpr MemSpan(self_type const &that) = default;
 
+  /// Copy assignment operator.
+  constexpr self_type& operator=(self_type const &that) = default
+
   /** Cross type copy constructor.
    *
    * @tparam U Type for source span.


### PR DESCRIPTION
This was required by Clang 13.0.1.

---

Here is the warning this fixes:

```
In file included from /var/tmp/trafficserver/lib/swoc/include/swoc/MemArena.h:18:
/var/tmp/trafficserver/lib/swoc/include/swoc/MemSpan.h:278:13: error: definition of implicit copy assignment operator for 'MemSpan<void>' is deprecated because it has a user-declared copy constructor [-Werror,-Wdeprecated-copy]
  constexpr MemSpan(self_type const &that) = default;
            ^
src/MemArena.cc:105:14: note: in implicit copy assignment operator for 'swoc::MemSpan<void>' first required here
  zret       = block->alloc(n, align);
             ^
1 error generated.
make[2]: *** [Makefile:776: src/MemArena.lo] Error 1
```