### PR TITLE
Fix unused var warning + explicit includes

### DIFF
--- a/code/include/swoc/IPAddr.h
+++ b/code/include/swoc/IPAddr.h
@@ -9,6 +9,8 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 
+#include <cstddef>
+
 #include "swoc/swoc_version.h"
 #include "swoc/swoc_meta.h"
 #include "swoc/MemSpan.h"

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -8,12 +8,20 @@ set_target_properties(ex_netdb PROPERTIES CLANG_FORMAT_DIRS ${CMAKE_CURRENT_SOUR
 
 if (CMAKE_COMPILER_IS_GNUCXX)
     target_compile_options(ex_netdb PRIVATE -Wall -Wextra -Werror)
+     # stop the compiler from complaining about unused variable in structured binding
+    if (GCC_VERSION VERSION_LESS 8.0)
+        target_compile_options(ex_netdb PRIVATE -Wno-unused-variable)
+    endif ()
 endif()
 
 add_executable(ex_netcompact ex_netcompact.cc)
 target_link_libraries(ex_netcompact PUBLIC libswoc-static)
 if (CMAKE_COMPILER_IS_GNUCXX)
     target_compile_options(ex_netcompact PRIVATE -Wall -Wextra -Werror)
+     # stop the compiler from complaining about unused variable in structured binding
+    if (GCC_VERSION VERSION_LESS 8.0)
+        target_compile_options(ex_netcompact PRIVATE -Wno-unused-variable)
+    endif ()
 endif()
 
 add_executable(ex_flat_space ex_flat_space.cc)

--- a/example/ex_lru_cache.cc
+++ b/example/ex_lru_cache.cc
@@ -10,6 +10,7 @@
 #include <chrono>
 #include <utility>
 #include <thread>
+#include <shared_mutex>
 #include <condition_variable>
 #include <iostream>
 

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -33,5 +33,9 @@ target_link_libraries(test_libswoc PUBLIC libswoc)
 set_target_properties(test_libswoc PROPERTIES CLANG_FORMAT_DIRS ${CMAKE_CURRENT_SOURCE_DIR})
 if (CMAKE_COMPILER_IS_GNUCXX)
     target_compile_options(test_libswoc PRIVATE -Wall -Wextra -Werror -Wno-unused-parameter -Wno-format-truncation -Wno-stringop-overflow -Wno-invalid-offsetof)
+    # stop the compiler from complaining about unused variable in structured binding
+    if (GCC_VERSION VERSION_LESS 8.0)
+        target_compile_options(test_libswoc PRIVATE -Wno-unused-variable)
+    endif ()
 endif()
 


### PR DESCRIPTION
* Disable unused variable warning for structured binding for GCC < 8.0 
* Added explicit includes for std::byte and std::shared_mutex