### PR TITLE
Make install optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 project("Solid Wall Of C++ Library")
+include(CMakeDependentOption)
 set(INSTALL_DIR ${CMAKE_HOME_DIRECTORY})
 
 # Fortunately this has no external dependencies so the set up can be simple.

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -64,7 +64,7 @@ target_include_directories(libswoc
         $<INSTALL_INTERFACE:include>
     )
 
-if (LIBSWOC_INSTALL STREQUAL "on")
+if (LIBSWOC_INSTALL)
     # These install target variables are created by GNUInstallDirs.
     install(TARGETS libswoc
         EXPORT libswoc-config

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -5,6 +5,10 @@ set(LIBSWOC_VERSION "1.3.8")
 set(CMAKE_CXX_STANDARD 17)
 include(GNUInstallDirs)
 
+cmake_dependent_option(LIBSWOC_INSTALL
+    "Enable generation of libswoc install targets" ON
+    "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
+
 set(HEADER_FILES
     include/swoc/swoc_version.h
     include/swoc/ArenaWriter.h
@@ -60,22 +64,24 @@ target_include_directories(libswoc
         $<INSTALL_INTERFACE:include>
     )
 
-# These install target variables are created by GNUInstallDirs.
-install(TARGETS libswoc
-    EXPORT libswoc-config
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} # seems to have no effect.
-    )
-install(DIRECTORY include/swoc DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if (LIBSWOC_INSTALL STREQUAL "on")
+    # These install target variables are created by GNUInstallDirs.
+    install(TARGETS libswoc
+        EXPORT libswoc-config
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} # seems to have no effect.
+        )
+    install(DIRECTORY include/swoc DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-install(EXPORT libswoc-config
-    NAMESPACE libswoc::
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libswoc
-    )
+    install(EXPORT libswoc-config
+        NAMESPACE libswoc::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libswoc
+        )
 
 
-set(PKG_CONFIG_FILE ${CMAKE_INSTALL_LIBDIR}/libswoc.pc)
-configure_file("libswoc.pc.cmake" ${PKG_CONFIG_FILE} @ONLY)
-install(FILES ${PKG_CONFIG_FILE} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+    set(PKG_CONFIG_FILE ${CMAKE_INSTALL_LIBDIR}/libswoc.pc)
+    configure_file("libswoc.pc.cmake" ${PKG_CONFIG_FILE} @ONLY)
+    install(FILES ${PKG_CONFIG_FILE} DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+endif()
 
 # Alledgedly this makes the targets "importable from the build directory" but I see no evidence of that.
 # AFAICT the file isn't created at all even with this enabled.


### PR DESCRIPTION
This enables another project to disable the install logic by setting a CMake variable. If libswoc is used in an embedded fashion only the parent project, and nothing in libswoc, should be installed.