### PR TITLE
Fix FreeBSD 13 compilation error.

### DIFF
--- a/code/include/swoc/swoc_ip.h
+++ b/code/include/swoc/swoc_ip.h
@@ -9,6 +9,7 @@
 #include <array>
 #include <climits>
 #include <netinet/in.h>
+#include <sys/socket.h>
 #include <string_view>
 #include <variant>
 

--- a/code/src/swoc_file.cc
+++ b/code/src/swoc_file.cc
@@ -114,37 +114,37 @@ chrono_cast(timespec const &ts) {
 // Under -O2 these are completely elided.
 template <typename S>
 auto
-a_time(S const &s) -> decltype(S::st_atim) {
+a_time(S const &s, meta::CaseTag<0>) -> decltype(S::st_atim) {
   return s.st_atim;
 }
 
 template <typename S>
 auto
-a_time(S const &s) -> decltype(S::st_atimespec) {
+a_time(S const &s, meta::CaseTag<1>) -> decltype(S::st_atimespec) {
   return s.st_atimespec;
 }
 
 template <typename S>
 auto
-m_time(S const &s) -> decltype(S::st_mtim) {
+m_time(S const &s, meta::CaseTag<0>) -> decltype(S::st_mtim) {
   return s.st_mtim;
 }
 
 template <typename S>
 auto
-m_time(S const &s) -> decltype(S::st_mtimespec) {
+m_time(S const &s, meta::CaseTag<1>) -> decltype(S::st_mtimespec) {
   return s.st_mtimespec;
 }
 
 template <typename S>
 auto
-c_time(S const &s) -> decltype(S::st_ctim) {
+c_time(S const &s, meta::CaseTag<0>) -> decltype(S::st_ctim) {
   return s.st_ctim;
 }
 
 template <typename S>
 auto
-c_time(S const &s) -> decltype(S::st_ctimespec) {
+c_time(S const &s, meta::CaseTag<1>) -> decltype(S::st_ctimespec) {
   return s.st_ctimespec;
 }
 
@@ -152,17 +152,17 @@ c_time(S const &s) -> decltype(S::st_ctimespec) {
 
 std::chrono::system_clock::time_point
 modify_time(file_status const &fs) {
-  return chrono_cast(m_time(fs._stat));
+  return chrono_cast(m_time(fs._stat, meta::CaseArg));
 }
 
 std::chrono::system_clock::time_point
 access_time(file_status const &fs) {
-  return chrono_cast(a_time(fs._stat));
+  return chrono_cast(a_time(fs._stat, meta::CaseArg));
 }
 
 std::chrono::system_clock::time_point
 status_time(file_status const &fs) {
-  return chrono_cast(c_time(fs._stat));
+  return chrono_cast(c_time(fs._stat, meta::CaseArg));
 }
 
 bool


### PR DESCRIPTION
The existing code assumes that only one version of the timespecs will be defined for each time spec,
but it seems that this version of FreeBSD defined two per each spec making impossible for the compiler
to define the right overload, this changes adds a tag(CaseTag) to each implementation making
each overload have a different signature.