### PR TITLE
update pc generation to work better

### DIFF
--- a/code/libswoc.pc.in
+++ b/code/libswoc.pc.in
@@ -7,5 +7,5 @@ Name: LibSWOC++
 Description: A collection of solid C++ utilities and classes.
 Version: pkg_version
 Requires:
-Libs: -L${libdir} -lswoc.pkg_version
+Libs: -L${libdir} -lswoc-pkg_version
 Cflags: -I${includedir}

--- a/code/libswoc.shared.part
+++ b/code/libswoc.shared.part
@@ -30,8 +30,13 @@ def source(env):
     env.InstallLib(out)
 
     # Export the package config.
-    pc_file = env.Substfile("libswoc.pc", "libswoc.pc.in", SUBST_DICT={
+    sdk_pc_file = env.Substfile("libswoc.pc", "libswoc.pc.in", SUBST_DICT={
+        "pkg_prefix": env.Dir("$SDK_ROOT").abspath, "pkg_version": "$PART_VERSION"
+    })
+
+    pc_file = env.Substfile("_install_/libswoc.pc", "libswoc.pc.in", SUBST_DICT={
         "pkg_prefix": env.Dir("$INSTALL_ROOT").abspath, "pkg_version": "$PART_VERSION"
     })
 
-    env.InstallPkgConfig(pc_file)
+    env.SdkPkgConfig(sdk_pc_file)
+    env.InstallPkgConfig(pc_file,create_sdk=False)

--- a/code/libswoc.static.part
+++ b/code/libswoc.static.part
@@ -29,11 +29,18 @@ def source(env):
     env.InstallLib(out)
 
     # Export the package config.
-    pc_file = env.Substfile("libswoc.static.pc", "libswoc.static.pc.in"
+    sdk_pc_file = env.Substfile("libswoc.static.pc", "libswoc.static.pc.in"
+        , SUBST_DICT = {
+            "pkg_prefix": env.Dir("$SDK_ROOT").abspath
+        , "pkg_version": "$PART_VERSION"
+        })
+
+    pc_file = env.Substfile("_install_/libswoc.static.pc", "libswoc.static.pc.in"
         , SUBST_DICT = {
             "pkg_prefix": env.Dir("$INSTALL_ROOT").abspath
         , "pkg_version": "$PART_VERSION"
         })
 
 
-    env.InstallPkgConfig(pc_file)
+    env.SdkPkgConfig(sdk_pc_file)
+    env.InstallPkgConfig(pc_file,create_sdk=False)


### PR DESCRIPTION
The main fix here is that the PC file has a different prefix if it is in the SDK location or the install sandbox. 
This allows the referencing of the SDK PC file which is often used in larger build to point to the correct bits
It also fixes an issue with the shared pc file name.. the part file was making a libswoc-1.4.2.so while the .pc files said it was a libswoc.1.4.2.so... now it use the `-` form in both.