### PR TITLE
adding -Wshadow && adding corrections for this

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -67,7 +67,7 @@ endif()
 add_library(libswoc-static STATIC ${CC_FILES})
 set_target_properties(libswoc-static PROPERTIES OUTPUT_NAME swoc-static-${LIBSWOC_VERSION})
 if (CMAKE_COMPILER_IS_GNUCXX)
-    target_compile_options(libswoc-static PRIVATE -fPIC -Wall -Wextra -Werror -Wnon-virtual-dtor -Wpedantic)
+    target_compile_options(libswoc-static PRIVATE -fPIC -Wall -Wextra -Werror -Wnon-virtual-dtor -Wpedantic -Wshadow)
 endif()
 
 # Not quite sure how this works, but I think it generates one of two paths depending on the context.

--- a/code/include/swoc/IPEndpoint.h
+++ b/code/include/swoc/IPEndpoint.h
@@ -190,8 +190,8 @@ inline IPEndpoint::IPEndpoint(IPAddr const &addr) {
   this->assign(addr);
 }
 
-inline IPEndpoint::IPEndpoint(sockaddr const *sa) {
-  this->assign(sa);
+inline IPEndpoint::IPEndpoint(sockaddr const *socketaddr) {
+  this->assign(socketaddr);
 }
 
 inline IPEndpoint::IPEndpoint(IPEndpoint::self_type const &that) : self_type(&that.sa) {}

--- a/code/include/swoc/TextView.h
+++ b/code/include/swoc/TextView.h
@@ -1543,16 +1543,16 @@ template <typename Stream>
 Stream &
 TextView::stream_write(Stream &os, const TextView &b) const {
   // Local function, avoids extra template work.
-  static const auto stream_fill = [](Stream &os, size_t n) -> Stream & {
+  static const auto stream_fill = [](Stream &ostream, size_t n) -> Stream & {
     static constexpr size_t pad_size = 8;
     typename Stream::char_type padding[pad_size];
 
-    std::fill_n(padding, pad_size, os.fill());
-    for (; n >= pad_size && os.good(); n -= pad_size)
-      os.write(padding, pad_size);
-    if (n > 0 && os.good())
-      os.write(padding, n);
-    return os;
+    std::fill_n(padding, pad_size, ostream.fill());
+    for (; n >= pad_size && ostream.good(); n -= pad_size)
+      ostream.write(padding, pad_size);
+    if (n > 0 && ostream.good())
+      ostream.write(padding, n);
+    return ostream;
   };
 
   const std::size_t w = os.width();


### PR DESCRIPTION
we were bumping into some issues with libswoc when we added the -Wshadow compiler flag for GXX.  Added it in and renamed variables in two locations to prevent possible shadowing bugs.