### PR TITLE
Updated clang-format version, and rran it against all C++ code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,62 +2,99 @@
 Language:        Cpp
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
-AlignConsecutiveMacros: false
-AlignConsecutiveAssignments: true
-AlignConsecutiveDeclarations: false
+AlignArrayOfStructures: Left
+AlignConsecutiveAssignments:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   true
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    true
+AlignConsecutiveMacros:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    true
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseColons: false
 AlignEscapedNewlines: Left
-AlignOperands:   true
-AlignTrailingComments: true
-AllowAllArgumentsOnNextLine: true
-AllowAllConstructorInitializersOnNextLine: true
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: Inline
-AllowShortLambdasOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: All
 AlwaysBreakAfterReturnType: AllDefinitions
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
 BinPackArguments: true
 BinPackParameters: true
+BitFieldColonSpacing: Both
 BraceWrapping:
   AfterCaseLabel:  false
   AfterClass:      true
-  AfterControlStatement: false
+  AfterControlStatement: Never
   AfterEnum:       false
+  AfterExternBlock: false
   AfterFunction:   true
   AfterNamespace:  true
   AfterObjCDeclaration: false
   AfterStruct:     false
   AfterUnion:      false
-  AfterExternBlock: false
   BeforeCatch:     false
   BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
   IndentBraces:    false
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
-BreakBeforeBinaryOperators: None
-BreakBeforeInheritanceComma: false
-BreakInheritanceList: BeforeColon
-BreakBeforeTernaryOperators: false
-BreakConstructorInitializersBeforeComma: false
-BreakConstructorInitializers: BeforeColon
+BreakAfterAttributes: Never
 BreakAfterJavaFieldAnnotations: false
+BreakArrays:     true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Linux
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
 BreakStringLiterals: true
 ColumnLimit:     132
 CommentPragmas:  '^ IWYU pragma:'
-CompactNamespaces: true
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
+CompactNamespaces: false
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 2
 Cpp11BracedListStyle: true
-DeriveLineEnding: true
 DerivePointerAlignment: false
 DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
 ForEachMacros:
@@ -67,72 +104,135 @@ ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
 IncludeBlocks:   Preserve
 IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2
     SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '^(<|"(gtest|isl|json)/)'
     Priority:        3
     SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '.*'
     Priority:        1
     SortPriority:    0
+    CaseSensitive:   false
 IncludeIsMainRegex: '$'
 IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
 IndentCaseLabels: false
+IndentExternBlock: AfterExternBlock
 IndentGotoLabels: true
 IndentPPDirectives: None
+IndentRequiresClause: true
 IndentWidth:     2
 IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: true
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
+KeepEmptyLinesAtEOF: false
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
+NamespaceIndentation: Inner
 ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: true
 ObjCSpaceBeforeProtocolList: false
+PackConstructorInitializers: NextLine
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 30000
 PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Right
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
 ReflowComments:  true
-SortIncludes:    false
-SortUsingDeclarations: false
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    Never
+SortJavaStaticImport: Before
+SortUsingDeclarations: Never
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
 SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
 SpaceBeforeRangeBasedForLoopColon: true
-SpaceInEmptyBlock: false
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
-SpacesInConditionalStatement: false
-SpacesInContainerLiterals: true
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInParensOptions:
+  InCStyleCasts:   false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other:           false
+SpacesInSquareBrackets: false
 Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
 TabWidth:        8
-UseCRLF:         false
 UseTab:          Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
 ...
 

--- a/code/include/swoc/ArenaWriter.h
+++ b/code/include/swoc/ArenaWriter.h
@@ -10,54 +10,59 @@
 #include "swoc/bwf_base.h"
 #include "swoc/MemArena.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
-/** Buffer writer for a @c MemArena.
- *
- * This provides formatted output to the remnant of a @c MemArena. The output resides in uncommitted
- * arena memory and must be committed externally. This will resize the remnant as needed to contain
- * the output without overflow. Because it uses the remnant, if there is an error or resizing,
- * no arena memory will be lost.
- */
-class ArenaWriter : public FixedBufferWriter {
-  using self_type  = ArenaWriter;       ///< Self reference type.
-  using super_type = FixedBufferWriter; ///< Parent type.
-public:
-  /** Constructor.
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  /** Buffer writer for a @c MemArena.
    *
-   * @param arena Arena to use for storage.
+   * This provides formatted output to the remnant of a @c MemArena. The output resides in uncommitted
+   * arena memory and must be committed externally. This will resize the remnant as needed to contain
+   * the output without overflow. Because it uses the remnant, if there is an error or resizing,
+   * no arena memory will be lost.
    */
-  ArenaWriter(MemArena &arena);
+  class ArenaWriter : public FixedBufferWriter
+  {
+    using self_type  = ArenaWriter;       ///< Self reference type.
+    using super_type = FixedBufferWriter; ///< Parent type.
+  public:
+    /** Constructor.
+     *
+     * @param arena Arena to use for storage.
+     */
+    ArenaWriter(MemArena &arena);
 
-  /** Write data to the buffer.
-   *
-   * @param data Data to write.
-   * @param n Amount of data in bytes.
-   * @return @a this
-   */
-  ArenaWriter &write(void const *data, size_t n) override;
+    /** Write data to the buffer.
+     *
+     * @param data Data to write.
+     * @param n Amount of data in bytes.
+     * @return @a this
+     */
+    ArenaWriter &write(void const *data, size_t n) override;
 
-  /// Write a single character @a c to the buffer.
-  ArenaWriter &write(char c) override;
+    /// Write a single character @a c to the buffer.
+    ArenaWriter &write(char c) override;
 
-  using super_type::write; // import super class write.
+    using super_type::write; // import super class write.
 
-  /** Mark bytes as in use.
-   *
-   * @param n Number of bytes to include in the used buffer.
-   * @return @c true if successful, @c false if additional buffer space was required.
-   */
-  bool commit(size_t n) override;
+    /** Mark bytes as in use.
+     *
+     * @param n Number of bytes to include in the used buffer.
+     * @return @c true if successful, @c false if additional buffer space was required.
+     */
+    bool commit(size_t n) override;
 
-protected:
-  MemArena &_arena; ///< Arena for the buffer.
+  protected:
+    MemArena &_arena; ///< Arena for the buffer.
 
-  /** Reallocate the buffer to increase the capacity.
-   *
-   * @param n Total size required.
-   */
-  void realloc(size_t n);
-};
+    /** Reallocate the buffer to increase the capacity.
+     *
+     * @param n Total size required.
+     */
+    void realloc(size_t n);
+  };
 
-inline swoc::ArenaWriter::ArenaWriter(swoc::MemArena &arena) : super_type(arena.remnant()), _arena(arena) {}
+  inline swoc::ArenaWriter::ArenaWriter(swoc::MemArena &arena) : super_type(arena.remnant()), _arena(arena) {}
 
-}} // namespace swoc::SWOC_VERSION_NS
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/include/swoc/BufferWriter.h
+++ b/code/include/swoc/BufferWriter.h
@@ -20,639 +20,677 @@
 #include "swoc/MemSpan.h"
 #include "swoc/bwf_fwd.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
 
-/** Wrapper for operations on a buffer.
- *
- * This maintains information about the size and amount in use of the buffer, preventing data
- * overruns. In all cases, methods that write to the buffer clip the input to the size of the
- * remaining buffer space. The @c error method can be used to detect such clipping. The theoretical
- * size of the buffer is also tracked such that if there is not enough buffer space, the amount
- * needed can be determined by the method @c extent.
- *
- * @note This is a protocol class, concrete subclasses implement the functionality.
- */
-class BufferWriter {
-public:
-  /** Write @a c to the buffer.
+  /** Wrapper for operations on a buffer.
    *
-   * @param c Character to write.
-   * @return @a this.
+   * This maintains information about the size and amount in use of the buffer, preventing data
+   * overruns. In all cases, methods that write to the buffer clip the input to the size of the
+   * remaining buffer space. The @c error method can be used to detect such clipping. The theoretical
+   * size of the buffer is also tracked such that if there is not enough buffer space, the amount
+   * needed can be determined by the method @c extent.
+   *
+   * @note This is a protocol class, concrete subclasses implement the functionality.
    */
-  virtual BufferWriter &write(char c) = 0;
+  class BufferWriter
+  {
+  public:
+    /** Write @a c to the buffer.
+     *
+     * @param c Character to write.
+     * @return @a this.
+     */
+    virtual BufferWriter &write(char c) = 0;
 
-  /** Write @a length bytes starting at @a data to the buffer.
+    /** Write @a length bytes starting at @a data to the buffer.
+     *
+     * @param data Source data.
+     * @param length Number of bytes in the source data.
+     * @return @a this.
+     *
+     * @internal This uses the single character write to output the data. It is presumed concrete
+     * subclasses will override this method to use more efficient mechanisms, dependent on the type of
+     * output buffer.
+     */
+    virtual BufferWriter &write(void const *data, size_t length);
+
+    /** Write data to the buffer.
+     *
+     * @param span Data source.
+     * @return @a this
+     *
+     * Data from @a span is written directly to the buffer, and clipped to the size of the buffer.
+     *
+     * @internal The char poointer overloads protect this method in order to protect against including
+     * the terminal nul in the destination buffer.
+     */
+    BufferWriter &write(MemSpan<void const> span);
+
+    /// @return Pointer to first byte in buffer.
+    virtual const char *data() const = 0;
+
+    /// Get the error state.
+    /// @return @c true if in an error state, @c false if not.
+    virtual bool error() const = 0;
+
+    /** Address of the first unused byte in the output buffer.
+
+        The address is fragile and calls to non-const methods can invalidate it.
+
+        @return Address of the next output byte, or @c nullptr if there is no remaining capacity.
+     */
+    virtual char *aux_data();
+
+    /// @return The number of bytes that can be successfully written to this buffer.
+    virtual size_t capacity() const = 0;
+
+    /// @return Number of characters written to the buffer, including those discarded.
+    virtual size_t extent() const = 0;
+
+    /// @return Number of bytes of valid (used) data in the buffer.
+    size_t size() const;
+
+    /// @return The number of bytes which have not yet been written.
+    size_t remaining() const;
+
+    /** A memory span of the unused bytes.
+     *
+     * @return A span of the unused bytes.
+     *
+     * This is a convenience method that is identical to
+     * @code
+     *   BufferWriter w;
+     *   // ...
+     *   MemSpan<char>{ w.aux_data(), w.remaining() };
+     * @endcode
+     */
+    MemSpan<char> aux_span();
+
+    /** Increase the extent by @a n bytes.
+     *
+     * @param n Number of bytes.
+     * @return @c true if the commit is final, @c false if it should be retried.
+     *
+     * This is used to add data written in the @c aux_data to the written data in the buffer.
+     *
+     * The return value should be @c true unless the write operation proceeding the call to @c commit
+     * along with the @c commit call should be retried. That is only reasonable if some state in the
+     * concrete implementation has changed to make success possible on the next try. Generally this
+     * will be because the implementation increased capacity.
+     *
+     * @internal Concrete subclasses @b must override this in a way consistent with the specific buffer type.
+     */
+    virtual bool commit(size_t n) = 0;
+
+    /** Decrease the extent by @a n.
+     *
+     * @param n Number of bytes to remove from the extent.
+     * @return @a this.
+     *
+     * The buffer content is unchanged, only the extent value is adjusted. This effectively discards
+     * @a n bytes of already written data.
+     */
+    virtual BufferWriter &discard(size_t n) = 0;
+
+    /// Reduce the capacity by @a n bytes
+    /// If the capacity is reduced below the current @c size the instance goes in to an error state.
+    /// @see restore
+    /// @return @c *this
+    virtual BufferWriter &restrict(size_t n) = 0;
+
+    /// Restore @a n bytes of capacity.
+    /// If there is an error condition, this function clears it and sets the extent to the size.  It
+    /// then increases the capacity by n characters.
+    /// @note This does not make the internal buffer size larger. It can only restore capacity earlier
+    /// removed by @c restrict.
+    /// @see restrict
+    virtual BufferWriter &restore(size_t n) = 0;
+
+    /** Copy data from one part of the buffer to another.
+     *
+     * The copy is guaranteed to be correct even if the @a src and @a dst overlap. The regions are
+     * clipped by the current extent. That is, bytes cannot be copied to nor from unwritten buffer.
+     * If the extent is currently more than the capacity, the copy is performed as if the buffer
+     * existed and then clipped to the actual buffer space.
+     *
+     * @param dst Offset of the first by to copy onto.
+     * @param src Offset of the first byte to copy from.
+     * @param n Number of bytes to copy.
+     * @return @c *this
+     *
+     * @internal This is used to perform justification for formatting.
+     */
+    virtual BufferWriter &copy(size_t dst, size_t src, size_t n) = 0;
+
+    // Force virtual destructor.
+    virtual ~BufferWriter();
+
+    /** Formatted output to the buffer.
+     *
+     * @tparam Args Types of the format arguments.
+     * @param fmt Format string to control formatted output.
+     * @param args Parameters for the format string.
+     * @return @a this.
+     *
+     * The format string is Python style.
+     * See http://docs.solidwallofcode.com/libswoc/code/BW_Format.en.html for further information.
+     *
+     * @note This must be declared here, but the implementation is in @c bwf_base.h. That file does
+     * not need to be included if formatted output is not used.
+     */
+    template <typename... Args> BufferWriter &print(const TextView &fmt, Args &&...args);
+
+    /** Formatted output to the buffer.
+     *
+     * @tparam Args Types of the arguments for formatting.
+     * @param fmt Format string.
+     * @param args The format arguments in a tuple.
+     * @return @a this
+     *
+     * This is the equivalent of the "va..." form for printing. Alternate front ends to formatted
+     * output should gather their formatting arguments into a tuple, usually using
+     * @c std::forward_as_tuple().
+     */
+    template <typename... Args> BufferWriter &print_v(const TextView &fmt, const std::tuple<Args...> &args);
+
+    /** Formatted output to the buffer.
+     *
+     * @tparam Args Types of the format input parameters.
+     * @param fmt Pre-condensed format.
+     * @param args Arguments for the format string.
+     * @return @a this.
+     */
+    template <typename... Args> BufferWriter &print(const bwf::Format &fmt, Args &&...args);
+
+    /** Formatted output to the buffer.
+     *
+     * @tparam Args Types of the parameter for formatting.
+     * @param fmt Pre-condensed format string.
+     * @param args The format parameters in a tuple.
+     * @return @a this
+     *
+     * This is the equivalent of the "va..." form for printing. Alternate front ends to formatted
+     * output should gather their formatting arguments into a tuple, usually using
+     * @c std::forward_as_tuple().
+     */
+    template <typename... Args> BufferWriter &print_v(const bwf::Format &fmt, const std::tuple<Args...> &args);
+
+    /** Write formatted output of @a args to @a this buffer.
+     *
+     * @tparam Binding Type for the name binding instance.
+     * @tparam Extractor Format extractor type.
+     * @param names Name set for specifier names.
+     * @param ex Format processor instance, which parse the format piecewise.
+     * @param args The format parameters.
+     *
+     * @a Extractor must have at least two methods
+     * - A conversion to @c bool that indicates if there is data left.
+     * - A function of the signature <tt>bool ex(std::string_view& lit, bwf::Spec & spec)</tt>
+     *
+     * The latter must return whether a specifier was parsed, while filling in @a lit and @a spec
+     * as appropriate for the next chunk of format string. No literal is represented by a empty
+     * @a lit.
+     *
+     * The name binding must have a function operator that takes two arguments, a @c BufferWriter&
+     * and a format specifier @c bwf::Spec. It is expected to generate output to the @c BufferWriter
+     * instance based on data in the format specifier (which contains, among other things, the
+     * name which caused the binding to be invoked).
+     *
+     * @note This is the base implementation, all of the other variants are wrappers for this.
+     *
+     * @see NameBinding
+     */
+    template <typename Binding, typename Extractor>
+    BufferWriter &print_nfv(Binding &&names, Extractor &&ex, bwf::ArgPack const &args);
+
+    /** Write formatted output of @a args to @a this buffer.
+     *
+     * @tparam Binding Name binding functor.
+     * @tparam Extractor Format processor type.
+     * @param names Name set for specifier names.
+     * @param ex Format processor instance, which parse the format piecewise.
+     *
+     * @note This is primarily an internal convenience for certain situations where a format parameter
+     * tuple is not needed and difficult to create.
+     */
+    template <typename Binding, typename Extractor> BufferWriter &print_nfv(Binding const &names, Extractor &&ex);
+
+    /** Write formatted output to @a this buffer.
+     *
+     * @param names Name set for specifier names.
+     * @param fmt Format string.
+     *
+     * This is intended to be use with context name binding where @a names has the bindings and the
+     * format string @a fmt contains only references to those names, not to any arguments.
+     */
+    template <typename Binding> BufferWriter &print_n(Binding const &names, TextView const &fmt);
+
+    /** Write formattted data.
+     *
+     * @tparam T Data type.
+     * @param spec Format specifier.
+     * @param t Instance to print.
+     * @return @a this
+     *
+     * Essentially this forwards @a t to @c bwformat.
+     */
+    template <typename T> BufferWriter &format(bwf::Spec const &spec, T &&t);
+
+    /** Write formattted data.
+     *
+     * @tparam T Data type.
+     * @param spec Format specifier.
+     * @param t Instance to print.
+     * @return @a this
+     *
+     * Essentially this forwards @a t to @c bwformat.
+     */
+    template <typename T> BufferWriter &format(bwf::Spec const &spec, T const &t);
+
+    /** IO stream operator.
+     *
+     * @param stream Output stream.
+     * @return @a stream
+     *
+     * Write the buffer contents to @a stream.
+     */
+    virtual std::ostream &operator>>(std::ostream &stream) const = 0;
+  };
+
+  /** A concrete @c BufferWriter class for a fixed buffer.
    *
-   * @param data Source data.
-   * @param length Number of bytes in the source data.
-   * @return @a this.
-   *
-   * @internal This uses the single character write to output the data. It is presumed concrete
-   * subclasses will override this method to use more efficient mechanisms, dependent on the type of
-   * output buffer.
    */
-  virtual BufferWriter &write(void const *data, size_t length);
+  class FixedBufferWriter : public BufferWriter
+  {
+    using super_type = BufferWriter;
+    using self_type  = FixedBufferWriter;
 
-  /** Write data to the buffer.
+  public:
+    /** Construct a buffer writer on a fixed @a buffer of size @a capacity.
+
+        If writing goes past the end of the buffer, the excess is dropped.
+     */
+    FixedBufferWriter(char *buffer, size_t capacity);
+
+    /// Construct using the memory @a span as the buffer.
+    FixedBufferWriter(MemSpan<void> const &span);
+
+    /// Construct using the memory @a span as the buffer.
+    FixedBufferWriter(MemSpan<char> const &span);
+
+    /** Constructor an empty buffer with no capacity.
+     * This can be useful to measure the extent of the output before allocating memory.
+     */
+    FixedBufferWriter(std::nullptr_t);
+
+    FixedBufferWriter(const FixedBufferWriter &) = delete;
+
+    FixedBufferWriter &operator=(const FixedBufferWriter &) = delete;
+
+    /// Move constructor.
+    FixedBufferWriter(FixedBufferWriter &&that);
+
+    /// Move assignment.
+    FixedBufferWriter &operator=(FixedBufferWriter &&that);
+
+    /// Reset buffer.
+    self_type &assign(MemSpan<char> const &span);
+
+    /// Write a single character @a c to the buffer.
+    FixedBufferWriter &write(char c) override;
+
+    /// Write @a length bytes, starting at @a data, to the buffer.
+    FixedBufferWriter &write(const void *data, size_t length) override;
+
+    // Bring in non-overridden methods.
+    using super_type::write;
+
+    /// @return The start of the buffer.
+    const char *data() const override;
+
+    /// @return @c true if output has been discarded, @a false otherwise.
+    bool error() const override;
+
+    /// @return Start of the unused buffer, or @c nullptr is there is no remaining unwritten space.
+    char *aux_data() override;
+
+    /// Get the total capacity of the output buffer.
+    size_t capacity() const override;
+
+    /// Get the total output sent to the writer.
+    size_t extent() const override;
+
+    /// Advance the used part of the output buffer.
+    bool commit(size_t n) override;
+
+    /// Drop @a n characters from the end of the buffer.
+    self_type &discard(size_t n) override;
+
+    /// Reduce the capacity by @a n.
+    self_type &restrict(size_t n) override;
+
+    /// Restore @a n bytes of the capacity.
+    self_type &restore(size_t n) override;
+
+    /// Copy data in the buffer.
+    FixedBufferWriter &copy(size_t dst, size_t src, size_t n) override;
+
+    /// Erase the buffer, reset to empty (no valid data).
+    /// This is a convenience for reusing a buffer. For instance
+    /// @code
+    ///   bw.clear().print("....."); // clear old data and print new data.
+    /// @endcode
+    /// This is equivalent to @c w.discard(w.size()) but clearer for that case.
+    self_type &clear();
+
+    self_type &detach();
+
+    /// @return The used part of the buffer as a @c std::string_view.
+    swoc::TextView view() const;
+
+    /// Provide a @c string_view of all successfully written characters as a user conversion.
+    operator std::string_view() const;
+
+    /// Provide a @c string_view of all successfully written characters as a user conversion.
+    operator swoc::TextView() const;
+
+    /// Output the buffer contents to the @a stream.
+    std::ostream &operator>>(std::ostream &stream) const override;
+
+    /// @cond COVARY
+    template <typename... Rest> self_type &print(TextView fmt, Rest &&...rest);
+
+    template <typename... Args> self_type &print_v(TextView fmt, std::tuple<Args...> const &args);
+
+    template <typename... Args> self_type &print(bwf::Format const &fmt, Args &&...args);
+
+    template <typename... Args> self_type &print_v(bwf::Format const &fmt, std::tuple<Args...> const &args);
+    /// @endcond
+
+  protected:
+    char *const _buffer;   ///< Output buffer.
+    size_t _capacity;      ///< Size of output buffer.
+    size_t _attempted = 0; ///< Number of characters written, including those discarded due error condition.
+  };
+
+  /** A @c BufferWriter that has an internal buffer.
    *
-   * @param span Data source.
-   * @return @a this
+   * @tparam N Number of bytes in internal buffer.
    *
-   * Data from @a span is written directly to the buffer, and clipped to the size of the buffer.
+   * The buffer is part of the class instance and is therefore allocated from the same memory pool
+   * as the object. E.g, if this is declared as a local variable the buffer is on the stack.
    *
-   * @internal The char poointer overloads protect this method in order to protect against including
-   * the terminal nul in the destination buffer.
-   */
-  BufferWriter & write(MemSpan<void const> span);
-
-  /// @return Pointer to first byte in buffer.
-  virtual const char *data() const = 0;
-
-  /// Get the error state.
-  /// @return @c true if in an error state, @c false if not.
-  virtual bool error() const = 0;
-
-  /** Address of the first unused byte in the output buffer.
-
-      The address is fragile and calls to non-const methods can invalidate it.
-
-      @return Address of the next output byte, or @c nullptr if there is no remaining capacity.
-   */
-  virtual char *aux_data();
-
-  /// @return The number of bytes that can be successfully written to this buffer.
-  virtual size_t capacity() const = 0;
-
-  /// @return Number of characters written to the buffer, including those discarded.
-  virtual size_t extent() const = 0;
-
-  /// @return Number of bytes of valid (used) data in the buffer.
-  size_t size() const;
-
-  /// @return The number of bytes which have not yet been written.
-  size_t remaining() const;
-
-  /** A memory span of the unused bytes.
-   *
-   * @return A span of the unused bytes.
-   *
-   * This is a convenience method that is identical to
+   * This was written to make code such as
    * @code
-   *   BufferWriter w;
-   *   // ...
-   *   MemSpan<char>{ w.aux_data(), w.remaining() };
+   * char buff[1024];
+   * FixedBufferWriter w(buff, sizeof(buff));
+   * @endcode
+   * simpler as
+   * @code
+   * LocalBufferWriter<1024> w;
+   * @endcode
+   *
+   * This also makes it possible to use inside expressions and other stream operations without concern
+   * about having to previously declare the storage. E.g.
+   * @code
+   * create_note(LocalBufferWriter<256>().print("Note {}", idx).view());
    * @endcode
    */
-  MemSpan<char> aux_span();
+  template <size_t N> class LocalBufferWriter : public FixedBufferWriter
+  {
+    using self_type  = LocalBufferWriter;
+    using super_type = FixedBufferWriter;
 
-  /** Increase the extent by @a n bytes.
-   *
-   * @param n Number of bytes.
-   * @return @c true if the commit is final, @c false if it should be retried.
-   *
-   * This is used to add data written in the @c aux_data to the written data in the buffer.
-   *
-   * The return value should be @c true unless the write operation proceeding the call to @c commit
-   * along with the @c commit call should be retried. That is only reasonable if some state in the
-   * concrete implementation has changed to make success possible on the next try. Generally this
-   * will be because the implementation increased capacity.
-   *
-   * @internal Concrete subclasses @b must override this in a way consistent with the specific buffer type.
-   */
-  virtual bool commit(size_t n) = 0;
+  public:
+    /// Construct an empty writer.
+    LocalBufferWriter();
 
-  /** Decrease the extent by @a n.
-   *
-   * @param n Number of bytes to remove from the extent.
-   * @return @a this.
-   *
-   * The buffer content is unchanged, only the extent value is adjusted. This effectively discards
-   * @a n bytes of already written data.
-   */
-  virtual BufferWriter &discard(size_t n) = 0;
+    LocalBufferWriter(const LocalBufferWriter &that) = delete;
 
-  /// Reduce the capacity by @a n bytes
-  /// If the capacity is reduced below the current @c size the instance goes in to an error state.
-  /// @see restore
-  /// @return @c *this
-  virtual BufferWriter &restrict(size_t n) = 0;
+    LocalBufferWriter &operator=(const LocalBufferWriter &that) = delete;
 
-  /// Restore @a n bytes of capacity.
-  /// If there is an error condition, this function clears it and sets the extent to the size.  It
-  /// then increases the capacity by n characters.
-  /// @note This does not make the internal buffer size larger. It can only restore capacity earlier
-  /// removed by @c restrict.
-  /// @see restrict
-  virtual BufferWriter &restore(size_t n) = 0;
+  protected:
+    char _arr[N]; ///< output buffer.
+  };
 
-  /** Copy data from one part of the buffer to another.
-   *
-   * The copy is guaranteed to be correct even if the @a src and @a dst overlap. The regions are
-   * clipped by the current extent. That is, bytes cannot be copied to nor from unwritten buffer.
-   * If the extent is currently more than the capacity, the copy is performed as if the buffer
-   * existed and then clipped to the actual buffer space.
-   *
-   * @param dst Offset of the first by to copy onto.
-   * @param src Offset of the first byte to copy from.
-   * @param n Number of bytes to copy.
-   * @return @c *this
-   *
-   * @internal This is used to perform justification for formatting.
-   */
-  virtual BufferWriter &copy(size_t dst, size_t src, size_t n) = 0;
+  // --------------- Implementation --------------------
 
-  // Force virtual destructor.
-  virtual ~BufferWriter();
+  inline BufferWriter::~BufferWriter() {}
 
-  /** Formatted output to the buffer.
-   *
-   * @tparam Args Types of the format arguments.
-   * @param fmt Format string to control formatted output.
-   * @param args Parameters for the format string.
-   * @return @a this.
-   *
-   * The format string is Python style.
-   * See http://docs.solidwallofcode.com/libswoc/code/BW_Format.en.html for further information.
-   *
-   * @note This must be declared here, but the implementation is in @c bwf_base.h. That file does
-   * not need to be included if formatted output is not used.
-   */
-  template <typename... Args> BufferWriter &print(const TextView &fmt, Args &&... args);
+  inline BufferWriter &
+  BufferWriter::write(const void *data, size_t length)
+  {
+    const char *d = static_cast<const char *>(data);
 
-  /** Formatted output to the buffer.
-   *
-   * @tparam Args Types of the arguments for formatting.
-   * @param fmt Format string.
-   * @param args The format arguments in a tuple.
-   * @return @a this
-   *
-   * This is the equivalent of the "va..." form for printing. Alternate front ends to formatted
-   * output should gather their formatting arguments into a tuple, usually using
-   * @c std::forward_as_tuple().
-   */
-  template <typename... Args> BufferWriter &print_v(const TextView &fmt, const std::tuple<Args...> &args);
-
-  /** Formatted output to the buffer.
-   *
-   * @tparam Args Types of the format input parameters.
-   * @param fmt Pre-condensed format.
-   * @param args Arguments for the format string.
-   * @return @a this.
-   */
-  template <typename... Args> BufferWriter &print(const bwf::Format &fmt, Args &&... args);
-
-  /** Formatted output to the buffer.
-   *
-   * @tparam Args Types of the parameter for formatting.
-   * @param fmt Pre-condensed format string.
-   * @param args The format parameters in a tuple.
-   * @return @a this
-   *
-   * This is the equivalent of the "va..." form for printing. Alternate front ends to formatted
-   * output should gather their formatting arguments into a tuple, usually using
-   * @c std::forward_as_tuple().
-   */
-  template <typename... Args> BufferWriter &print_v(const bwf::Format &fmt, const std::tuple<Args...> &args);
-
-  /** Write formatted output of @a args to @a this buffer.
-   *
-   * @tparam Binding Type for the name binding instance.
-   * @tparam Extractor Format extractor type.
-   * @param names Name set for specifier names.
-   * @param ex Format processor instance, which parse the format piecewise.
-   * @param args The format parameters.
-   *
-   * @a Extractor must have at least two methods
-   * - A conversion to @c bool that indicates if there is data left.
-   * - A function of the signature <tt>bool ex(std::string_view& lit, bwf::Spec & spec)</tt>
-   *
-   * The latter must return whether a specifier was parsed, while filling in @a lit and @a spec
-   * as appropriate for the next chunk of format string. No literal is represented by a empty
-   * @a lit.
-   *
-   * The name binding must have a function operator that takes two arguments, a @c BufferWriter&
-   * and a format specifier @c bwf::Spec. It is expected to generate output to the @c BufferWriter
-   * instance based on data in the format specifier (which contains, among other things, the
-   * name which caused the binding to be invoked).
-   *
-   * @note This is the base implementation, all of the other variants are wrappers for this.
-   *
-   * @see NameBinding
-   */
-  template <typename Binding, typename Extractor>
-  BufferWriter &print_nfv(Binding &&names, Extractor &&ex, bwf::ArgPack const &args);
-
-  /** Write formatted output of @a args to @a this buffer.
-   *
-   * @tparam Binding Name binding functor.
-   * @tparam Extractor Format processor type.
-   * @param names Name set for specifier names.
-   * @param ex Format processor instance, which parse the format piecewise.
-   *
-   * @note This is primarily an internal convenience for certain situations where a format parameter
-   * tuple is not needed and difficult to create.
-   */
-  template <typename Binding, typename Extractor> BufferWriter &print_nfv(Binding const &names, Extractor &&ex);
-
-  /** Write formatted output to @a this buffer.
-   *
-   * @param names Name set for specifier names.
-   * @param fmt Format string.
-   *
-   * This is intended to be use with context name binding where @a names has the bindings and the
-   * format string @a fmt contains only references to those names, not to any arguments.
-   */
-  template <typename Binding> BufferWriter &print_n(Binding const &names, TextView const &fmt);
-
-  /** Write formattted data.
-   *
-   * @tparam T Data type.
-   * @param spec Format specifier.
-   * @param t Instance to print.
-   * @return @a this
-   *
-   * Essentially this forwards @a t to @c bwformat.
-   */
-  template <typename T> BufferWriter & format(bwf::Spec const& spec, T && t);
-
-  /** Write formattted data.
-   *
-   * @tparam T Data type.
-   * @param spec Format specifier.
-   * @param t Instance to print.
-   * @return @a this
-   *
-   * Essentially this forwards @a t to @c bwformat.
-   */
-  template <typename T> BufferWriter & format(bwf::Spec const& spec, T const& t);
-
-  /** IO stream operator.
-   *
-   * @param stream Output stream.
-   * @return @a stream
-   *
-   * Write the buffer contents to @a stream.
-   */
-  virtual std::ostream &operator>>(std::ostream &stream) const = 0;
-};
-
-/** A concrete @c BufferWriter class for a fixed buffer.
- *
- */
-class FixedBufferWriter : public BufferWriter {
-  using super_type = BufferWriter;
-  using self_type  = FixedBufferWriter;
-
-public:
-  /** Construct a buffer writer on a fixed @a buffer of size @a capacity.
-
-      If writing goes past the end of the buffer, the excess is dropped.
-   */
-  FixedBufferWriter(char *buffer, size_t capacity);
-
-  /// Construct using the memory @a span as the buffer.
-  FixedBufferWriter(MemSpan<void> const &span);
-
-  /// Construct using the memory @a span as the buffer.
-  FixedBufferWriter(MemSpan<char> const &span);
-
-  /** Constructor an empty buffer with no capacity.
-   * This can be useful to measure the extent of the output before allocating memory.
-   */
-  FixedBufferWriter(std::nullptr_t);
-
-  FixedBufferWriter(const FixedBufferWriter &) = delete;
-
-  FixedBufferWriter &operator=(const FixedBufferWriter &) = delete;
-
-  /// Move constructor.
-  FixedBufferWriter(FixedBufferWriter &&that);
-
-  /// Move assignment.
-  FixedBufferWriter &operator=(FixedBufferWriter &&that);
-
-  /// Reset buffer.
-  self_type &assign(MemSpan<char> const &span);
-
-  /// Write a single character @a c to the buffer.
-  FixedBufferWriter &write(char c) override;
-
-  /// Write @a length bytes, starting at @a data, to the buffer.
-  FixedBufferWriter &write(const void *data, size_t length) override;
-
-  // Bring in non-overridden methods.
-  using super_type::write;
-
-  /// @return The start of the buffer.
-  const char *data() const override;
-
-  /// @return @c true if output has been discarded, @a false otherwise.
-  bool error() const override;
-
-  /// @return Start of the unused buffer, or @c nullptr is there is no remaining unwritten space.
-  char *aux_data() override;
-
-  /// Get the total capacity of the output buffer.
-  size_t capacity() const override;
-
-  /// Get the total output sent to the writer.
-  size_t extent() const override;
-
-  /// Advance the used part of the output buffer.
-  bool commit(size_t n) override;
-
-  /// Drop @a n characters from the end of the buffer.
-  self_type &discard(size_t n) override;
-
-  /// Reduce the capacity by @a n.
-  self_type &restrict(size_t n) override;
-
-  /// Restore @a n bytes of the capacity.
-  self_type &restore(size_t n) override;
-
-  /// Copy data in the buffer.
-  FixedBufferWriter &copy(size_t dst, size_t src, size_t n) override;
-
-  /// Erase the buffer, reset to empty (no valid data).
-  /// This is a convenience for reusing a buffer. For instance
-  /// @code
-  ///   bw.clear().print("....."); // clear old data and print new data.
-  /// @endcode
-  /// This is equivalent to @c w.discard(w.size()) but clearer for that case.
-  self_type &clear();
-
-  self_type &detach();
-
-  /// @return The used part of the buffer as a @c std::string_view.
-  swoc::TextView view() const;
-
-  /// Provide a @c string_view of all successfully written characters as a user conversion.
-  operator std::string_view() const;
-
-  /// Provide a @c string_view of all successfully written characters as a user conversion.
-  operator swoc::TextView() const;
-
-  /// Output the buffer contents to the @a stream.
-  std::ostream &operator>>(std::ostream &stream) const override;
-
-  /// @cond COVARY
-  template <typename... Rest> self_type &print(TextView fmt, Rest &&... rest);
-
-  template <typename... Args> self_type &print_v(TextView fmt, std::tuple<Args...> const &args);
-
-  template <typename... Args> self_type &print(bwf::Format const &fmt, Args &&... args);
-
-  template <typename... Args> self_type &print_v(bwf::Format const &fmt, std::tuple<Args...> const &args);
-  /// @endcond
-
-protected:
-  char *const _buffer;   ///< Output buffer.
-  size_t _capacity;      ///< Size of output buffer.
-  size_t _attempted = 0; ///< Number of characters written, including those discarded due error condition.
-};
-
-/** A @c BufferWriter that has an internal buffer.
- *
- * @tparam N Number of bytes in internal buffer.
- *
- * The buffer is part of the class instance and is therefore allocated from the same memory pool
- * as the object. E.g, if this is declared as a local variable the buffer is on the stack.
- *
- * This was written to make code such as
- * @code
- * char buff[1024];
- * FixedBufferWriter w(buff, sizeof(buff));
- * @endcode
- * simpler as
- * @code
- * LocalBufferWriter<1024> w;
- * @endcode
- *
- * This also makes it possible to use inside expressions and other stream operations without concern
- * about having to previously declare the storage. E.g.
- * @code
- * create_note(LocalBufferWriter<256>().print("Note {}", idx).view());
- * @endcode
- */
-template <size_t N> class LocalBufferWriter : public FixedBufferWriter {
-  using self_type  = LocalBufferWriter;
-  using super_type = FixedBufferWriter;
-
-public:
-  /// Construct an empty writer.
-  LocalBufferWriter();
-
-  LocalBufferWriter(const LocalBufferWriter &that) = delete;
-
-  LocalBufferWriter &operator=(const LocalBufferWriter &that) = delete;
-
-protected:
-  char _arr[N]; ///< output buffer.
-};
-
-// --------------- Implementation --------------------
-
-inline BufferWriter::~BufferWriter() {}
-
-inline BufferWriter &
-BufferWriter::write(const void *data, size_t length) {
-  const char *d = static_cast<const char *>(data);
-
-  while (length--) {
-    this->write(*(d++));
+    while (length--) {
+      this->write(*(d++));
+    }
+    return *this;
   }
-  return *this;
-}
 
-# if 0
+#if 0
 inline BufferWriter &
 BufferWriter::write(const std::string_view &sv) {
   return this->write(sv.data(), sv.size());
 }
-# endif
+#endif
 
-inline BufferWriter &
-BufferWriter::write(MemSpan<void const> span) { return this->write(span.data(), span.size()); }
-
-inline char *
-BufferWriter::aux_data() {
-  return nullptr;
-}
-
-inline size_t
-BufferWriter::size() const {
-  return std::min(this->extent(), this->capacity());
-}
-
-inline size_t
-BufferWriter::remaining() const {
-  return this->capacity() - this->size();
-}
-
-// --- FixedBufferWriter ---
-inline FixedBufferWriter::FixedBufferWriter(char *buffer, size_t capacity) : _buffer(buffer), _capacity(capacity) {
-  if (_capacity != 0 && buffer == nullptr) {
-    throw(std::invalid_argument{"FixedBufferWriter created with null buffer and non-zero size."});
-  };
-}
-
-inline FixedBufferWriter::FixedBufferWriter(MemSpan<void> const &span)
-  : _buffer{static_cast<char *>(span.data())}, _capacity{span.size()} {}
-
-inline FixedBufferWriter::FixedBufferWriter(MemSpan<char> const &span) : _buffer{span.begin()}, _capacity{span.size()} {}
-
-inline FixedBufferWriter::FixedBufferWriter(std::nullptr_t) : _buffer(nullptr), _capacity(0) {}
-
-inline FixedBufferWriter::self_type &
-FixedBufferWriter::detach() {
-  const_cast<char *&>(_buffer) = nullptr;
-  _capacity                    = 0;
-  _attempted                   = 0;
-  return *this;
-}
-
-inline FixedBufferWriter::FixedBufferWriter(FixedBufferWriter &&that)
-  : _buffer(that._buffer), _capacity(that._capacity), _attempted(that._attempted) {
-  that.detach();
-}
-
-inline FixedBufferWriter::self_type &
-FixedBufferWriter::assign(MemSpan<char> const &span) {
-  const_cast<char *&>(_buffer) = span.data();
-  _capacity                    = span.size();
-  _attempted                   = 0;
-  return *this;
-}
-
-inline FixedBufferWriter &
-FixedBufferWriter::operator=(FixedBufferWriter &&that) {
-  const_cast<char *&>(_buffer) = that._buffer;
-  _capacity                    = that._capacity;
-  _attempted                   = that._attempted;
-  that.detach();
-  return *this;
-}
-
-inline FixedBufferWriter &
-FixedBufferWriter::write(char c) {
-  if (_attempted < _capacity) {
-    _buffer[_attempted] = c;
+  inline BufferWriter &
+  BufferWriter::write(MemSpan<void const> span)
+  {
+    return this->write(span.data(), span.size());
   }
-  ++_attempted;
 
-  return *this;
-}
+  inline char *
+  BufferWriter::aux_data()
+  {
+    return nullptr;
+  }
 
-inline FixedBufferWriter &
-FixedBufferWriter::write(const void *data, size_t length) {
-  const size_t newSize = _attempted + length;
+  inline size_t
+  BufferWriter::size() const
+  {
+    return std::min(this->extent(), this->capacity());
+  }
 
-  if (_buffer) {
-    if (newSize <= _capacity) {
-      std::memcpy(_buffer + _attempted, data, length);
-    } else if (_attempted < _capacity) {
-      std::memcpy(_buffer + _attempted, data, _capacity - _attempted);
+  inline size_t
+  BufferWriter::remaining() const
+  {
+    return this->capacity() - this->size();
+  }
+
+  // --- FixedBufferWriter ---
+  inline FixedBufferWriter::FixedBufferWriter(char *buffer, size_t capacity) : _buffer(buffer), _capacity(capacity)
+  {
+    if (_capacity != 0 && buffer == nullptr) {
+      throw(std::invalid_argument{"FixedBufferWriter created with null buffer and non-zero size."});
+    };
+  }
+
+  inline FixedBufferWriter::FixedBufferWriter(MemSpan<void> const &span)
+    : _buffer{static_cast<char *>(span.data())}, _capacity{span.size()}
+  {
+  }
+
+  inline FixedBufferWriter::FixedBufferWriter(MemSpan<char> const &span) : _buffer{span.begin()}, _capacity{span.size()} {}
+
+  inline FixedBufferWriter::FixedBufferWriter(std::nullptr_t) : _buffer(nullptr), _capacity(0) {}
+
+  inline FixedBufferWriter::self_type &
+  FixedBufferWriter::detach()
+  {
+    const_cast<char *&>(_buffer) = nullptr;
+    _capacity                    = 0;
+    _attempted                   = 0;
+    return *this;
+  }
+
+  inline FixedBufferWriter::FixedBufferWriter(FixedBufferWriter &&that)
+    : _buffer(that._buffer), _capacity(that._capacity), _attempted(that._attempted)
+  {
+    that.detach();
+  }
+
+  inline FixedBufferWriter::self_type &
+  FixedBufferWriter::assign(MemSpan<char> const &span)
+  {
+    const_cast<char *&>(_buffer) = span.data();
+    _capacity                    = span.size();
+    _attempted                   = 0;
+    return *this;
+  }
+
+  inline FixedBufferWriter &
+  FixedBufferWriter::operator=(FixedBufferWriter &&that)
+  {
+    const_cast<char *&>(_buffer) = that._buffer;
+    _capacity                    = that._capacity;
+    _attempted                   = that._attempted;
+    that.detach();
+    return *this;
+  }
+
+  inline FixedBufferWriter &
+  FixedBufferWriter::write(char c)
+  {
+    if (_attempted < _capacity) {
+      _buffer[_attempted] = c;
     }
+    ++_attempted;
+
+    return *this;
   }
-  _attempted = newSize;
 
-  return *this;
-}
+  inline FixedBufferWriter &
+  FixedBufferWriter::write(const void *data, size_t length)
+  {
+    const size_t newSize = _attempted + length;
 
-/// Return the output buffer.
-inline const char *
-FixedBufferWriter::data() const {
-  return _buffer;
-}
+    if (_buffer) {
+      if (newSize <= _capacity) {
+        std::memcpy(_buffer + _attempted, data, length);
+      } else if (_attempted < _capacity) {
+        std::memcpy(_buffer + _attempted, data, _capacity - _attempted);
+      }
+    }
+    _attempted = newSize;
 
-inline bool
-FixedBufferWriter::error() const {
-  return _attempted > _capacity;
-}
-
-inline char *
-FixedBufferWriter::aux_data() {
-  return error() ? nullptr : _buffer + _attempted;
-}
-
-inline bool
-FixedBufferWriter::commit(size_t n) {
-  _attempted += n;
-
-  return true;
-}
-
-inline size_t
-FixedBufferWriter::capacity() const {
-  return _capacity;
-}
-
-inline size_t
-FixedBufferWriter::extent() const {
-  return _attempted;
-}
-
-inline auto
-FixedBufferWriter::restrict(size_t n) -> self_type & {
-  if (n > _capacity) {
-    throw(std::invalid_argument{"FixedBufferWriter restrict value more than capacity"});
+    return *this;
   }
-  _capacity -= n;
-  return *this;
-}
 
-inline auto
-FixedBufferWriter::restore(size_t n) -> self_type & {
-  if (error()) {
-    _attempted = _capacity;
+  /// Return the output buffer.
+  inline const char *
+  FixedBufferWriter::data() const
+  {
+    return _buffer;
   }
-  _capacity += n;
-  return *this;
-}
 
-inline auto
-FixedBufferWriter::discard(size_t n) -> self_type & {
-  _attempted -= std::min(_attempted, n);
-  return *this;
-}
+  inline bool
+  FixedBufferWriter::error() const
+  {
+    return _attempted > _capacity;
+  }
 
-inline auto
-FixedBufferWriter::clear() -> self_type & {
-  _attempted = 0;
-  return *this;
-}
+  inline char *
+  FixedBufferWriter::aux_data()
+  {
+    return error() ? nullptr : _buffer + _attempted;
+  }
 
-inline auto
-FixedBufferWriter::copy(size_t dst, size_t src, size_t n) -> self_type & {
-  auto limit = std::min<size_t>(_capacity, _attempted); // max offset of region possible.
-  MemSpan<char> src_span{_buffer + src, std::min(limit, src + n)};
-  MemSpan<char> dst_span{_buffer + dst, std::min(limit, dst + n)};
-  std::memmove(dst_span.data(), src_span.data(), std::min(dst_span.size(), src_span.size()));
-  return *this;
-}
+  inline bool
+  FixedBufferWriter::commit(size_t n)
+  {
+    _attempted += n;
 
-inline swoc::TextView
-FixedBufferWriter::view() const {
-  return {_buffer, size()};
-}
+    return true;
+  }
 
-inline FixedBufferWriter::operator std::string_view() const {
-  return this->view();
-}
+  inline size_t
+  FixedBufferWriter::capacity() const
+  {
+    return _capacity;
+  }
 
-inline FixedBufferWriter::operator swoc::TextView() const {
-  return this->view();
-}
+  inline size_t
+  FixedBufferWriter::extent() const
+  {
+    return _attempted;
+  }
 
-// --- LocalBufferWriter ---
-template <size_t N> LocalBufferWriter<N>::LocalBufferWriter() : super_type(_arr, N) {}
+  inline auto FixedBufferWriter::restrict(size_t n) -> self_type &
+  {
+    if (n > _capacity) {
+      throw(std::invalid_argument{"FixedBufferWriter restrict value more than capacity"});
+    }
+    _capacity -= n;
+    return *this;
+  }
 
-}} // namespace swoc::SWOC_VERSION_NS
+  inline auto
+  FixedBufferWriter::restore(size_t n) -> self_type &
+  {
+    if (error()) {
+      _attempted = _capacity;
+    }
+    _capacity += n;
+    return *this;
+  }
+
+  inline auto
+  FixedBufferWriter::discard(size_t n) -> self_type &
+  {
+    _attempted -= std::min(_attempted, n);
+    return *this;
+  }
+
+  inline auto
+  FixedBufferWriter::clear() -> self_type &
+  {
+    _attempted = 0;
+    return *this;
+  }
+
+  inline auto
+  FixedBufferWriter::copy(size_t dst, size_t src, size_t n) -> self_type &
+  {
+    auto limit = std::min<size_t>(_capacity, _attempted); // max offset of region possible.
+    MemSpan<char> src_span{_buffer + src, std::min(limit, src + n)};
+    MemSpan<char> dst_span{_buffer + dst, std::min(limit, dst + n)};
+    std::memmove(dst_span.data(), src_span.data(), std::min(dst_span.size(), src_span.size()));
+    return *this;
+  }
+
+  inline swoc::TextView
+  FixedBufferWriter::view() const
+  {
+    return {_buffer, size()};
+  }
+
+  inline FixedBufferWriter::operator std::string_view() const
+  {
+    return this->view();
+  }
+
+  inline FixedBufferWriter::operator swoc::TextView() const
+  {
+    return this->view();
+  }
+
+  // --- LocalBufferWriter ---
+  template <size_t N> LocalBufferWriter<N>::LocalBufferWriter() : super_type(_arr, N) {}
+
+} // namespace SWOC_VERSION_NS
+} // namespace swoc
 
 /// @cond NOT_DOCUMENTED
-namespace std {
+namespace std
+{
 inline ostream &
-operator<<(ostream &s, swoc::BufferWriter const &w) {
+operator<<(ostream &s, swoc::BufferWriter const &w)
+{
   return w >> s;
 }
 } // end namespace std

--- a/code/include/swoc/DiscreteRange.h
+++ b/code/include/swoc/DiscreteRange.h
@@ -16,1735 +16,1840 @@
 #include "swoc/RBTree.h"
 #include "swoc/MemArena.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
-namespace detail {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  namespace detail
+  {
 
-/// A set of metafunctions to get extrema from a metric type.
-/// These probe for a static member and falls back to @c std::numeric_limits.
-/// @{
+    /// A set of metafunctions to get extrema from a metric type.
+    /// These probe for a static member and falls back to @c std::numeric_limits.
+    /// @{
 
-/** Maximum value.
- *
- * @tparam M Metric type.
- * @return Maximum value for @a M.
- *
- * Use @c std::numeric_limits.
- */
-template <typename M>
-constexpr auto
-maximum(meta::CaseTag<0>) -> M {
-  return std::numeric_limits<M>::max();
-}
+    /** Maximum value.
+     *
+     * @tparam M Metric type.
+     * @return Maximum value for @a M.
+     *
+     * Use @c std::numeric_limits.
+     */
+    template <typename M>
+    constexpr auto
+    maximum(meta::CaseTag<0>) -> M
+    {
+      return std::numeric_limits<M>::max();
+    }
 
-/** Maximum value.
- *
- * @tparam M Metric type.
- * @return Maximum value for @a M.
- *
- * Use @c M::MAX
- */
-template <typename M>
-constexpr auto
-maximum(meta::CaseTag<1>) -> decltype(M::MAX) {
-  return M::MAX;
-}
+    /** Maximum value.
+     *
+     * @tparam M Metric type.
+     * @return Maximum value for @a M.
+     *
+     * Use @c M::MAX
+     */
+    template <typename M>
+    constexpr auto
+    maximum(meta::CaseTag<1>) -> decltype(M::MAX)
+    {
+      return M::MAX;
+    }
 
-/** Maximum value.
- *
- * @tparam M Metric type.
- * @return Maximum value for @a M.
- */
-template <typename M>
-constexpr M
-maximum() {
-  return maximum<M>(meta::CaseArg);
-}
+    /** Maximum value.
+     *
+     * @tparam M Metric type.
+     * @return Maximum value for @a M.
+     */
+    template <typename M>
+    constexpr M
+    maximum()
+    {
+      return maximum<M>(meta::CaseArg);
+    }
 
-/** Minimum value.
- *
- * @tparam M Metric type.
- * @return Minimum value for @a M
- *
- * Use @c std::numeric_limits
- */
-template <typename M>
-constexpr auto
-minimum(meta::CaseTag<0>) -> M {
-  return std::numeric_limits<M>::min();
-}
+    /** Minimum value.
+     *
+     * @tparam M Metric type.
+     * @return Minimum value for @a M
+     *
+     * Use @c std::numeric_limits
+     */
+    template <typename M>
+    constexpr auto
+    minimum(meta::CaseTag<0>) -> M
+    {
+      return std::numeric_limits<M>::min();
+    }
 
-/** Minimum value.
- *
- * @tparam M Metric type.
- * @return Minimum value for @a M
- *
- * Use @c M::MIN
- */
-template <typename M>
-constexpr auto
-minimum(meta::CaseTag<1>) -> decltype(M::MIN) {
-  return M::MIN;
-}
+    /** Minimum value.
+     *
+     * @tparam M Metric type.
+     * @return Minimum value for @a M
+     *
+     * Use @c M::MIN
+     */
+    template <typename M>
+    constexpr auto
+    minimum(meta::CaseTag<1>) -> decltype(M::MIN)
+    {
+      return M::MIN;
+    }
 
-/** Minimum value.
- *
- * @tparam M Metric type.
- * @return Minimum value for @a M
- */
-template <typename M>
-constexpr M
-minimum() {
-  return minimum<M>(meta::CaseArg);
-}
-/// @}
-} // namespace detail
+    /** Minimum value.
+     *
+     * @tparam M Metric type.
+     * @return Minimum value for @a M
+     */
+    template <typename M>
+    constexpr M
+    minimum()
+    {
+      return minimum<M>(meta::CaseArg);
+    }
+    /// @}
+  } // namespace detail
 
-/// Relationship between two intervals.
-enum class DiscreteRangeRelation : uint8_t {
-  NONE,     ///< No common elements.
-  EQUAL,    ///< Identical ranges.
-  SUBSET,   ///< All elements in LHS are also in RHS.
-  SUPERSET, ///< Every element in RHS is in LHS.
-  OVERLAP,  ///< There exists at least one element in both LHS and RHS.
-  ADJACENT  ///< The two intervals are adjacent and disjoint.
-};
-
-/// Relationship between one edge of an interval and the "opposite" edge of another.
-enum class DiscreteRangeEdgeRelation : uint8_t {
-  NONE, ///< Edge is on the opposite side of the relating edge.
-  GAP,  ///< There is a gap between the edges.
-  ADJ,  ///< The edges are adjacent.
-  OVLP, ///< Edge is inside interval.
-};
-
-/** A range over a discrete finite value metric.
-   @tparam T The type for the range values.
-
-   The template argument @a T is presumed to
-   - be completely ordered.
-   - have prefix increment and decrement operators
-   - equality operator
-   - have value semantics
-   - have minimum and maximum values either
-     - members @c MIN and @c MAX that define static instances
-     - @c std::numeric_limits<T> support.
-
-   The interval is always an inclusive (closed) contiguous interval,
-   defined by the minimum and maximum values contained in the interval.
-   An interval can be @em empty and contain no values. This is the state
-   of a default constructed interval.
- */
-template <typename T> class DiscreteRange {
-  using self_type = DiscreteRange;
-
-protected:
-  T _min; ///< The minimum value in the interval
-  T _max; ///< the maximum value in the interval
-
-public:
-  using metric_type  = T;                         ///< Export metric type.
-  using Relation     = DiscreteRangeRelation;     ///< Import type for convenience.
-  using EdgeRelation = DiscreteRangeEdgeRelation; ///< Import type for convenience.
-
-  /** Default constructor.
-   * An invalid (empty) range is constructed.
-   */
-  constexpr DiscreteRange() : _min(detail::maximum<T>()), _max(detail::minimum<T>()) {}
-
-  /** Construct a singleton range.
-   * @param value Single value to be contained by the interval.
-   *
-   * @note Not marked @c explicit and so serves as a conversion from scalar values to an interval.
-   */
-  constexpr DiscreteRange(T const &value) : _min(value), _max(value){};
-
-  /** Constructor.
-   *
-   * @param min Minimum value in the interval.
-   * @param max Maximum value in the interval.
-   */
-  constexpr DiscreteRange(T const &min, T const &max) : _min(min), _max(max) {}
-
-  ~DiscreteRange() = default;
-
-  /** Check if there are no values in the range.
-   *
-   * @return @c true if the range is empty (contains no values), @c false if it contains at least
-   * one value.
-   */
-  bool empty() const;
-
-  /** Update the range.
-   *
-   * @param min New minimum value.
-   * @param max New maximum value.
-   * @return @a this.
-   */
-  self_type &assign(metric_type const &min, metric_type const &max);
-
-  /** Update the range.
-   *
-   * @param value The new minimum and maximum value.
-   * @return @a this.
-   *
-   * The range will contain the single value @a value.
-   */
-  self_type &assign(metric_type const &value);
-
-  /** Update the minimum value.
-   *
-   * @param min The new minimum value.
-   * @return @a this.
-   *
-   * @note No checks are done - this can result in an empty range.
-   */
-  self_type &assign_min(metric_type const &min);
-
-  /** Update the maximum value.
-   *
-   * @param max The new maximum value.
-   * @return @a this.
-   *
-   * @note No checks are done - this can result in an empty range.
-   */
-  self_type &assign_max(metric_type const &max);
-
-  /** Decrement the maximum value.
-   *
-   * @return @a this.
-   *
-   * @note No checks are done, the caller must ensure it is valid to decremented the current maximum.
-   */
-  self_type & clip_max();
-
-  /** Minimum value.
-   * @return the minimum value in the range.
-   * @note The return value is unspecified if the interval is empty.
-   */
-  metric_type const &min() const;
-
-  /** Maximum value.
-   * @return The maximum value in the range.
-   * @note The return value is unspecified if the interval is empty.
-   */
-  metric_type const &max() const;
-
-  /// Equality.
-  bool operator==(self_type const &that) const;
-
-  /// Inequality.
-  bool operator!=(self_type const &that) const;
-
-  /** Check if a value is in @a this range.
-   *
-   * @param value Metric value to check.
-   * @return @c true if @a value is in the range, @c false if not.
-   */
-  bool contains(metric_type const &value) const;
-
-  /** Logical intersection.
-   * @return @c true if there is at least one common value in the two intervals, @c false otherwise.
-   */
-  bool has_intersection_with(self_type const &that) const;
-
-  /** Compute the intersection of two intervals
-   *
-   * @return The interval consisting of values that are contained by both intervals. The return range
-   * is empty if the intervals are disjoint.
-   *
-   * @internal Co-variant
-   */
-  self_type intersection(self_type const &that) const;
-
-  /** Test for adjacency.
-   * @return @c true if the intervals are adjacent.
-   * @note Only disjoint intervals can be adjacent.
-   */
-  bool is_adjacent_to(self_type const &that) const;
-
-  /** Lower adjacency.
-   *
-   * @param that Range to check for adjacency.
-   * @return @c true if @a this and @ta that are adjacent and @a this is less than @a that.
-   */
-  bool is_left_adjacent_to(self_type const &that) const;
-
-  /** Valid union.
-   *
-   * @param that Range to compare.
-   *
-   * @return @a true if the hull of @a this and @a that contains only elements that are also in
-   * @a this or @a that.
-   */
-  bool has_union(self_type const &that) const;
-
-  /** Superset test.
-   *
-   * @return @c true if every value in @c that is also in @c this.
-   */
-  bool is_superset_of(self_type const &that) const;
-
-  /** Subset test.
-   *
-   *  @return @c true if every value in @c this is also in @c that.
-   */
-  bool is_subset_of(self_type const &that) const;
-
-  /** Strict superset test.
-   *
-   * @return @c true if @a this contains every value in @a this and @a this has at least one value not
-   * in @a that.
-   */
-  bool is_strict_superset_of(self_type const &that) const;
-
-  /** Strict subset test.
-   *
-   * @return @c true if @a that contains every value in @a this and @a that has at least one value not
-   * in @a this.
-   */
-  bool is_strict_subset_of(self_type const &that) const;
-
-  /** Generic relationship.
-   *
-   * @return The relationship between @a this and @a that.
-   */
-  Relation relationship(self_type const &that) const;
-
-  /** Determine the relationship of the left edge of @a that with @a this.
-   *
-   * @param that The other interval.
-   * @return The edge relationship.
-   *
-   * This checks the right edge of @a this against the left edge of @a that.
-   *
-   * - GAP: @a that left edge is right of @a this.
-   * - ADJ: @a that left edge is right adjacent to @a this.
-   * - OVLP: @a that left edge is inside @a this.
-   * - NONE: @a that left edge is left of @a this.
-   */
-  EdgeRelation left_edge_relationship(self_type const &that) const;
-
-  /** Convex hull.
-   * @return The smallest interval that is a superset of @c this and @a that.
-   * @internal Co-variant
-   */
-  self_type hull(self_type const &that) const;
-
-  //! Check if the interval is exactly one element.
-  bool is_singleton() const;
-
-  /** Test for empty, operator form.
-      @return @c true if the interval is empty, @c false otherwise.
-   */
-  bool operator!() const;
-
-  /** Test for non-empty.
-   *
-   * @return @c true if there values in the range, @c false if no values in the range.
-   */
-  explicit operator bool() const;
-
-  /** Maximality.
-    * @return @c true if this range contains every value.
-   */
-  bool is_maximal() const;
-
-  /** Clip interval.
-   *  Remove all element in @c this interval not in @a that interval.
-   */
-  self_type &operator&=(self_type const &that);
-
-  /** Convex hull.
-    * Minimally extend @a this to cover all elements in @c this and @a that.
-    * @return @a this.
-   */
-  self_type &operator|=(self_type const &that);
-
-  /// Make the range empty.
-  self_type & clear();
-
-  /** Functor for lexicographic ordering.
-      If, for some reason, an interval needs to be put in a container
-      that requires a strict weak ordering, the default @c operator @c < will
-      not work. Instead, this functor should be used as the comparison
-      functor. E.g.
-      @code
-      typedef std::set<Interval<T>, Interval<T>::lexicographic_order> container;
-      @endcode
-
-      @note Lexicographic ordering is a standard tuple ordering where the
-      order is determined by pairwise comparing the elements of both tuples.
-      The first pair of elements that are not equal determine the ordering
-      of the overall tuples.
-   */
-  struct lexicographic_order {
-    using first_argument_type = self_type;
-    using second_argument_type = self_type;
-    using result_type = bool;
-
-    //! Functor operator.
-    bool operator()(self_type const &lhs, self_type const &rhs) const;
+  /// Relationship between two intervals.
+  enum class DiscreteRangeRelation : uint8_t {
+    NONE,     ///< No common elements.
+    EQUAL,    ///< Identical ranges.
+    SUBSET,   ///< All elements in LHS are also in RHS.
+    SUPERSET, ///< Every element in RHS is in LHS.
+    OVERLAP,  ///< There exists at least one element in both LHS and RHS.
+    ADJACENT  ///< The two intervals are adjacent and disjoint.
   };
-};
 
-template <typename T>
-bool
-DiscreteRange<T>::operator==(DiscreteRange::self_type const &that) const {
-  return _min == that._min && _max == that._max;
-}
+  /// Relationship between one edge of an interval and the "opposite" edge of another.
+  enum class DiscreteRangeEdgeRelation : uint8_t {
+    NONE, ///< Edge is on the opposite side of the relating edge.
+    GAP,  ///< There is a gap between the edges.
+    ADJ,  ///< The edges are adjacent.
+    OVLP, ///< Edge is inside interval.
+  };
 
-template <typename T>
-bool
-DiscreteRange<T>::operator!=(DiscreteRange::self_type const &that) const {
-  return _min != that._min | _max != that._max;
-}
+  /** A range over a discrete finite value metric.
+     @tparam T The type for the range values.
 
-template <typename T>
-auto
-DiscreteRange<T>::clip_max() -> self_type & {
-  --_max;
-  return *this;
-}
+     The template argument @a T is presumed to
+     - be completely ordered.
+     - have prefix increment and decrement operators
+     - equality operator
+     - have value semantics
+     - have minimum and maximum values either
+       - members @c MIN and @c MAX that define static instances
+       - @c std::numeric_limits<T> support.
 
-template <typename T>
-bool
-DiscreteRange<T>::operator!() const {
-  return _min > _max;
-}
-
-template <typename T> DiscreteRange<T>::operator bool() const { return _min <= _max; }
-
-template <typename T>
-bool
-DiscreteRange<T>::contains(metric_type const &value) const {
-  return _min <= value && value <= _max;
-}
-
-template <typename T>
-auto
-DiscreteRange<T>::clear() -> self_type & {
-  _min = detail::maximum<T>();
-  _max = detail::minimum<T>();
-  return *this;
-}
-
-template <typename T>
-bool
-DiscreteRange<T>::lexicographic_order::operator()(DiscreteRange::self_type const &lhs, DiscreteRange::self_type const &rhs) const {
-  return lhs._min == rhs._min ? lhs._max < rhs._max : lhs._min < rhs._min;
-}
-
-template <typename T>
-DiscreteRange<T> &
-DiscreteRange<T>::assign(metric_type const &min, metric_type const &max) {
-  _min = min;
-  _max = max;
-  return *this;
-}
-
-template <typename T>
-DiscreteRange<T>
-DiscreteRange<T>::hull(DiscreteRange::self_type const &that) const {
-  // need to account for invalid ranges.
-  return !*this ? that : !that ? *this : self_type(std::min(_min, that._min), std::max(_max, that._max));
-}
-
-template <typename T>
-auto
-DiscreteRange<T>::left_edge_relationship(self_type const &that) const -> EdgeRelation {
-  if (_max < that._max) {
-    return ++metric_type(_max) < that._max ? EdgeRelation::GAP : EdgeRelation::ADJ;
-  }
-  return _min >= that._min ? EdgeRelation::NONE : EdgeRelation::OVLP;
-}
-
-template <typename T>
-auto
-DiscreteRange<T>::relationship(self_type const &that) const -> Relation{
-  Relation retval = Relation::NONE;
-  if (this->has_intersection(that)) {
-    if (*this == that)
-      retval = Relation::EQUAL;
-    else if (this->is_subset_of(that))
-      retval = Relation::SUBSET;
-    else if (this->is_superset_of(that))
-      retval = Relation::SUPERSET;
-    else
-      retval = Relation::OVERLAP;
-  } else if (this->is_adjacent_to(that)) {
-    retval = Relation::ADJACENT;
-  }
-  return retval;
-}
-
-template <typename T>
-DiscreteRange<T> &
-DiscreteRange<T>::assign(metric_type const &singleton) {
-  _min = singleton;
-  _max = singleton;
-  return *this;
-}
-
-template <typename T>
-DiscreteRange<T> &
-DiscreteRange<T>::assign_min(metric_type const &min) {
-  _min = min;
-  return *this;
-}
-
-template <typename T>
-bool
-DiscreteRange<T>::is_singleton() const {
-  return _min == _max;
-}
-
-template <typename T>
-bool
-DiscreteRange<T>::empty() const {
-  return _min > _max;
-}
-
-template <typename T>
-bool
-DiscreteRange<T>::is_maximal() const {
-  return _min == detail::minimum<T>() && _max == detail::maximum<T>();
-}
-
-template <typename T>
-bool
-DiscreteRange<T>::is_strict_superset_of(DiscreteRange::self_type const &that) const {
-  return (_min < that._min && that._max <= _max) || (_min <= that._min && that._max < _max);
-}
-
-template <typename T>
-DiscreteRange<T> &
-DiscreteRange<T>::operator|=(DiscreteRange::self_type const &that) {
-  if (!*this) {
-    *this = that;
-  } else if (that) {
-    if (that._min < _min) {
-      _min = that._min;
-    }
-    if (that._max > _max) {
-      _max = that._max;
-    }
-  }
-  return *this;
-}
-
-template <typename T>
-DiscreteRange<T> &
-DiscreteRange<T>::assign_max(metric_type const &max) {
-  _max = max;
-  return *this;
-}
-
-template <typename T>
-bool
-DiscreteRange<T>::is_strict_subset_of(DiscreteRange::self_type const &that) const {
-  return that.is_strict_superset_of(*this);
-}
-
-template <typename T>
-bool
-DiscreteRange<T>::is_subset_of(DiscreteRange::self_type const &that) const {
-  return that.is_superset_of(*this);
-}
-
-template <typename T>
-T const &
-DiscreteRange<T>::min() const {
-  return _min;
-}
-
-template <typename T>
-T const &
-DiscreteRange<T>::max() const {
-  return _max;
-}
-
-template <typename T>
-bool
-DiscreteRange<T>::has_union(DiscreteRange::self_type const &that) const {
-  return this->has_intersection(that) || this->is_adjacent_to(that);
-}
-
-template <typename T>
-DiscreteRange<T> &
-DiscreteRange<T>::operator&=(DiscreteRange::self_type const &that) {
-  *this = this->intersection(that);
-  return *this;
-}
-
-template <typename T>
-bool
-DiscreteRange<T>::has_intersection_with(DiscreteRange::self_type const &that) const {
-  return (that._min <= _min && _min <= that._max) || (_min <= that._min && that._min <= _max);
-}
-
-template <typename T>
-bool
-DiscreteRange<T>::is_superset_of(DiscreteRange::self_type const &that) const {
-  return _min <= that._min && that._max <= _max;
-}
-
-template <typename T>
-bool
-DiscreteRange<T>::is_adjacent_to(DiscreteRange::self_type const &that) const {
-  return this->is_left_adjacent_to(that) || that.is_left_adjacent_to(*this);
-}
-
-template <typename T>
-bool
-DiscreteRange<T>::is_left_adjacent_to(DiscreteRange::self_type const &that) const {
-  /* Need to be careful here. We don't know much about T and we certainly don't know if "t+1"
-   * even compiles for T. We do require the increment operator, however, so we can use that on a
-   * copy to get the equivalent of t+1 for adjacency testing. We must also handle the possibility
-   * T has a modulus and not depend on ++t > t always being true. However, we know that if t1 >
-   * t0 then ++t0 > t0.
+     The interval is always an inclusive (closed) contiguous interval,
+     defined by the minimum and maximum values contained in the interval.
+     An interval can be @em empty and contain no values. This is the state
+     of a default constructed interval.
    */
-  metric_type max(_max); // some built in integer types don't support increment on rvalues.
-  return _max < that._min && ++max == that._min;
-}
+  template <typename T> class DiscreteRange
+  {
+    using self_type = DiscreteRange;
 
-template <typename T>
-DiscreteRange<T>
-DiscreteRange<T>::intersection(DiscreteRange::self_type const &that) const {
-  return {std::max(_min, that._min), std::min(_max, that._max)};
-}
-
-template <typename T>
-bool
-operator==(DiscreteRange<T> const &lhs, DiscreteRange<T> const &rhs) {
-  return lhs.min() == rhs.min() && lhs.max() == rhs.max();
-}
-
-/** Inequality.
-    Two intervals are equal if their min and max values are equal.
-    @relates DiscreteRange
- */
-template <typename T>
-bool
-operator!=(DiscreteRange<T> const &lhs, DiscreteRange<T> const &rhs) {
-  return !(lhs == rhs);
-}
-
-/** Operator form of logical intersection test for two intervals.
-    @return @c true if there is at least one common value in the
-    two intervals, @c false otherwise.
-    @note Yeah, a bit ugly, using an operator that is not standardly
-    boolean but
-    - There don't seem to be better choices (&&,|| not good)
-    - The assymmetry between intersection and union makes for only three natural operators
-    - ^ at least looks like "intersects"
-    @relates DiscreteRange
- */
-template <typename T>
-bool
-operator^(DiscreteRange<T> const &lhs, DiscreteRange<T> const &rhs) {
-  return lhs.has_intersection(rhs);
-}
-
-/** Containment ordering.
-    @return @c true if @c this is a strict subset of @a rhs.
-    @note Equivalent to @c is_strict_subset.
-    @relates DiscreteRange
- */
-template <typename T>
-inline bool
-operator<(DiscreteRange<T> const &lhs, DiscreteRange<T> const &rhs) {
-  return rhs.is_strict_superset_of(lhs);
-}
-
-/** Containment ordering.
-    @return @c true if @c this is a subset of @a rhs.
-    @note Equivalent to @c is_subset.
-    @relates DiscreteRange
- */
-template <typename T>
-inline bool
-operator<=(DiscreteRange<T> const &lhs, DiscreteRange<T> const &rhs) {
-  return rhs.is_superset_of(lhs);
-}
-
-/** Containment ordering.
-    @return @c true if @c this is a strict superset of @a rhs.
-    @note Equivalent to @c is_strict_superset.
-    @relates DiscreteRange
- */
-template <typename T>
-inline bool
-operator>(DiscreteRange<T> const &lhs, DiscreteRange<T> const &rhs) {
-  return lhs.is_strict_superset_of(rhs);
-}
-
-/** Containment ordering.
-    @return @c true if @c this is a superset of @a rhs.
-    @note Equivalent to @c is_superset.
-    @relates DiscreteRange
-    */
-template <typename T>
-inline bool
-operator>=(DiscreteRange<T> const &lhs, DiscreteRange<T> const &rhs) {
-  return lhs.is_superset_of(rhs);
-}
-
-/** A space for a discrete @c METRIC.
- *
- * @tparam METRIC Value type for the space.
- * @tparam PAYLOAD Data stored with values in the space.
- *
- * This is a range based mapping of all values in @c METRIC (the "space") to @c PAYLOAD.
- *
- * @c PAYLOAD is presumed to be relatively cheap to construct and copy.
- *
- * @c METRIC must be
- * - discrete and finite valued type with increment and decrement operations.
- */
-template <typename METRIC, typename PAYLOAD> class DiscreteSpace {
-  using self_type = DiscreteSpace;
-
-protected:
-  using metric_type  = METRIC;  ///< Export.
-  using payload_type = PAYLOAD; ///< Export.
-  using range_type   = DiscreteRange<METRIC>;
-
-  /// A node in the range tree.
-  class Node : public detail::RBNode {
-    using self_type  = Node;           ///< Self reference type.
-    using super_type = detail::RBNode; ///< Parent class.
-    friend class DiscreteSpace;
-
-    range_type _range;  ///< Range covered by this node.
-    range_type _hull;   ///< Range covered by subtree rooted at this node.
-    PAYLOAD _payload{}; ///< Default constructor, should zero init if @c PAYLOAD is a pointer.
+  protected:
+    T _min; ///< The minimum value in the interval
+    T _max; ///< the maximum value in the interval
 
   public:
-    /// Linkage for @c IntrusiveDList.
-    using Linkage = swoc::IntrusiveLinkageRebind<self_type, super_type::Linkage>;
+    using metric_type  = T;                         ///< Export metric type.
+    using Relation     = DiscreteRangeRelation;     ///< Import type for convenience.
+    using EdgeRelation = DiscreteRangeEdgeRelation; ///< Import type for convenience.
 
-    Node() = default; ///< Construct empty node.
-
-    /// Construct from @a range and @a payload.
-    Node(range_type const &range, PAYLOAD const &payload) : _range(range), _payload(payload) {}
-
-    /// Construct from two metrics and a payload
-    Node(METRIC const &min, METRIC const &max, PAYLOAD const &payload) : _range(min, max), _payload(payload) {}
-
-    /// @return The payload in the node.
-    PAYLOAD &payload();
-
-    /** Set the @a range of a node.
-     *
-     * @param range Range to use.
-     * @return @a this
+    /** Default constructor.
+     * An invalid (empty) range is constructed.
      */
-    self_type &assign(range_type const &range);
+    constexpr DiscreteRange() : _min(detail::maximum<T>()), _max(detail::minimum<T>()) {}
 
-    /** Set the @a payload for @a this node.
+    /** Construct a singleton range.
+     * @param value Single value to be contained by the interval.
      *
-     * @param payload Payload to use.
-     * @return @a this
+     * @note Not marked @c explicit and so serves as a conversion from scalar values to an interval.
      */
-    self_type &assign(PAYLOAD const &payload);
+    constexpr DiscreteRange(T const &value) : _min(value), _max(value){};
 
-    range_type const &
-    range() const {
-      return _range;
-    }
+    /** Constructor.
+     *
+     * @param min Minimum value in the interval.
+     * @param max Maximum value in the interval.
+     */
+    constexpr DiscreteRange(T const &min, T const &max) : _min(min), _max(max) {}
 
-    self_type &
-    assign_min(METRIC const &m) {
-      _range.assign_min(m);
-      this->ripple_structure_fixup();
-      return *this;
-    }
+    ~DiscreteRange() = default;
 
-    self_type &
-    assign_max(METRIC const &m) {
-      _range.assign_max(m);
-      this->ripple_structure_fixup();
-      return *this;
-    }
+    /** Check if there are no values in the range.
+     *
+     * @return @c true if the range is empty (contains no values), @c false if it contains at least
+     * one value.
+     */
+    bool empty() const;
 
-    METRIC const &
-    min() const {
-      return _range.min();
-    }
+    /** Update the range.
+     *
+     * @param min New minimum value.
+     * @param max New maximum value.
+     * @return @a this.
+     */
+    self_type &assign(metric_type const &min, metric_type const &max);
 
-    METRIC const &
-    max() const {
-      return _range.max();
-    }
+    /** Update the range.
+     *
+     * @param value The new minimum and maximum value.
+     * @return @a this.
+     *
+     * The range will contain the single value @a value.
+     */
+    self_type &assign(metric_type const &value);
 
-    void structure_fixup() override;
+    /** Update the minimum value.
+     *
+     * @param min The new minimum value.
+     * @return @a this.
+     *
+     * @note No checks are done - this can result in an empty range.
+     */
+    self_type &assign_min(metric_type const &min);
 
-    self_type *
-    left() {
-      return static_cast<self_type *>(_left);
-    }
+    /** Update the maximum value.
+     *
+     * @param max The new maximum value.
+     * @return @a this.
+     *
+     * @note No checks are done - this can result in an empty range.
+     */
+    self_type &assign_max(metric_type const &max);
 
-    self_type *
-    right() {
-      return static_cast<self_type *>(_right);
-    }
+    /** Decrement the maximum value.
+     *
+     * @return @a this.
+     *
+     * @note No checks are done, the caller must ensure it is valid to decremented the current maximum.
+     */
+    self_type &clip_max();
+
+    /** Minimum value.
+     * @return the minimum value in the range.
+     * @note The return value is unspecified if the interval is empty.
+     */
+    metric_type const &min() const;
+
+    /** Maximum value.
+     * @return The maximum value in the range.
+     * @note The return value is unspecified if the interval is empty.
+     */
+    metric_type const &max() const;
+
+    /// Equality.
+    bool operator==(self_type const &that) const;
+
+    /// Inequality.
+    bool operator!=(self_type const &that) const;
+
+    /** Check if a value is in @a this range.
+     *
+     * @param value Metric value to check.
+     * @return @c true if @a value is in the range, @c false if not.
+     */
+    bool contains(metric_type const &value) const;
+
+    /** Logical intersection.
+     * @return @c true if there is at least one common value in the two intervals, @c false otherwise.
+     */
+    bool has_intersection_with(self_type const &that) const;
+
+    /** Compute the intersection of two intervals
+     *
+     * @return The interval consisting of values that are contained by both intervals. The return range
+     * is empty if the intervals are disjoint.
+     *
+     * @internal Co-variant
+     */
+    self_type intersection(self_type const &that) const;
+
+    /** Test for adjacency.
+     * @return @c true if the intervals are adjacent.
+     * @note Only disjoint intervals can be adjacent.
+     */
+    bool is_adjacent_to(self_type const &that) const;
+
+    /** Lower adjacency.
+     *
+     * @param that Range to check for adjacency.
+     * @return @c true if @a this and @ta that are adjacent and @a this is less than @a that.
+     */
+    bool is_left_adjacent_to(self_type const &that) const;
+
+    /** Valid union.
+     *
+     * @param that Range to compare.
+     *
+     * @return @a true if the hull of @a this and @a that contains only elements that are also in
+     * @a this or @a that.
+     */
+    bool has_union(self_type const &that) const;
+
+    /** Superset test.
+     *
+     * @return @c true if every value in @c that is also in @c this.
+     */
+    bool is_superset_of(self_type const &that) const;
+
+    /** Subset test.
+     *
+     *  @return @c true if every value in @c this is also in @c that.
+     */
+    bool is_subset_of(self_type const &that) const;
+
+    /** Strict superset test.
+     *
+     * @return @c true if @a this contains every value in @a this and @a this has at least one value not
+     * in @a that.
+     */
+    bool is_strict_superset_of(self_type const &that) const;
+
+    /** Strict subset test.
+     *
+     * @return @c true if @a that contains every value in @a this and @a that has at least one value not
+     * in @a this.
+     */
+    bool is_strict_subset_of(self_type const &that) const;
+
+    /** Generic relationship.
+     *
+     * @return The relationship between @a this and @a that.
+     */
+    Relation relationship(self_type const &that) const;
+
+    /** Determine the relationship of the left edge of @a that with @a this.
+     *
+     * @param that The other interval.
+     * @return The edge relationship.
+     *
+     * This checks the right edge of @a this against the left edge of @a that.
+     *
+     * - GAP: @a that left edge is right of @a this.
+     * - ADJ: @a that left edge is right adjacent to @a this.
+     * - OVLP: @a that left edge is inside @a this.
+     * - NONE: @a that left edge is left of @a this.
+     */
+    EdgeRelation left_edge_relationship(self_type const &that) const;
+
+    /** Convex hull.
+     * @return The smallest interval that is a superset of @c this and @a that.
+     * @internal Co-variant
+     */
+    self_type hull(self_type const &that) const;
+
+    //! Check if the interval is exactly one element.
+    bool is_singleton() const;
+
+    /** Test for empty, operator form.
+        @return @c true if the interval is empty, @c false otherwise.
+     */
+    bool operator!() const;
+
+    /** Test for non-empty.
+     *
+     * @return @c true if there values in the range, @c false if no values in the range.
+     */
+    explicit operator bool() const;
+
+    /** Maximality.
+     * @return @c true if this range contains every value.
+     */
+    bool is_maximal() const;
+
+    /** Clip interval.
+     *  Remove all element in @c this interval not in @a that interval.
+     */
+    self_type &operator&=(self_type const &that);
+
+    /** Convex hull.
+     * Minimally extend @a this to cover all elements in @c this and @a that.
+     * @return @a this.
+     */
+    self_type &operator|=(self_type const &that);
+
+    /// Make the range empty.
+    self_type &clear();
+
+    /** Functor for lexicographic ordering.
+        If, for some reason, an interval needs to be put in a container
+        that requires a strict weak ordering, the default @c operator @c < will
+        not work. Instead, this functor should be used as the comparison
+        functor. E.g.
+        @code
+        typedef std::set<Interval<T>, Interval<T>::lexicographic_order> container;
+        @endcode
+
+        @note Lexicographic ordering is a standard tuple ordering where the
+        order is determined by pairwise comparing the elements of both tuples.
+        The first pair of elements that are not equal determine the ordering
+        of the overall tuples.
+     */
+    struct lexicographic_order {
+      using first_argument_type  = self_type;
+      using second_argument_type = self_type;
+      using result_type          = bool;
+
+      //! Functor operator.
+      bool operator()(self_type const &lhs, self_type const &rhs) const;
+    };
   };
 
-  using Direction = typename Node::Direction;
-
-  Node *_root = nullptr;                        ///< Root node.
-  IntrusiveDList<typename Node::Linkage> _list; ///< In order list of nodes.
-  swoc::MemArena _arena{4000};                  ///< Memory Storage.
-  swoc::FixedArena<Node> _fa{_arena};           ///< Node allocator and free list.
-
-  // Utility methods to avoid having casts scattered all over.
-  Node *
-  prev(Node *n) {
-    return Node::Linkage::prev_ptr(n);
+  template <typename T>
+  bool
+  DiscreteRange<T>::operator==(DiscreteRange::self_type const &that) const
+  {
+    return _min == that._min && _max == that._max;
   }
 
-  Node *
-  next(Node *n) {
-    return Node::Linkage::next_ptr(n);
+  template <typename T>
+  bool
+  DiscreteRange<T>::operator!=(DiscreteRange::self_type const &that) const
+  {
+    return _min != that._min | _max != that._max;
   }
 
-  Node *
-  left(Node *n) {
-    return static_cast<Node *>(n->_left);
+  template <typename T>
+  auto
+  DiscreteRange<T>::clip_max() -> self_type &
+  {
+    --_max;
+    return *this;
   }
 
-  Node *
-  right(Node *n) {
-    return static_cast<Node *>(n->_right);
+  template <typename T>
+  bool
+  DiscreteRange<T>::operator!() const
+  {
+    return _min > _max;
   }
 
-public:
-  using iterator       = typename decltype(_list)::iterator;
-  using const_iterator = typename decltype(_list)::const_iterator;
-
-  DiscreteSpace() = default;
-
-  ~DiscreteSpace();
-
-  /** Set the @a payload for a @a range
-   *
-   * @param range Range to mark.
-   * @param payload Payload to set.
-   * @return @a this
-   *
-   * Values in @a range are set to @a payload regardless of the current state.
-   */
-  self_type &mark(range_type const &range, PAYLOAD const &payload);
-
-  /** Erase a @a range.
-   *
-   * @param range Range to erase.
-   * @return @a this
-   *
-   * All values in @a range are removed from the space.
-   */
-  self_type &erase(range_type const &range);
-
-  /** Blend a @a color to a @a range.
-   *
-   * @tparam F Functor to blend payloads.
-   * @tparam U type to blend in to payloads.
-   * @param range Range for blending.
-   * @param color Payload to blend.
-   * @param blender Functor to compute blended color.
-   * @return @a this
-   *
-   * @a color is blended to values in @a range. If an address in @a range does not have a payload,
-   * its payload is set a default constructed @c PAYLOAD blended with @a color. If such an address
-   * does have a payload, @a color is blended in to that payload using @a blender. The existing color
-   * is passed as the first argument and @a color as the second argument. The functor is expected to
-   * update the first argument to be the blended color. The function must return a @c bool to
-   * indicate whether the blend resulted in a valid color. If @c false is returned, the blended
-   * region is removed from the space.
-   */
-  template <typename F, typename U = PAYLOAD> self_type &blend(range_type const &range, U const &color, F &&blender);
-
-  /** Fill @a range with @a payload.
-   *
-   * @param range Range to fill.
-   * @param payload Payload to use.
-   * @return @a this
-   *
-   * Values in @a range that do not have a payload are set to @a payload. Values in the space are
-   * not changed.
-   */
-  self_type &fill(range_type const &range, PAYLOAD const &payload);
-
-  /** Find the payload at @a metric.
-   *
-   * @param metric The metric for which to search.
-   * @return An iterator for the item or the @c end iterator if not.
-   */
-  iterator find(METRIC const &metric);
-
-  /** Find the payload at @a metric.
-   *
-   * @param metric The metric for which to search.
-   * @return An iterator for the item or the @c end iterator if not.
-   */
-  const_iterator find(METRIC const &metric) const;
-
-  /** Lower bound.
-   *
-   * @param m Search value.
-   * @return Rightmost range that starts at or before @a m.
-   */
-  iterator lower_bound(METRIC const& m);
-
-  /** Upper bound.
-   *
-   * @param m search value
-   * @return Leftmost range that starts after @a m.
-   */
-  iterator upper_bound(METRIC const& m);
-
-  /** Intersection of @a range with container.
-   *
-   * @param range Search range.
-   * @return Iterator pair that contains all ranges that intersect with @a range.
-   *
-   * @see lower_bound
-   * @see upper_bound
-   */
-  std::pair<iterator, iterator> intersection(range_type const& range);
-
-  /// @return The number of distinct ranges.
-  size_t count() const;
-
-  /// @return @c true if there are no ranges in the container, @c false otherwise.
-  bool empty() const;
-
-  /// @return Iterator for the first range.
-  iterator begin() { return _list.begin(); }
-  /// @return Iterator past the last node.
-  iterator end() { return _list.end(); }
-  /// @return Iterator for the first range.
-  const_iterator begin() const { return _list.begin(); }
-  /// @return Iterator past the last node.
-  const_iterator end() const { return _list.end(); }
-
-  /// Remove all ranges.
-  void clear();
-
-protected:
-  /** Find the lower bounding node.
-   *
-   * @param target Search value.
-   * @return The rightmost range that starts at or before @a target, or @c nullptr if all ranges start
-   * after @a target.
-   */
-  Node *lower_node(METRIC const &target);
-
-  /** Find the upper bound node.
-   *
-   * @param target Search value.
-   * @return The leftmoswt range that starts after @a target, or @c nullptr if all ranges start
-   * before @a target.
-   */
-  Node *upper_node(METRIC const &target);
-
-  /// @return First node in the tree.
-  Node *head();
-
-  /// @return Last node in the tree.
-  Node *tail();
-
-  /** Insert @a node before @a spot.
-   *
-   * @param spot Target node.
-   * @param node Node to insert.
-   */
-  void insert_before(Node *spot, Node *node);
-
-  /** Insert @a node after @a spot.
-   *
-   * @param spot Target node.
-   * @param node Node to insert.
-   */
-  void insert_after(Node *spot, Node *node);
-
-  /** Add @a node to tree as the first element.
-   *
-   * @param node Node to prepend.
-   *
-   * Invariant - @a node is first in order.
-   */
-  void prepend(Node *node);
-
-  /** Add @a node to tree as the last node.
-   *
-   * @param node Node to append.
-   *
-   * Invariant - @a node is last in order.
-   */
-  void append(Node *node);
-
-  /** Remove node from container and update container.
-   *
-   * @param node Node to remove.
-   */
-  void remove(Node *node);
-};
-
-// ---
-
-template <typename METRIC, typename PAYLOAD>
-PAYLOAD &
-DiscreteSpace<METRIC, PAYLOAD>::Node::payload() {
-  return _payload;
-}
-
-template <typename METRIC, typename PAYLOAD>
-auto
-DiscreteSpace<METRIC, PAYLOAD>::Node::assign(DiscreteSpace::range_type const &range) -> self_type & {
-  _range = range;
-  return *this;
-}
-
-template <typename METRIC, typename PAYLOAD>
-auto
-DiscreteSpace<METRIC, PAYLOAD>::Node::assign(PAYLOAD const &payload) -> self_type & {
-  _payload = payload;
-  return *this;
-}
-
-template <typename METRIC, typename PAYLOAD>
-void
-DiscreteSpace<METRIC, PAYLOAD>::Node::structure_fixup() {
-  // Invariant: The hulls of all children are correct.
-  if (_left && _right) {
-    // If both children, local range must be inside the hull of the children and irrelevant.
-    _hull.assign(this->left()->_hull.min(), this->right()->_hull.max());
-  } else if (_left) {
-    _hull.assign(this->left()->_hull.min(), _range.max());
-  } else if (_right) {
-    _hull.assign(_range.min(), this->right()->_hull.max());
-  } else {
-    _hull = _range;
+  template <typename T> DiscreteRange<T>::operator bool() const
+  {
+    return _min <= _max;
   }
-}
 
-// ---
-// Discrete Space
-// ---
-
-template <typename METRIC, typename PAYLOAD> DiscreteSpace<METRIC, PAYLOAD>::~DiscreteSpace() {
-  // Destruct all the payloads - the nodes themselves are in the arena and disappear with it.
-  for (auto &node : _list) {
-    std::destroy_at(&node.payload());
+  template <typename T>
+  bool
+  DiscreteRange<T>::contains(metric_type const &value) const
+  {
+    return _min <= value && value <= _max;
   }
-}
 
-template <typename METRIC, typename PAYLOAD>
-size_t
-DiscreteSpace<METRIC, PAYLOAD>::count() const {
-  return _list.count();
-}
+  template <typename T>
+  auto
+  DiscreteRange<T>::clear() -> self_type &
+  {
+    _min = detail::maximum<T>();
+    _max = detail::minimum<T>();
+    return *this;
+  }
 
-template <typename METRIC, typename PAYLOAD>
-bool
-DiscreteSpace<METRIC, PAYLOAD>::empty() const {
-  return _list.empty();
-}
+  template <typename T>
+  bool
+  DiscreteRange<T>::lexicographic_order::operator()(DiscreteRange::self_type const &lhs, DiscreteRange::self_type const &rhs) const
+  {
+    return lhs._min == rhs._min ? lhs._max < rhs._max : lhs._min < rhs._min;
+  }
 
-template <typename METRIC, typename PAYLOAD>
-auto
-DiscreteSpace<METRIC, PAYLOAD>::head() -> Node * {
-  return static_cast<Node *>(_list.head());
-}
+  template <typename T>
+  DiscreteRange<T> &
+  DiscreteRange<T>::assign(metric_type const &min, metric_type const &max)
+  {
+    _min = min;
+    _max = max;
+    return *this;
+  }
 
-template <typename METRIC, typename PAYLOAD>
-auto
-DiscreteSpace<METRIC, PAYLOAD>::tail() -> Node * {
-  return static_cast<Node *>(_list.tail());
-}
+  template <typename T>
+  DiscreteRange<T>
+  DiscreteRange<T>::hull(DiscreteRange::self_type const &that) const
+  {
+    // need to account for invalid ranges.
+    return !*this ? that : !that ? *this : self_type(std::min(_min, that._min), std::max(_max, that._max));
+  }
 
-template <typename METRIC, typename PAYLOAD>
-auto
-DiscreteSpace<METRIC, PAYLOAD>::find(METRIC const &metric) -> iterator {
-  auto n = _root; // current node to test.
-  while (n) {
-    if (metric < n->min()) {
-      if (n->_hull.contains(metric)) {
-        n = n->left();
-      } else {
-        return this->end();
-      }
-    } else if (n->max() < metric) {
-      if (n->_hull.contains(metric)) {
-        n = n->right();
-      } else {
-        return this->end();
-      }
-    } else {
-      return _list.iterator_for(n);
+  template <typename T>
+  auto
+  DiscreteRange<T>::left_edge_relationship(self_type const &that) const -> EdgeRelation
+  {
+    if (_max < that._max) {
+      return ++metric_type(_max) < that._max ? EdgeRelation::GAP : EdgeRelation::ADJ;
     }
-  }
-  return this->end();
-}
-
-template <typename METRIC, typename PAYLOAD>
-auto
-DiscreteSpace<METRIC, PAYLOAD>::find(METRIC const &metric) const -> const_iterator
-{
-  return const_cast<self_type *>(this)->find(metric);
-}
-
-template <typename METRIC, typename PAYLOAD>
-auto
-DiscreteSpace<METRIC, PAYLOAD>::lower_node(METRIC const &target) -> Node * {
-  Node *n    = _root;   // current node to test.
-  Node *zret = nullptr; // best node so far.
-
-  // Fast check for sequential insertion
-  if (auto ln = _list.tail(); ln != nullptr && ln->max() < target) {
-    return ln;
+    return _min >= that._min ? EdgeRelation::NONE : EdgeRelation::OVLP;
   }
 
-  while (n) {
-    if (target < n->min()) {
-      n = left(n);
-    } else {
-      zret = n; // this is a better candidate.
-      if (n->max() < target) {
-        n = right(n);
-      } else {
-        break;
+  template <typename T>
+  auto
+  DiscreteRange<T>::relationship(self_type const &that) const -> Relation
+  {
+    Relation retval = Relation::NONE;
+    if (this->has_intersection(that)) {
+      if (*this == that)
+        retval = Relation::EQUAL;
+      else if (this->is_subset_of(that))
+        retval = Relation::SUBSET;
+      else if (this->is_superset_of(that))
+        retval = Relation::SUPERSET;
+      else
+        retval = Relation::OVERLAP;
+    } else if (this->is_adjacent_to(that)) {
+      retval = Relation::ADJACENT;
+    }
+    return retval;
+  }
+
+  template <typename T>
+  DiscreteRange<T> &
+  DiscreteRange<T>::assign(metric_type const &singleton)
+  {
+    _min = singleton;
+    _max = singleton;
+    return *this;
+  }
+
+  template <typename T>
+  DiscreteRange<T> &
+  DiscreteRange<T>::assign_min(metric_type const &min)
+  {
+    _min = min;
+    return *this;
+  }
+
+  template <typename T>
+  bool
+  DiscreteRange<T>::is_singleton() const
+  {
+    return _min == _max;
+  }
+
+  template <typename T>
+  bool
+  DiscreteRange<T>::empty() const
+  {
+    return _min > _max;
+  }
+
+  template <typename T>
+  bool
+  DiscreteRange<T>::is_maximal() const
+  {
+    return _min == detail::minimum<T>() && _max == detail::maximum<T>();
+  }
+
+  template <typename T>
+  bool
+  DiscreteRange<T>::is_strict_superset_of(DiscreteRange::self_type const &that) const
+  {
+    return (_min < that._min && that._max <= _max) || (_min <= that._min && that._max < _max);
+  }
+
+  template <typename T>
+  DiscreteRange<T> &
+  DiscreteRange<T>::operator|=(DiscreteRange::self_type const &that)
+  {
+    if (!*this) {
+      *this = that;
+    } else if (that) {
+      if (that._min < _min) {
+        _min = that._min;
+      }
+      if (that._max > _max) {
+        _max = that._max;
       }
     }
-  }
-  return zret;
-}
-
-template <typename METRIC, typename PAYLOAD>
-auto
-DiscreteSpace<METRIC, PAYLOAD>::upper_node(METRIC const &target) -> Node * {
-  Node *n    = _root;   // current node to test.
-  Node *zret = nullptr; // best node so far.
-
-  // Fast check if there is no range past @a target.
-  if (auto ln = _list.tail() ; ln == nullptr || ln->min() <= target) {
-    return nullptr;
+    return *this;
   }
 
-  while (n) {
-    if (target > n->min()) {
-      n = right(n);
+  template <typename T>
+  DiscreteRange<T> &
+  DiscreteRange<T>::assign_max(metric_type const &max)
+  {
+    _max = max;
+    return *this;
+  }
+
+  template <typename T>
+  bool
+  DiscreteRange<T>::is_strict_subset_of(DiscreteRange::self_type const &that) const
+  {
+    return that.is_strict_superset_of(*this);
+  }
+
+  template <typename T>
+  bool
+  DiscreteRange<T>::is_subset_of(DiscreteRange::self_type const &that) const
+  {
+    return that.is_superset_of(*this);
+  }
+
+  template <typename T>
+  T const &
+  DiscreteRange<T>::min() const
+  {
+    return _min;
+  }
+
+  template <typename T>
+  T const &
+  DiscreteRange<T>::max() const
+  {
+    return _max;
+  }
+
+  template <typename T>
+  bool
+  DiscreteRange<T>::has_union(DiscreteRange::self_type const &that) const
+  {
+    return this->has_intersection(that) || this->is_adjacent_to(that);
+  }
+
+  template <typename T>
+  DiscreteRange<T> &
+  DiscreteRange<T>::operator&=(DiscreteRange::self_type const &that)
+  {
+    *this = this->intersection(that);
+    return *this;
+  }
+
+  template <typename T>
+  bool
+  DiscreteRange<T>::has_intersection_with(DiscreteRange::self_type const &that) const
+  {
+    return (that._min <= _min && _min <= that._max) || (_min <= that._min && that._min <= _max);
+  }
+
+  template <typename T>
+  bool
+  DiscreteRange<T>::is_superset_of(DiscreteRange::self_type const &that) const
+  {
+    return _min <= that._min && that._max <= _max;
+  }
+
+  template <typename T>
+  bool
+  DiscreteRange<T>::is_adjacent_to(DiscreteRange::self_type const &that) const
+  {
+    return this->is_left_adjacent_to(that) || that.is_left_adjacent_to(*this);
+  }
+
+  template <typename T>
+  bool
+  DiscreteRange<T>::is_left_adjacent_to(DiscreteRange::self_type const &that) const
+  {
+    /* Need to be careful here. We don't know much about T and we certainly don't know if "t+1"
+     * even compiles for T. We do require the increment operator, however, so we can use that on a
+     * copy to get the equivalent of t+1 for adjacency testing. We must also handle the possibility
+     * T has a modulus and not depend on ++t > t always being true. However, we know that if t1 >
+     * t0 then ++t0 > t0.
+     */
+    metric_type max(_max); // some built in integer types don't support increment on rvalues.
+    return _max < that._min && ++max == that._min;
+  }
+
+  template <typename T>
+  DiscreteRange<T>
+  DiscreteRange<T>::intersection(DiscreteRange::self_type const &that) const
+  {
+    return {std::max(_min, that._min), std::min(_max, that._max)};
+  }
+
+  template <typename T>
+  bool
+  operator==(DiscreteRange<T> const &lhs, DiscreteRange<T> const &rhs)
+  {
+    return lhs.min() == rhs.min() && lhs.max() == rhs.max();
+  }
+
+  /** Inequality.
+      Two intervals are equal if their min and max values are equal.
+      @relates DiscreteRange
+   */
+  template <typename T>
+  bool
+  operator!=(DiscreteRange<T> const &lhs, DiscreteRange<T> const &rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+  /** Operator form of logical intersection test for two intervals.
+      @return @c true if there is at least one common value in the
+      two intervals, @c false otherwise.
+      @note Yeah, a bit ugly, using an operator that is not standardly
+      boolean but
+      - There don't seem to be better choices (&&,|| not good)
+      - The assymmetry between intersection and union makes for only three natural operators
+      - ^ at least looks like "intersects"
+      @relates DiscreteRange
+   */
+  template <typename T>
+  bool
+  operator^(DiscreteRange<T> const &lhs, DiscreteRange<T> const &rhs)
+  {
+    return lhs.has_intersection(rhs);
+  }
+
+  /** Containment ordering.
+      @return @c true if @c this is a strict subset of @a rhs.
+      @note Equivalent to @c is_strict_subset.
+      @relates DiscreteRange
+   */
+  template <typename T>
+  inline bool
+  operator<(DiscreteRange<T> const &lhs, DiscreteRange<T> const &rhs)
+  {
+    return rhs.is_strict_superset_of(lhs);
+  }
+
+  /** Containment ordering.
+      @return @c true if @c this is a subset of @a rhs.
+      @note Equivalent to @c is_subset.
+      @relates DiscreteRange
+   */
+  template <typename T>
+  inline bool
+  operator<=(DiscreteRange<T> const &lhs, DiscreteRange<T> const &rhs)
+  {
+    return rhs.is_superset_of(lhs);
+  }
+
+  /** Containment ordering.
+      @return @c true if @c this is a strict superset of @a rhs.
+      @note Equivalent to @c is_strict_superset.
+      @relates DiscreteRange
+   */
+  template <typename T>
+  inline bool
+  operator>(DiscreteRange<T> const &lhs, DiscreteRange<T> const &rhs)
+  {
+    return lhs.is_strict_superset_of(rhs);
+  }
+
+  /** Containment ordering.
+      @return @c true if @c this is a superset of @a rhs.
+      @note Equivalent to @c is_superset.
+      @relates DiscreteRange
+      */
+  template <typename T>
+  inline bool
+  operator>=(DiscreteRange<T> const &lhs, DiscreteRange<T> const &rhs)
+  {
+    return lhs.is_superset_of(rhs);
+  }
+
+  /** A space for a discrete @c METRIC.
+   *
+   * @tparam METRIC Value type for the space.
+   * @tparam PAYLOAD Data stored with values in the space.
+   *
+   * This is a range based mapping of all values in @c METRIC (the "space") to @c PAYLOAD.
+   *
+   * @c PAYLOAD is presumed to be relatively cheap to construct and copy.
+   *
+   * @c METRIC must be
+   * - discrete and finite valued type with increment and decrement operations.
+   */
+  template <typename METRIC, typename PAYLOAD> class DiscreteSpace
+  {
+    using self_type = DiscreteSpace;
+
+  protected:
+    using metric_type  = METRIC;  ///< Export.
+    using payload_type = PAYLOAD; ///< Export.
+    using range_type   = DiscreteRange<METRIC>;
+
+    /// A node in the range tree.
+    class Node : public detail::RBNode
+    {
+      using self_type  = Node;           ///< Self reference type.
+      using super_type = detail::RBNode; ///< Parent class.
+      friend class DiscreteSpace;
+
+      range_type _range;  ///< Range covered by this node.
+      range_type _hull;   ///< Range covered by subtree rooted at this node.
+      PAYLOAD _payload{}; ///< Default constructor, should zero init if @c PAYLOAD is a pointer.
+
+    public:
+      /// Linkage for @c IntrusiveDList.
+      using Linkage = swoc::IntrusiveLinkageRebind<self_type, super_type::Linkage>;
+
+      Node() = default; ///< Construct empty node.
+
+      /// Construct from @a range and @a payload.
+      Node(range_type const &range, PAYLOAD const &payload) : _range(range), _payload(payload) {}
+
+      /// Construct from two metrics and a payload
+      Node(METRIC const &min, METRIC const &max, PAYLOAD const &payload) : _range(min, max), _payload(payload) {}
+
+      /// @return The payload in the node.
+      PAYLOAD &payload();
+
+      /** Set the @a range of a node.
+       *
+       * @param range Range to use.
+       * @return @a this
+       */
+      self_type &assign(range_type const &range);
+
+      /** Set the @a payload for @a this node.
+       *
+       * @param payload Payload to use.
+       * @return @a this
+       */
+      self_type &assign(PAYLOAD const &payload);
+
+      range_type const &
+      range() const
+      {
+        return _range;
+      }
+
+      self_type &
+      assign_min(METRIC const &m)
+      {
+        _range.assign_min(m);
+        this->ripple_structure_fixup();
+        return *this;
+      }
+
+      self_type &
+      assign_max(METRIC const &m)
+      {
+        _range.assign_max(m);
+        this->ripple_structure_fixup();
+        return *this;
+      }
+
+      METRIC const &
+      min() const
+      {
+        return _range.min();
+      }
+
+      METRIC const &
+      max() const
+      {
+        return _range.max();
+      }
+
+      void structure_fixup() override;
+
+      self_type *
+      left()
+      {
+        return static_cast<self_type *>(_left);
+      }
+
+      self_type *
+      right()
+      {
+        return static_cast<self_type *>(_right);
+      }
+    };
+
+    using Direction = typename Node::Direction;
+
+    Node *_root = nullptr;                        ///< Root node.
+    IntrusiveDList<typename Node::Linkage> _list; ///< In order list of nodes.
+    swoc::MemArena _arena{4000};                  ///< Memory Storage.
+    swoc::FixedArena<Node> _fa{_arena};           ///< Node allocator and free list.
+
+    // Utility methods to avoid having casts scattered all over.
+    Node *
+    prev(Node *n)
+    {
+      return Node::Linkage::prev_ptr(n);
+    }
+
+    Node *
+    next(Node *n)
+    {
+      return Node::Linkage::next_ptr(n);
+    }
+
+    Node *
+    left(Node *n)
+    {
+      return static_cast<Node *>(n->_left);
+    }
+
+    Node *
+    right(Node *n)
+    {
+      return static_cast<Node *>(n->_right);
+    }
+
+  public:
+    using iterator       = typename decltype(_list)::iterator;
+    using const_iterator = typename decltype(_list)::const_iterator;
+
+    DiscreteSpace() = default;
+
+    ~DiscreteSpace();
+
+    /** Set the @a payload for a @a range
+     *
+     * @param range Range to mark.
+     * @param payload Payload to set.
+     * @return @a this
+     *
+     * Values in @a range are set to @a payload regardless of the current state.
+     */
+    self_type &mark(range_type const &range, PAYLOAD const &payload);
+
+    /** Erase a @a range.
+     *
+     * @param range Range to erase.
+     * @return @a this
+     *
+     * All values in @a range are removed from the space.
+     */
+    self_type &erase(range_type const &range);
+
+    /** Blend a @a color to a @a range.
+     *
+     * @tparam F Functor to blend payloads.
+     * @tparam U type to blend in to payloads.
+     * @param range Range for blending.
+     * @param color Payload to blend.
+     * @param blender Functor to compute blended color.
+     * @return @a this
+     *
+     * @a color is blended to values in @a range. If an address in @a range does not have a payload,
+     * its payload is set a default constructed @c PAYLOAD blended with @a color. If such an address
+     * does have a payload, @a color is blended in to that payload using @a blender. The existing color
+     * is passed as the first argument and @a color as the second argument. The functor is expected to
+     * update the first argument to be the blended color. The function must return a @c bool to
+     * indicate whether the blend resulted in a valid color. If @c false is returned, the blended
+     * region is removed from the space.
+     */
+    template <typename F, typename U = PAYLOAD> self_type &blend(range_type const &range, U const &color, F &&blender);
+
+    /** Fill @a range with @a payload.
+     *
+     * @param range Range to fill.
+     * @param payload Payload to use.
+     * @return @a this
+     *
+     * Values in @a range that do not have a payload are set to @a payload. Values in the space are
+     * not changed.
+     */
+    self_type &fill(range_type const &range, PAYLOAD const &payload);
+
+    /** Find the payload at @a metric.
+     *
+     * @param metric The metric for which to search.
+     * @return An iterator for the item or the @c end iterator if not.
+     */
+    iterator find(METRIC const &metric);
+
+    /** Find the payload at @a metric.
+     *
+     * @param metric The metric for which to search.
+     * @return An iterator for the item or the @c end iterator if not.
+     */
+    const_iterator find(METRIC const &metric) const;
+
+    /** Lower bound.
+     *
+     * @param m Search value.
+     * @return Rightmost range that starts at or before @a m.
+     */
+    iterator lower_bound(METRIC const &m);
+
+    /** Upper bound.
+     *
+     * @param m search value
+     * @return Leftmost range that starts after @a m.
+     */
+    iterator upper_bound(METRIC const &m);
+
+    /** Intersection of @a range with container.
+     *
+     * @param range Search range.
+     * @return Iterator pair that contains all ranges that intersect with @a range.
+     *
+     * @see lower_bound
+     * @see upper_bound
+     */
+    std::pair<iterator, iterator> intersection(range_type const &range);
+
+    /// @return The number of distinct ranges.
+    size_t count() const;
+
+    /// @return @c true if there are no ranges in the container, @c false otherwise.
+    bool empty() const;
+
+    /// @return Iterator for the first range.
+    iterator
+    begin()
+    {
+      return _list.begin();
+    }
+    /// @return Iterator past the last node.
+    iterator
+    end()
+    {
+      return _list.end();
+    }
+    /// @return Iterator for the first range.
+    const_iterator
+    begin() const
+    {
+      return _list.begin();
+    }
+    /// @return Iterator past the last node.
+    const_iterator
+    end() const
+    {
+      return _list.end();
+    }
+
+    /// Remove all ranges.
+    void clear();
+
+  protected:
+    /** Find the lower bounding node.
+     *
+     * @param target Search value.
+     * @return The rightmost range that starts at or before @a target, or @c nullptr if all ranges start
+     * after @a target.
+     */
+    Node *lower_node(METRIC const &target);
+
+    /** Find the upper bound node.
+     *
+     * @param target Search value.
+     * @return The leftmoswt range that starts after @a target, or @c nullptr if all ranges start
+     * before @a target.
+     */
+    Node *upper_node(METRIC const &target);
+
+    /// @return First node in the tree.
+    Node *head();
+
+    /// @return Last node in the tree.
+    Node *tail();
+
+    /** Insert @a node before @a spot.
+     *
+     * @param spot Target node.
+     * @param node Node to insert.
+     */
+    void insert_before(Node *spot, Node *node);
+
+    /** Insert @a node after @a spot.
+     *
+     * @param spot Target node.
+     * @param node Node to insert.
+     */
+    void insert_after(Node *spot, Node *node);
+
+    /** Add @a node to tree as the first element.
+     *
+     * @param node Node to prepend.
+     *
+     * Invariant - @a node is first in order.
+     */
+    void prepend(Node *node);
+
+    /** Add @a node to tree as the last node.
+     *
+     * @param node Node to append.
+     *
+     * Invariant - @a node is last in order.
+     */
+    void append(Node *node);
+
+    /** Remove node from container and update container.
+     *
+     * @param node Node to remove.
+     */
+    void remove(Node *node);
+  };
+
+  // ---
+
+  template <typename METRIC, typename PAYLOAD>
+  PAYLOAD &
+  DiscreteSpace<METRIC, PAYLOAD>::Node::payload()
+  {
+    return _payload;
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  auto
+  DiscreteSpace<METRIC, PAYLOAD>::Node::assign(DiscreteSpace::range_type const &range) -> self_type &
+  {
+    _range = range;
+    return *this;
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  auto
+  DiscreteSpace<METRIC, PAYLOAD>::Node::assign(PAYLOAD const &payload) -> self_type &
+  {
+    _payload = payload;
+    return *this;
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  void
+  DiscreteSpace<METRIC, PAYLOAD>::Node::structure_fixup()
+  {
+    // Invariant: The hulls of all children are correct.
+    if (_left && _right) {
+      // If both children, local range must be inside the hull of the children and irrelevant.
+      _hull.assign(this->left()->_hull.min(), this->right()->_hull.max());
+    } else if (_left) {
+      _hull.assign(this->left()->_hull.min(), _range.max());
+    } else if (_right) {
+      _hull.assign(_range.min(), this->right()->_hull.max());
     } else {
-      zret = n; // this is a better candidate.
-      if (n->min() > target) {
+      _hull = _range;
+    }
+  }
+
+  // ---
+  // Discrete Space
+  // ---
+
+  template <typename METRIC, typename PAYLOAD> DiscreteSpace<METRIC, PAYLOAD>::~DiscreteSpace()
+  {
+    // Destruct all the payloads - the nodes themselves are in the arena and disappear with it.
+    for (auto &node : _list) {
+      std::destroy_at(&node.payload());
+    }
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  size_t
+  DiscreteSpace<METRIC, PAYLOAD>::count() const
+  {
+    return _list.count();
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  bool
+  DiscreteSpace<METRIC, PAYLOAD>::empty() const
+  {
+    return _list.empty();
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  auto
+  DiscreteSpace<METRIC, PAYLOAD>::head() -> Node *
+  {
+    return static_cast<Node *>(_list.head());
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  auto
+  DiscreteSpace<METRIC, PAYLOAD>::tail() -> Node *
+  {
+    return static_cast<Node *>(_list.tail());
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  auto
+  DiscreteSpace<METRIC, PAYLOAD>::find(METRIC const &metric) -> iterator
+  {
+    auto n = _root; // current node to test.
+    while (n) {
+      if (metric < n->min()) {
+        if (n->_hull.contains(metric)) {
+          n = n->left();
+        } else {
+          return this->end();
+        }
+      } else if (n->max() < metric) {
+        if (n->_hull.contains(metric)) {
+          n = n->right();
+        } else {
+          return this->end();
+        }
+      } else {
+        return _list.iterator_for(n);
+      }
+    }
+    return this->end();
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  auto
+  DiscreteSpace<METRIC, PAYLOAD>::find(METRIC const &metric) const -> const_iterator
+  {
+    return const_cast<self_type *>(this)->find(metric);
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  auto
+  DiscreteSpace<METRIC, PAYLOAD>::lower_node(METRIC const &target) -> Node *
+  {
+    Node *n    = _root;   // current node to test.
+    Node *zret = nullptr; // best node so far.
+
+    // Fast check for sequential insertion
+    if (auto ln = _list.tail(); ln != nullptr && ln->max() < target) {
+      return ln;
+    }
+
+    while (n) {
+      if (target < n->min()) {
         n = left(n);
       } else {
-        break;
-      }
-    }
-  }
-
-  // Must be past any intersecting range due to STL iteration being half open.
-  if (zret && (zret->min() <= target)) {
-    zret = next(zret);
-  }
-
-  return zret;
-}
-
-template <typename METRIC, typename PAYLOAD>
-auto
-DiscreteSpace<METRIC, PAYLOAD>::lower_bound(METRIC const &m) -> iterator {
-  auto n = this->lower_node(m);
-  return n ? iterator(n) : this->end();
-}
-
-template <typename METRIC, typename PAYLOAD>
-auto
-DiscreteSpace<METRIC, PAYLOAD>::upper_bound(METRIC const &m) -> iterator {
-  auto n = this->upper_node(m);
-  return n ? iterator(n) : this->end();
-}
-
-template <typename METRIC, typename PAYLOAD>
-auto
-DiscreteSpace<METRIC, PAYLOAD>::intersection(DiscreteSpace::range_type const &range) -> std::pair<iterator, iterator> {
-  // Quick checks for null intersection
-  if (this->head() == nullptr || // empty
-      this->head()->_range.min() > range.max() || // before first range
-      this->tail()->_range.max() < range.min() // after last range
-  ) {
-    return { this->end(), this->end() };
-  }
-  // Invariant - the search range intersects the convex hull of the ranges. This doesn't require the search
-  // range to intersect any of the actual ranges.
-
-  auto * lower = this->lower_node(range.min());
-  auto * upper = this->upper_node(range.max());
-
-  if (lower == nullptr) {
-    lower = this->head();
-  } else if (lower->_range.max() < range.min()) {
-    lower = next(lower); // lower is before @a range so @c next must be at or past.
-    if (lower->_range.min() > range.max()) { // @a range is in an uncolored gap.
-      return { this->end(), this->end() };
-    }
-  }
-
-  return { _list.iterator_for(lower), upper ? _list.iterator_for(upper) : this->end() };
-}
-
-template <typename METRIC, typename PAYLOAD>
-void
-DiscreteSpace<METRIC, PAYLOAD>::prepend(DiscreteSpace::Node *node) {
-  if (!_root) {
-    _root = node;
-  } else {
-    _root = static_cast<Node *>(_list.head()->set_child(node, Direction::LEFT)->rebalance_after_insert());
-  }
-  _list.prepend(node);
-}
-
-template <typename METRIC, typename PAYLOAD>
-void
-DiscreteSpace<METRIC, PAYLOAD>::append(DiscreteSpace::Node *node) {
-  if (!_root) {
-    _root = node;
-  } else {
-    // The last node has no right child, or it wouldn't be the last.
-    _root = static_cast<Node *>(_list.tail()->set_child(node, Direction::RIGHT)->rebalance_after_insert());
-  }
-  _list.append(node);
-}
-
-template <typename METRIC, typename PAYLOAD>
-void
-DiscreteSpace<METRIC, PAYLOAD>::remove(DiscreteSpace::Node *node) {
-  _root = static_cast<Node *>(node->remove());
-  _list.erase(node);
-  _fa.destroy(node);
-}
-
-template <typename METRIC, typename PAYLOAD>
-void
-DiscreteSpace<METRIC, PAYLOAD>::insert_before(DiscreteSpace::Node *spot, DiscreteSpace::Node *node) {
-  if (left(spot) == nullptr) {
-    spot->set_child(node, Direction::LEFT);
-  } else {
-    // If there's a left child, there's a previous node, therefore spot->_prev is valid.
-    // Further, the previous node must be the rightmost descendant node of the left subtree
-    // and therefore has no current right child.
-    spot->_prev->set_child(node, Direction::RIGHT);
-  }
-
-  _list.insert_before(spot, node);
-  _root = static_cast<Node *>(node->rebalance_after_insert());
-}
-
-template <typename METRIC, typename PAYLOAD>
-void
-DiscreteSpace<METRIC, PAYLOAD>::insert_after(DiscreteSpace::Node *spot, DiscreteSpace::Node *node) {
-  if (right(spot) == nullptr) {
-    spot->set_child(node, Direction::RIGHT);
-  } else {
-    // If there's a right child, there's a successor node, and therefore @a _next is valid.
-    // Further, the successor node must be the left most descendant of the right subtree
-    // therefore it doesn't have a left child.
-    spot->_next->set_child(node, Direction::LEFT);
-  }
-
-  _list.insert_after(spot, node);
-  _root = static_cast<Node *>(node->rebalance_after_insert());
-}
-
-template <typename METRIC, typename PAYLOAD>
-DiscreteSpace<METRIC, PAYLOAD> &
-DiscreteSpace<METRIC, PAYLOAD>::erase(DiscreteSpace::range_type const &range) {
-  Node *n = this->lower_node(range.min()); // current node.
-  while (n) {
-    auto nn = next(n);            // cache in case @a n disappears.
-    if (n->min() > range.max()) { // cleared the target range, done.
-      break;
-    }
-
-    if (n->max() >= range.min()) {     // some overlap
-      if (n->max() <= range.max()) {   // pure left overlap, clip.
-        if (n->min() >= range.min()) { // covered, remove.
-          this->remove(n);
-        } else { // stub on the left, clip to that.
-          n->assign_max(--metric_type{range.min()});
+        zret = n; // this is a better candidate.
+        if (n->max() < target) {
+          n = right(n);
+        } else {
+          break;
         }
-      } else if (n->min() >= range.min()) { // pure left overlap, clip.
-        n->assign_min(++metric_type{range.max()});
-      } else { // @a n covers @a range, must split.
-        auto y = _fa.make(range_type{n->min(), --metric_type{range.min()}}, n->payload());
-        n->assign_min(++metric_type{range.max()});
-        this->insert_before(n, y);
-        break;
       }
     }
-    n = nn;
+    return zret;
   }
-  return *this;
-}
 
-template <typename METRIC, typename PAYLOAD>
-DiscreteSpace<METRIC, PAYLOAD> &
-DiscreteSpace<METRIC, PAYLOAD>::mark(DiscreteSpace::range_type const &range, PAYLOAD const &payload) {
-  Node *n = this->lower_node(range.min()); // current node.
-  Node *x = nullptr;                        // New node, gets set if we re-use an existing one.
-  Node *y = nullptr;                        // Temporary for removing and advancing.
+  template <typename METRIC, typename PAYLOAD>
+  auto
+  DiscreteSpace<METRIC, PAYLOAD>::upper_node(METRIC const &target) -> Node *
+  {
+    Node *n    = _root;   // current node to test.
+    Node *zret = nullptr; // best node so far.
 
-  // Use carefully, only in situations where it is known there is no overflow.
-  auto max_plus_1 = ++metric_type{range.max()};
+    // Fast check if there is no range past @a target.
+    if (auto ln = _list.tail(); ln == nullptr || ln->min() <= target) {
+      return nullptr;
+    }
 
-  /*  We have lots of special cases here primarily to minimize memory
-      allocation by re-using an existing node as often as possible.
-  */
-  if (n) {
-    // Watch for wrap.
-    auto min_minus_1 = --metric_type{range.min()};
-    if (n->min() == range.min()) {
-      // Could be another span further left which is adjacent.
-      // Coalesce if the data is the same. min_minus_1 is OK because
-      // if there is a previous range, min is not zero.
-      Node *p = prev(n);
-      if (p && p->payload() == payload && p->max() == min_minus_1) {
-        x = p;
-        n = x; // need to back up n because frame of reference moved.
+    while (n) {
+      if (target > n->min()) {
+        n = right(n);
+      } else {
+        zret = n; // this is a better candidate.
+        if (n->min() > target) {
+          n = left(n);
+        } else {
+          break;
+        }
+      }
+    }
+
+    // Must be past any intersecting range due to STL iteration being half open.
+    if (zret && (zret->min() <= target)) {
+      zret = next(zret);
+    }
+
+    return zret;
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  auto
+  DiscreteSpace<METRIC, PAYLOAD>::lower_bound(METRIC const &m) -> iterator
+  {
+    auto n = this->lower_node(m);
+    return n ? iterator(n) : this->end();
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  auto
+  DiscreteSpace<METRIC, PAYLOAD>::upper_bound(METRIC const &m) -> iterator
+  {
+    auto n = this->upper_node(m);
+    return n ? iterator(n) : this->end();
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  auto
+  DiscreteSpace<METRIC, PAYLOAD>::intersection(DiscreteSpace::range_type const &range) -> std::pair<iterator, iterator>
+  {
+    // Quick checks for null intersection
+    if (this->head() == nullptr ||                  // empty
+        this->head()->_range.min() > range.max() || // before first range
+        this->tail()->_range.max() < range.min()    // after last range
+    ) {
+      return {this->end(), this->end()};
+    }
+    // Invariant - the search range intersects the convex hull of the ranges. This doesn't require the search
+    // range to intersect any of the actual ranges.
+
+    auto *lower = this->lower_node(range.min());
+    auto *upper = this->upper_node(range.max());
+
+    if (lower == nullptr) {
+      lower = this->head();
+    } else if (lower->_range.max() < range.min()) {
+      lower = next(lower);                     // lower is before @a range so @c next must be at or past.
+      if (lower->_range.min() > range.max()) { // @a range is in an uncolored gap.
+        return {this->end(), this->end()};
+      }
+    }
+
+    return {_list.iterator_for(lower), upper ? _list.iterator_for(upper) : this->end()};
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  void
+  DiscreteSpace<METRIC, PAYLOAD>::prepend(DiscreteSpace::Node *node)
+  {
+    if (!_root) {
+      _root = node;
+    } else {
+      _root = static_cast<Node *>(_list.head()->set_child(node, Direction::LEFT)->rebalance_after_insert());
+    }
+    _list.prepend(node);
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  void
+  DiscreteSpace<METRIC, PAYLOAD>::append(DiscreteSpace::Node *node)
+  {
+    if (!_root) {
+      _root = node;
+    } else {
+      // The last node has no right child, or it wouldn't be the last.
+      _root = static_cast<Node *>(_list.tail()->set_child(node, Direction::RIGHT)->rebalance_after_insert());
+    }
+    _list.append(node);
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  void
+  DiscreteSpace<METRIC, PAYLOAD>::remove(DiscreteSpace::Node *node)
+  {
+    _root = static_cast<Node *>(node->remove());
+    _list.erase(node);
+    _fa.destroy(node);
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  void
+  DiscreteSpace<METRIC, PAYLOAD>::insert_before(DiscreteSpace::Node *spot, DiscreteSpace::Node *node)
+  {
+    if (left(spot) == nullptr) {
+      spot->set_child(node, Direction::LEFT);
+    } else {
+      // If there's a left child, there's a previous node, therefore spot->_prev is valid.
+      // Further, the previous node must be the rightmost descendant node of the left subtree
+      // and therefore has no current right child.
+      spot->_prev->set_child(node, Direction::RIGHT);
+    }
+
+    _list.insert_before(spot, node);
+    _root = static_cast<Node *>(node->rebalance_after_insert());
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  void
+  DiscreteSpace<METRIC, PAYLOAD>::insert_after(DiscreteSpace::Node *spot, DiscreteSpace::Node *node)
+  {
+    if (right(spot) == nullptr) {
+      spot->set_child(node, Direction::RIGHT);
+    } else {
+      // If there's a right child, there's a successor node, and therefore @a _next is valid.
+      // Further, the successor node must be the left most descendant of the right subtree
+      // therefore it doesn't have a left child.
+      spot->_next->set_child(node, Direction::LEFT);
+    }
+
+    _list.insert_after(spot, node);
+    _root = static_cast<Node *>(node->rebalance_after_insert());
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  DiscreteSpace<METRIC, PAYLOAD> &
+  DiscreteSpace<METRIC, PAYLOAD>::erase(DiscreteSpace::range_type const &range)
+  {
+    Node *n = this->lower_node(range.min()); // current node.
+    while (n) {
+      auto nn = next(n);            // cache in case @a n disappears.
+      if (n->min() > range.max()) { // cleared the target range, done.
+        break;
+      }
+
+      if (n->max() >= range.min()) {     // some overlap
+        if (n->max() <= range.max()) {   // pure left overlap, clip.
+          if (n->min() >= range.min()) { // covered, remove.
+            this->remove(n);
+          } else { // stub on the left, clip to that.
+            n->assign_max(--metric_type{range.min()});
+          }
+        } else if (n->min() >= range.min()) { // pure left overlap, clip.
+          n->assign_min(++metric_type{range.max()});
+        } else { // @a n covers @a range, must split.
+          auto y = _fa.make(range_type{n->min(), --metric_type{range.min()}}, n->payload());
+          n->assign_min(++metric_type{range.max()});
+          this->insert_before(n, y);
+          break;
+        }
+      }
+      n = nn;
+    }
+    return *this;
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  DiscreteSpace<METRIC, PAYLOAD> &
+  DiscreteSpace<METRIC, PAYLOAD>::mark(DiscreteSpace::range_type const &range, PAYLOAD const &payload)
+  {
+    Node *n = this->lower_node(range.min()); // current node.
+    Node *x = nullptr;                       // New node, gets set if we re-use an existing one.
+    Node *y = nullptr;                       // Temporary for removing and advancing.
+
+    // Use carefully, only in situations where it is known there is no overflow.
+    auto max_plus_1 = ++metric_type{range.max()};
+
+    /*  We have lots of special cases here primarily to minimize memory
+        allocation by re-using an existing node as often as possible.
+    */
+    if (n) {
+      // Watch for wrap.
+      auto min_minus_1 = --metric_type{range.min()};
+      if (n->min() == range.min()) {
+        // Could be another span further left which is adjacent.
+        // Coalesce if the data is the same. min_minus_1 is OK because
+        // if there is a previous range, min is not zero.
+        Node *p = prev(n);
+        if (p && p->payload() == payload && p->max() == min_minus_1) {
+          x = p;
+          n = x; // need to back up n because frame of reference moved.
+          x->assign_max(range.max());
+        } else if (n->max() <= range.max()) {
+          // Span will be subsumed by request span so it's available for use.
+          x = n;
+          x->assign_max(range.max()).assign(payload);
+        } else if (n->payload() == payload) {
+          return *this; // request is covered by existing span with the same data
+        } else {
+          // request span is covered by existing span.
+          x = _fa.make(range, payload); //
+          n->assign_min(max_plus_1);    // clip existing.
+          this->insert_before(n, x);
+          return *this;
+        }
+      } else if (n->payload() == payload && n->max() >= min_minus_1) {
+        // min_minus_1 is safe here because n->min() < min so min is not zero.
+        x = n;
+        // If the existing span covers the requested span, we're done.
+        if (x->max() >= range.max()) {
+          return *this;
+        }
         x->assign_max(range.max());
       } else if (n->max() <= range.max()) {
-        // Span will be subsumed by request span so it's available for use.
-        x = n;
-        x->assign_max(range.max()).assign(payload);
-      } else if (n->payload() == payload) {
-        return *this; // request is covered by existing span with the same data
+        // Can only have left skew overlap, otherwise disjoint.
+        // Clip if overlap.
+        if (n->max() >= range.min()) {
+          n->assign_max(min_minus_1);
+        } else if (nullptr != (y = next(n)) && y->max() <= range.max()) {
+          // because @a n was selected as the minimum it must be the case that
+          // y->min >= min (or y would have been selected). Therefore in this
+          // case the request covers the next node therefore it can be reused.
+          x = y;
+          x->assign(range).assign(payload).ripple_structure_fixup();
+          n = x; // this gets bumped again, which is correct.
+        }
       } else {
-        // request span is covered by existing span.
-        x = _fa.make(range, payload); //
-        n->assign_min(max_plus_1);    // clip existing.
-        this->insert_before(n, x);
-        return *this;
-      }
-    } else if (n->payload() == payload && n->max() >= min_minus_1) {
-      // min_minus_1 is safe here because n->min() < min so min is not zero.
-      x = n;
-      // If the existing span covers the requested span, we're done.
-      if (x->max() >= range.max()) {
-        return *this;
-      }
-      x->assign_max(range.max());
-    } else if (n->max() <= range.max()) {
-      // Can only have left skew overlap, otherwise disjoint.
-      // Clip if overlap.
-      if (n->max() >= range.min()) {
+        // Existing span covers new span but with a different payload.
+        // We split it, put the new span in between and we're done.
+        // max_plus_1 is valid because n->max() > max.
+        Node *r;
+        x = _fa.make(range, payload);
+        r = _fa.make(range_type{max_plus_1, n->max()}, n->payload());
         n->assign_max(min_minus_1);
-      } else if (nullptr != (y = next(n)) && y->max() <= range.max()) {
-        // because @a n was selected as the minimum it must be the case that
-        // y->min >= min (or y would have been selected). Therefore in this
-        // case the request covers the next node therefore it can be reused.
-        x = y;
-        x->assign(range).assign(payload).ripple_structure_fixup();
-        n = x; // this gets bumped again, which is correct.
+        this->insert_after(n, x);
+        this->insert_after(x, r);
+        return *this; // done.
+      }
+      n = next(n); // lower bound span handled, move on.
+      if (!x) {
+        x = _fa.make(range, payload);
+        if (n) {
+          this->insert_before(n, x);
+        } else {
+          this->append(x); // note that since n == 0 we'll just return.
+        }
+      }
+    } else if (nullptr != (n = this->head()) &&                    // at least one node in tree.
+               n->payload() == payload &&                          // payload matches
+               (n->max() <= range.max() || n->min() <= max_plus_1) // overlap or adj.
+    ) {
+      // Same payload with overlap, re-use.
+      x = n;
+      n = next(n);
+      x->assign_min(range.min());
+      if (x->max() < range.max()) {
+        x->assign_max(range.max());
       }
     } else {
-      // Existing span covers new span but with a different payload.
-      // We split it, put the new span in between and we're done.
-      // max_plus_1 is valid because n->max() > max.
-      Node *r;
       x = _fa.make(range, payload);
-      r = _fa.make(range_type{max_plus_1, n->max()}, n->payload());
-      n->assign_max(min_minus_1);
-      this->insert_after(n, x);
-      this->insert_after(x, r);
-      return *this; // done.
+      this->prepend(x);
     }
-    n = next(n); // lower bound span handled, move on.
-    if (!x) {
-      x = _fa.make(range, payload);
-      if (n) {
-        this->insert_before(n, x);
-      } else {
-        this->append(x); // note that since n == 0 we'll just return.
+
+    // At this point, @a x has the node for this span and all existing spans of
+    // interest start at or past this span.
+    while (n) {
+      if (n->max() <= range.max()) { // completely covered, drop span, continue
+        y = n;
+        n = next(n);
+        this->remove(y);
+      } else if (max_plus_1 < n->min()) { // no overlap, done.
+        break;
+      } else if (n->payload() == payload) { // skew overlap or adj., same payload
+        x->assign_max(n->max());
+        y = n;
+        n = next(n);
+        this->remove(y);
+      } else if (n->min() <= range.max()) { // skew overlap different payload
+        n->assign_min(max_plus_1);
+        break;
+      } else { // n->min() > range.max(), different payloads - done.
+        break;
       }
     }
-  } else if (nullptr != (n = this->head()) &&                    // at least one node in tree.
-             n->payload() == payload &&                          // payload matches
-             (n->max() <= range.max() || n->min() <= max_plus_1) // overlap or adj.
-  ) {
-    // Same payload with overlap, re-use.
-    x = n;
-    n = next(n);
-    x->assign_min(range.min());
-    if (x->max() < range.max()) {
-      x->assign_max(range.max());
-    }
-  } else {
-    x = _fa.make(range, payload);
-    this->prepend(x);
+
+    return *this;
   }
 
-  // At this point, @a x has the node for this span and all existing spans of
-  // interest start at or past this span.
-  while (n) {
-    if (n->max() <= range.max()) { // completely covered, drop span, continue
-      y = n;
-      n = next(n);
-      this->remove(y);
-    } else if (max_plus_1 < n->min()) { // no overlap, done.
-      break;
-    } else if (n->payload() == payload) { // skew overlap or adj., same payload
-      x->assign_max(n->max());
-      y = n;
-      n = next(n);
-      this->remove(y);
-    } else if (n->min() <= range.max()) { // skew overlap different payload
-      n->assign_min(max_plus_1);
-      break;
-    } else { // n->min() > range.max(), different payloads - done.
-      break;
-    }
-  }
+  template <typename METRIC, typename PAYLOAD>
+  DiscreteSpace<METRIC, PAYLOAD> &
+  DiscreteSpace<METRIC, PAYLOAD>::fill(DiscreteSpace::range_type const &range, PAYLOAD const &payload)
+  {
+    // Rightmost node of interest with n->min() <= min.
+    Node *n = this->lower_node(range.min());
+    Node *x = nullptr; // New node (if any).
+    // Need copies because we will modify these.
+    auto min = range.min();
+    auto max = range.max();
 
-  return *this;
-}
-
-template <typename METRIC, typename PAYLOAD>
-DiscreteSpace<METRIC, PAYLOAD> &
-DiscreteSpace<METRIC, PAYLOAD>::fill(DiscreteSpace::range_type const &range, PAYLOAD const &payload) {
-  // Rightmost node of interest with n->min() <= min.
-  Node *n = this->lower_node(range.min());
-  Node *x = nullptr; // New node (if any).
-  // Need copies because we will modify these.
-  auto min = range.min();
-  auto max = range.max();
-
-  // Handle cases involving a node of interest to the left of the
-  // range.
-  if (n) {
-    if (n->min() < min) {
-      auto min_1 = min;
-      --min_1;                // dec is OK because min isn't zero.
-      if (n->max() < min_1) { // no overlap, not adjacent.
-        n = next(n);
-      } else if (n->max() >= max) { // incoming range is covered, just discard.
-        return *this;
-      } else if (n->payload() != payload) { // different payload, clip range on left.
-        min = n->max();
-        ++min;
-        n = next(n);
-      } else { // skew overlap or adjacent to predecessor with same payload, use node and continue.
-        x = n;
-        n = next(n);
-      }
-    }
-  } else {
-    n = this->head();
-  }
-
-  // Work through the rest of the nodes of interest.
-  // Invariant: n->min() >= min
-
-  // Careful here -- because max_plus1 might wrap we need to use it only if we can be certain it
-  // didn't. This is done by ordering the range tests so that when max_plus1 is used when we know
-  // there exists a larger value than max.
-  auto max_plus1 = max;
-  ++max_plus1;
-
-  /* Notes:
-     - max (and thence also max_plus1) never change during the loop.
-     - we must have either x != 0 or adjust min but not both for each loop iteration.
-  */
-  while (n) {
-    if (n->payload() == payload) {
-      if (x) {
-        if (n->max() <= max) { // next range is covered, so we can remove and continue.
-          this->remove(n);
-          n = next(x);
-        } else if (n->min() <= max_plus1) {
-          // Overlap or adjacent with larger max - absorb and finish.
-          x->assign_max(n->max());
-          this->remove(n);
-          return *this;
-        } else {
-          // have the space to finish off the range.
-          x->assign_max(max);
-          return *this;
-        }
-      } else {                 // not carrying a span.
-        if (n->max() <= max) { // next range is covered - use it.
-          x = n;
-          x->assign_min(min);
+    // Handle cases involving a node of interest to the left of the
+    // range.
+    if (n) {
+      if (n->min() < min) {
+        auto min_1 = min;
+        --min_1;                // dec is OK because min isn't zero.
+        if (n->max() < min_1) { // no overlap, not adjacent.
           n = next(n);
-        } else if (n->min() <= max_plus1) {
-          n->assign_min(min);
+        } else if (n->max() >= max) { // incoming range is covered, just discard.
           return *this;
-        } else { // no overlap, space to complete range.
-          this->insert_before(n, _fa.make(min, max, payload));
-          return *this;
-        }
-      }
-    } else { // different payload
-      if (x) {
-        if (max < n->min()) { // range ends before n starts, done.
-          x->assign_max(max);
-          return *this;
-        } else if (max <= n->max()) { // range ends before n, done.
-          x->assign_max(--metric_type(n->min()));
-          return *this;
-        } else { // n is contained in range, skip over it.
-          x->assign_max(--metric_type(n->min()));
-          x   = nullptr;
-          min = n->max();
-          ++min; // OK because n->max() maximal => next is null.
-          n = next(n);
-        }
-      } else {                // no carry node.
-        if (max < n->min()) { // entirely before next span.
-          this->insert_before(n, _fa.make(min, max, payload));
-          return *this;
-        } else {
-          if (min < n->min()) { // leading section, need node.
-            auto y = _fa.make(min, --metric_type(n->min()), payload);
-            this->insert_before(n, y);
-          }
-          if (max <= n->max()) { // nothing past node
-            return *this;
-          }
+        } else if (n->payload() != payload) { // different payload, clip range on left.
           min = n->max();
           ++min;
           n = next(n);
+        } else { // skew overlap or adjacent to predecessor with same payload, use node and continue.
+          x = n;
+          n = next(n);
         }
       }
+    } else {
+      n = this->head();
     }
-  }
-  // Invariant: min is larger than any existing range maximum.
-  if (x) {
-    x->assign_max(max);
-  } else {
-    this->append(_fa.make(min, max, payload));
-  }
-  return *this;
-}
 
-template <typename METRIC, typename PAYLOAD>
-template <typename F, typename U>
-auto
-DiscreteSpace<METRIC, PAYLOAD>::blend(DiscreteSpace::range_type const &range, U const &color, F &&blender) -> self_type & {
-  // Do a base check for the color to use on unmapped values. If self blending on @a color
-  // is @c false, then do not color currently unmapped values.
-  PAYLOAD plain_color{};                            // color to paint uncolored metrics.
-  bool plain_color_p = blender(plain_color, color); // start with default and blend in @a color.
+    // Work through the rest of the nodes of interest.
+    // Invariant: n->min() >= min
 
-  auto node_cleaner = [&](Node *ptr) -> void { _fa.destroy(ptr); };
-  // Used to hold a temporary blended node - @c release if put in space, otherwise cleaned up.
-  using unique_node = std::unique_ptr<Node, decltype(node_cleaner)>;
+    // Careful here -- because max_plus1 might wrap we need to use it only if we can be certain it
+    // didn't. This is done by ordering the range tests so that when max_plus1 is used when we know
+    // there exists a larger value than max.
+    auto max_plus1 = max;
+    ++max_plus1;
 
-  // Rightmost node of interest with n->min() <= range.min().
-  Node *n = this->lower_node(range.min());
-
-  // This doesn't change, compute outside loop.
-  auto range_max_plus_1 = range.max();
-  ++range_max_plus_1; // only use in contexts where @a max < METRIC max value.
-
-  // Update every loop to track what remains to be filled.
-  auto remaining = range;
-
-  if (nullptr == n) {
-    n = this->head();
-  }
-
-  // Process @a n, covering the values from the previous range to @a n.max
-  while (n) {
-    // If there's no overlap, skip because this will be checked next loop, or it's the last node
-    // and will be checked post loop. Loop logic is simpler if n->max() >= remaining.min()
-    if (n->max() < remaining.min()) {
-      n = next(n);
-      continue;
-    }
-    // Invariant - n->max() >= remaining.min();
-
-    // Check for left extension. If found, clip that node to be adjacent and put in a
-    // temporary that covers the overlap with the original payload.
-    if (n->min() < remaining.min()) {
-      // @a fill is inserted iff n->max() < remaining.max(), in which case the max is correct.
-      // This is needed in other cases only for the color blending result.
-      unique_node fill{_fa.make(remaining.min(), n->max(), n->payload()), node_cleaner};
-      bool fill_p = blender(fill->payload(), color); // fill or clear?
-
-      if (fill_p) {
-        bool same_color_p = fill->payload() == n->payload();
-        if (same_color_p && n->max() >= remaining.max()) {
-          return *this; // incoming range is completely covered by @a n in the same color, done.
-        }
-        if (!same_color_p) {
-          auto fn    = fill.release();
-          auto n_max = n->max();                         // save this so @a n can be clipped.
-          n->assign_max(--metric_type(remaining.min())); // clip @a n down.
-          this->insert_after(n, fn);                     // add intersection node in different color.
-          if (n_max > remaining.max()) {                 // right extent too - split and done.
-            fn->assign_max(remaining.max());             // fill node stops at end of target range.
-            this->insert_after(fn, _fa.make(++metric_type(remaining.max()), n_max, n->payload()));
+    /* Notes:
+       - max (and thence also max_plus1) never change during the loop.
+       - we must have either x != 0 or adjust min but not both for each loop iteration.
+    */
+    while (n) {
+      if (n->payload() == payload) {
+        if (x) {
+          if (n->max() <= max) { // next range is covered, so we can remove and continue.
+            this->remove(n);
+            n = next(x);
+          } else if (n->min() <= max_plus1) {
+            // Overlap or adjacent with larger max - absorb and finish.
+            x->assign_max(n->max());
+            this->remove(n);
+            return *this;
+          } else {
+            // have the space to finish off the range.
+            x->assign_max(max);
             return *this;
           }
-          n = fn; // skip to use new node as current node.
+        } else {                 // not carrying a span.
+          if (n->max() <= max) { // next range is covered - use it.
+            x = n;
+            x->assign_min(min);
+            n = next(n);
+          } else if (n->min() <= max_plus1) {
+            n->assign_min(min);
+            return *this;
+          } else { // no overlap, space to complete range.
+            this->insert_before(n, _fa.make(min, max, payload));
+            return *this;
+          }
         }
-        remaining.assign_min(++metric_type(n->max())); // going to fill up n->max(), clip target.
-      } else {                                         // clear, don't fill.
-        auto n_r = n->range();                         // cache to avoid ordering requirements.
-        if (n_r.max() > remaining.max()) {             // overhang on the right, must split.
-          fill.release();                              // not going to use it,
-          n->assign_min(++metric_type(remaining.max()));
-          this->insert_before(n, _fa.make(n_r.min(), --metric_type(remaining.min()), n->payload()));
-          return *this;
+      } else { // different payload
+        if (x) {
+          if (max < n->min()) { // range ends before n starts, done.
+            x->assign_max(max);
+            return *this;
+          } else if (max <= n->max()) { // range ends before n, done.
+            x->assign_max(--metric_type(n->min()));
+            return *this;
+          } else { // n is contained in range, skip over it.
+            x->assign_max(--metric_type(n->min()));
+            x   = nullptr;
+            min = n->max();
+            ++min; // OK because n->max() maximal => next is null.
+            n = next(n);
+          }
+        } else {                // no carry node.
+          if (max < n->min()) { // entirely before next span.
+            this->insert_before(n, _fa.make(min, max, payload));
+            return *this;
+          } else {
+            if (min < n->min()) { // leading section, need node.
+              auto y = _fa.make(min, --metric_type(n->min()), payload);
+              this->insert_before(n, y);
+            }
+            if (max <= n->max()) { // nothing past node
+              return *this;
+            }
+            min = n->max();
+            ++min;
+            n = next(n);
+          }
         }
-        n->assign_max(--metric_type(remaining.min())); // clip @a n down.
-        if (n_r.max() == remaining.max()) {
-          return *this;
-        }
-        remaining.assign_min(++metric_type(n_r.max()));
       }
-      continue;
+    }
+    // Invariant: min is larger than any existing range maximum.
+    if (x) {
+      x->assign_max(max);
+    } else {
+      this->append(_fa.make(min, max, payload));
+    }
+    return *this;
+  }
+
+  template <typename METRIC, typename PAYLOAD>
+  template <typename F, typename U>
+  auto
+  DiscreteSpace<METRIC, PAYLOAD>::blend(DiscreteSpace::range_type const &range, U const &color, F &&blender) -> self_type &
+  {
+    // Do a base check for the color to use on unmapped values. If self blending on @a color
+    // is @c false, then do not color currently unmapped values.
+    PAYLOAD plain_color{};                            // color to paint uncolored metrics.
+    bool plain_color_p = blender(plain_color, color); // start with default and blend in @a color.
+
+    auto node_cleaner = [&](Node *ptr) -> void { _fa.destroy(ptr); };
+    // Used to hold a temporary blended node - @c release if put in space, otherwise cleaned up.
+    using unique_node = std::unique_ptr<Node, decltype(node_cleaner)>;
+
+    // Rightmost node of interest with n->min() <= range.min().
+    Node *n = this->lower_node(range.min());
+
+    // This doesn't change, compute outside loop.
+    auto range_max_plus_1 = range.max();
+    ++range_max_plus_1; // only use in contexts where @a max < METRIC max value.
+
+    // Update every loop to track what remains to be filled.
+    auto remaining = range;
+
+    if (nullptr == n) {
+      n = this->head();
     }
 
-    Node *pred = prev(n);
-    // invariant
-    // - remaining.min() <= n->max()
-    // - !pred || pred->max() < remaining.min()
-
-    // Calculate and cache key relationships between @a n and @a remaining.
-
-    // @a n extends past @a remaining, so the trailing segment must be dealt with.
-    bool right_ext_p = n->max() > remaining.max();
-    // @a n strictly right overlaps with @a remaining.
-    bool right_overlap_p = remaining.contains(n->min());
-    // @a n is adjacent on the right to @a remaining.
-    bool right_adj_p = !right_overlap_p && remaining.is_left_adjacent_to(n->range());
-    // @a n has the same color as would be used for unmapped values.
-    bool n_plain_colored_p = plain_color_p && (n->payload() == plain_color);
-
-    // Check for no right overlap - that means @a n is past the target range.
-    // It may be possible to extend @a n or the previous range to cover
-    // the target range. Regardless, all of @a range can be filled at this point.
-    if (!right_overlap_p) {
-      // @a pred has the same color as would be used for unmapped values
-      // and is adjacent to @a remaining.
-      bool pred_plain_colored_p = pred && ++metric_type(pred->max()) == remaining.min() && pred->payload() == plain_color;
-
-      if (right_adj_p && n_plain_colored_p) { // can pull @a n left to cover
-        n->assign_min(remaining.min());
-        if (pred_plain_colored_p) { // if that touches @a pred with same color, collapse.
-          auto pred_min = pred->min();
-          this->remove(pred);
-          n->assign_min(pred_min);
-        }
-      } else if (pred_plain_colored_p) { // can pull @a pred right to cover.
-        pred->assign_max(remaining.max());
-      } else if (!remaining.empty() && plain_color_p) { // Must add new range if plain color valid.
-        this->insert_before(n, _fa.make(remaining.min(), remaining.max(), plain_color));
+    // Process @a n, covering the values from the previous range to @a n.max
+    while (n) {
+      // If there's no overlap, skip because this will be checked next loop, or it's the last node
+      // and will be checked post loop. Loop logic is simpler if n->max() >= remaining.min()
+      if (n->max() < remaining.min()) {
+        n = next(n);
+        continue;
       }
-      return *this;
-    }
+      // Invariant - n->max() >= remaining.min();
 
-    // Invariant: @n has right overlap with @a remaining
+      // Check for left extension. If found, clip that node to be adjacent and put in a
+      // temporary that covers the overlap with the original payload.
+      if (n->min() < remaining.min()) {
+        // @a fill is inserted iff n->max() < remaining.max(), in which case the max is correct.
+        // This is needed in other cases only for the color blending result.
+        unique_node fill{_fa.make(remaining.min(), n->max(), n->payload()), node_cleaner};
+        bool fill_p = blender(fill->payload(), color); // fill or clear?
 
-    // If there's a gap on the left, fill from @a r.min to @a n.min - 1
-    if (plain_color_p && remaining.min() < n->min()) {
-      if (n->payload() == plain_color) {
-        if (pred && pred->payload() == n->payload()) {
-          auto pred_min{pred->min()};
-          this->remove(pred);
-          n->assign_min(pred_min);
-        } else {
+        if (fill_p) {
+          bool same_color_p = fill->payload() == n->payload();
+          if (same_color_p && n->max() >= remaining.max()) {
+            return *this; // incoming range is completely covered by @a n in the same color, done.
+          }
+          if (!same_color_p) {
+            auto fn    = fill.release();
+            auto n_max = n->max();                         // save this so @a n can be clipped.
+            n->assign_max(--metric_type(remaining.min())); // clip @a n down.
+            this->insert_after(n, fn);                     // add intersection node in different color.
+            if (n_max > remaining.max()) {                 // right extent too - split and done.
+              fn->assign_max(remaining.max());             // fill node stops at end of target range.
+              this->insert_after(fn, _fa.make(++metric_type(remaining.max()), n_max, n->payload()));
+              return *this;
+            }
+            n = fn; // skip to use new node as current node.
+          }
+          remaining.assign_min(++metric_type(n->max())); // going to fill up n->max(), clip target.
+        } else {                                         // clear, don't fill.
+          auto n_r = n->range();                         // cache to avoid ordering requirements.
+          if (n_r.max() > remaining.max()) {             // overhang on the right, must split.
+            fill.release();                              // not going to use it,
+            n->assign_min(++metric_type(remaining.max()));
+            this->insert_before(n, _fa.make(n_r.min(), --metric_type(remaining.min()), n->payload()));
+            return *this;
+          }
+          n->assign_max(--metric_type(remaining.min())); // clip @a n down.
+          if (n_r.max() == remaining.max()) {
+            return *this;
+          }
+          remaining.assign_min(++metric_type(n_r.max()));
+        }
+        continue;
+      }
+
+      Node *pred = prev(n);
+      // invariant
+      // - remaining.min() <= n->max()
+      // - !pred || pred->max() < remaining.min()
+
+      // Calculate and cache key relationships between @a n and @a remaining.
+
+      // @a n extends past @a remaining, so the trailing segment must be dealt with.
+      bool right_ext_p = n->max() > remaining.max();
+      // @a n strictly right overlaps with @a remaining.
+      bool right_overlap_p = remaining.contains(n->min());
+      // @a n is adjacent on the right to @a remaining.
+      bool right_adj_p = !right_overlap_p && remaining.is_left_adjacent_to(n->range());
+      // @a n has the same color as would be used for unmapped values.
+      bool n_plain_colored_p = plain_color_p && (n->payload() == plain_color);
+
+      // Check for no right overlap - that means @a n is past the target range.
+      // It may be possible to extend @a n or the previous range to cover
+      // the target range. Regardless, all of @a range can be filled at this point.
+      if (!right_overlap_p) {
+        // @a pred has the same color as would be used for unmapped values
+        // and is adjacent to @a remaining.
+        bool pred_plain_colored_p = pred && ++metric_type(pred->max()) == remaining.min() && pred->payload() == plain_color;
+
+        if (right_adj_p && n_plain_colored_p) { // can pull @a n left to cover
           n->assign_min(remaining.min());
+          if (pred_plain_colored_p) { // if that touches @a pred with same color, collapse.
+            auto pred_min = pred->min();
+            this->remove(pred);
+            n->assign_min(pred_min);
+          }
+        } else if (pred_plain_colored_p) { // can pull @a pred right to cover.
+          pred->assign_max(remaining.max());
+        } else if (!remaining.empty() && plain_color_p) { // Must add new range if plain color valid.
+          this->insert_before(n, _fa.make(remaining.min(), remaining.max(), plain_color));
         }
-      } else {
-        auto n_min_minus_1{n->min()};
-        --n_min_minus_1;
-        if (pred && pred->payload() == plain_color) {
-          pred->assign_max(n_min_minus_1);
+        return *this;
+      }
+
+      // Invariant: @n has right overlap with @a remaining
+
+      // If there's a gap on the left, fill from @a r.min to @a n.min - 1
+      if (plain_color_p && remaining.min() < n->min()) {
+        if (n->payload() == plain_color) {
+          if (pred && pred->payload() == n->payload()) {
+            auto pred_min{pred->min()};
+            this->remove(pred);
+            n->assign_min(pred_min);
+          } else {
+            n->assign_min(remaining.min());
+          }
         } else {
-          this->insert_before(n, _fa.make(remaining.min(), n_min_minus_1, plain_color));
+          auto n_min_minus_1{n->min()};
+          --n_min_minus_1;
+          if (pred && pred->payload() == plain_color) {
+            pred->assign_max(n_min_minus_1);
+          } else {
+            this->insert_before(n, _fa.make(remaining.min(), n_min_minus_1, plain_color));
+          }
         }
       }
-    }
 
-    // Invariant: Space in @a range and to the left of @a n has been filled.
+      // Invariant: Space in @a range and to the left of @a n has been filled.
 
-    // Create a node with the blend for the overlap and then update / replace @a n as needed.
-    auto max{right_ext_p ? remaining.max() : n->max()}; // smallest boundary of range and @a n.
-    unique_node fill{_fa.make(n->min(), max, n->payload()), node_cleaner};
-    bool fill_p = blender(fill->payload(), color); // fill or clear?
-    auto next_n = next(n);                         // cache this in case @a n is removed.
-    remaining.assign_min(++METRIC{fill->max()});   // Update what is left to fill.
+      // Create a node with the blend for the overlap and then update / replace @a n as needed.
+      auto max{right_ext_p ? remaining.max() : n->max()}; // smallest boundary of range and @a n.
+      unique_node fill{_fa.make(n->min(), max, n->payload()), node_cleaner};
+      bool fill_p = blender(fill->payload(), color); // fill or clear?
+      auto next_n = next(n);                         // cache this in case @a n is removed.
+      remaining.assign_min(++METRIC{fill->max()});   // Update what is left to fill.
 
-    // Clean up the range for @a n
-    if (fill_p) {
-      // Check if @a pred is suitable for extending right to cover the target range.
-      bool pred_adj_p =
-        nullptr != (pred = prev(n)) && pred->range().is_left_adjacent_to(fill->range()) && pred->payload() == fill->payload();
+      // Clean up the range for @a n
+      if (fill_p) {
+        // Check if @a pred is suitable for extending right to cover the target range.
+        bool pred_adj_p =
+          nullptr != (pred = prev(n)) && pred->range().is_left_adjacent_to(fill->range()) && pred->payload() == fill->payload();
 
-      if (right_ext_p) {
-        if (n->payload() == fill->payload()) {
-          n->assign_min(fill->min());
+        if (right_ext_p) {
+          if (n->payload() == fill->payload()) {
+            n->assign_min(fill->min());
+          } else {
+            n->assign_min(range_max_plus_1);
+            if (pred_adj_p) {
+              pred->assign_max(fill->max());
+            } else {
+              this->insert_before(n, fill.release());
+            }
+          }
+          return *this; // @a n extends past @a remaining, -> all done.
         } else {
-          n->assign_min(range_max_plus_1);
+          // Collapse in to previous range if it's adjacent and the color matches.
           if (pred_adj_p) {
+            this->remove(n);
             pred->assign_max(fill->max());
           } else {
             this->insert_before(n, fill.release());
+            this->remove(n);
           }
         }
-        return *this; // @a n extends past @a remaining, -> all done.
+      } else if (right_ext_p) {
+        n->assign_min(range_max_plus_1);
+        return *this;
       } else {
-        // Collapse in to previous range if it's adjacent and the color matches.
-        if (pred_adj_p) {
-          this->remove(n);
-          pred->assign_max(fill->max());
-        } else {
-          this->insert_before(n, fill.release());
-          this->remove(n);
-        }
+        this->remove(n);
       }
-    } else if (right_ext_p) {
-      n->assign_min(range_max_plus_1);
-      return *this;
-    } else {
-      this->remove(n);
+
+      // Everything up to @a n.max is correct, time to process next node.
+      n = next_n;
     }
 
-    // Everything up to @a n.max is correct, time to process next node.
-    n = next_n;
-  }
-
-  // Arriving here means there are no more ranges past @a range (those cases return from the loop).
-  // Therefore the final fill node is always last in the tree.
-  if (plain_color_p && !remaining.empty()) {
-    // Check if the last node can be extended to cover because it's left adjacent.
-    // Can decrement @a range_min because if there's a range to the left, @a range_min is not minimal.
-    n = _list.tail();
-    if (n && n->max() >= --metric_type{remaining.min()} && n->payload() == plain_color) {
-      n->assign_max(range.max());
-    } else {
-      this->append(_fa.make(remaining.min(), remaining.max(), plain_color));
+    // Arriving here means there are no more ranges past @a range (those cases return from the loop).
+    // Therefore the final fill node is always last in the tree.
+    if (plain_color_p && !remaining.empty()) {
+      // Check if the last node can be extended to cover because it's left adjacent.
+      // Can decrement @a range_min because if there's a range to the left, @a range_min is not minimal.
+      n = _list.tail();
+      if (n && n->max() >= --metric_type{remaining.min()} && n->payload() == plain_color) {
+        n->assign_max(range.max());
+      } else {
+        this->append(_fa.make(remaining.min(), remaining.max(), plain_color));
+      }
     }
+
+    return *this;
   }
 
-  return *this;
-}
-
-template <typename METRIC, typename PAYLOAD>
-void
-DiscreteSpace<METRIC, PAYLOAD>::clear()
-{
-  for (auto &node : _list) {
-    std::destroy_at(&node.payload());
+  template <typename METRIC, typename PAYLOAD>
+  void
+  DiscreteSpace<METRIC, PAYLOAD>::clear()
+  {
+    for (auto &node : _list) {
+      std::destroy_at(&node.payload());
+    }
+    _list.clear();
+    _root = nullptr;
+    _arena.clear();
+    _fa.clear();
   }
-  _list.clear();
-  _root = nullptr;
-  _arena.clear();
-  _fa.clear();
-}
 
-}} // namespace swoc::SWOC_VERSION_NS
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/include/swoc/Errata.h
+++ b/code/include/swoc/Errata.h
@@ -49,422 +49,430 @@
 #include "swoc/bwf_base.h"
 #include "swoc/IntrusiveDList.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
 
-/** Class to hold a stack of error messages (the "errata"). This is a smart handle class, which
- * wraps the actual data and can therefore be treated a value type with cheap copy semantics.
- * Default construction is very cheap.
- */
-class Errata {
-public:
-  using code_type     = std::error_code; ///< Type for message code.
-  using severity_type = uint8_t;         ///< Underlying type for @c Severity.
-
-  /// Severity value for an instance.
-  /// This provides conversion to a numeric value, but not from. The result is constructors must be
-  /// passed an explicit serverity, avoiding ambiguity with other possible numeric arguments.
-  struct Severity {
-    severity_type _raw; ///< Severity numeric value
-
-    explicit constexpr Severity(severity_type n) : _raw(n) {} ///< No implicit conversion from numeric.
-
-    Severity(Severity const &that) = default;
-    Severity &operator=(Severity const &that) = default;
-
-    operator severity_type() const { return _raw; } ///< Implicit conversion to numeric.
-  };
-
-  /// Code used if not specified.
-  static inline const code_type DEFAULT_CODE;
-  /// Severity reported if severity not set.
-  static Severity DEFAULT_SEVERITY;
-  /// Severity level at which the instance is a failure of some sort.
-  static Severity FAILURE_SEVERITY;
-  /// Minimum severity level for an @c Annotation.
-  /// If an @c Annotation is added with an explicit @c Severity that is smaller the @c Annotation is discarded instead of added.
-  /// This defaults to zero and no filtering is done unless it is overwritten.
-  static Severity FILTER_SEVERITY;
-
-  /// Mapping of severity to string.
-  /// Values larger than the span size will be rendered as numbers.
-  /// Defaults to an empty span, meaning all severities will be printed as integers.
-  static MemSpan<TextView const> SEVERITY_NAMES;
-
-  /** An annotation to the Errata consisting of a severity and informative text.
-   *
-   * The text cannot be changed because of memory ownership risks.
+  /** Class to hold a stack of error messages (the "errata"). This is a smart handle class, which
+   * wraps the actual data and can therefore be treated a value type with cheap copy semantics.
+   * Default construction is very cheap.
    */
-  class Annotation {
-    using self_type = Annotation; ///< Self reference type.
-
+  class Errata
+  {
   public:
-    /// Reset to the message to default state.
-    self_type &clear();
+    using code_type     = std::error_code; ///< Type for message code.
+    using severity_type = uint8_t;         ///< Underlying type for @c Severity.
 
-    /// Get the text of the message.
-    swoc::TextView text() const;
+    /// Severity value for an instance.
+    /// This provides conversion to a numeric value, but not from. The result is constructors must be
+    /// passed an explicit serverity, avoiding ambiguity with other possible numeric arguments.
+    struct Severity {
+      severity_type _raw; ///< Severity numeric value
 
-    /// Get the nesting level.
-    unsigned short level() const;
+      explicit constexpr Severity(severity_type n) : _raw(n) {} ///< No implicit conversion from numeric.
 
-    /// Check if @a this has a @c Severity.
-    bool has_severity() const;
+      Severity(Severity const &that)            = default;
+      Severity &operator=(Severity const &that) = default;
 
-    /// Retrieve the local severity.
-    /// @return The local severity.
-    /// @note The behavior is undefined if there is no local severity.
-    Severity severity() const;
+      operator severity_type() const { return _raw; } ///< Implicit conversion to numeric.
+    };
 
-    /// Retrieve the local severity.
-    /// @return The local severity or @a default_severity if none is set.
-    Severity severity(Severity default_severity) const;
+    /// Code used if not specified.
+    static inline const code_type DEFAULT_CODE;
+    /// Severity reported if severity not set.
+    static Severity DEFAULT_SEVERITY;
+    /// Severity level at which the instance is a failure of some sort.
+    static Severity FAILURE_SEVERITY;
+    /// Minimum severity level for an @c Annotation.
+    /// If an @c Annotation is added with an explicit @c Severity that is smaller the @c Annotation is discarded instead of added.
+    /// This defaults to zero and no filtering is done unless it is overwritten.
+    static Severity FILTER_SEVERITY;
 
-    /// Set the @a severity of @a this.
-    self_type &assign(Severity severity);
+    /// Mapping of severity to string.
+    /// Values larger than the span size will be rendered as numbers.
+    /// Defaults to an empty span, meaning all severities will be printed as integers.
+    static MemSpan<TextView const> SEVERITY_NAMES;
+
+    /** An annotation to the Errata consisting of a severity and informative text.
+     *
+     * The text cannot be changed because of memory ownership risks.
+     */
+    class Annotation
+    {
+      using self_type = Annotation; ///< Self reference type.
+
+    public:
+      /// Reset to the message to default state.
+      self_type &clear();
+
+      /// Get the text of the message.
+      swoc::TextView text() const;
+
+      /// Get the nesting level.
+      unsigned short level() const;
+
+      /// Check if @a this has a @c Severity.
+      bool has_severity() const;
+
+      /// Retrieve the local severity.
+      /// @return The local severity.
+      /// @note The behavior is undefined if there is no local severity.
+      Severity severity() const;
+
+      /// Retrieve the local severity.
+      /// @return The local severity or @a default_severity if none is set.
+      Severity severity(Severity default_severity) const;
+
+      /// Set the @a severity of @a this.
+      self_type &assign(Severity severity);
+
+    protected:
+      std::string_view _text;            ///< Annotation text.
+      unsigned short _level{0};          ///< Nesting level for display purposes.
+      std::optional<Severity> _severity; ///< Severity.
+
+      /// @{{
+      /// Policy and links for intrusive list.
+      self_type *_next{nullptr};
+      self_type *_prev{nullptr};
+      /// @}}
+      /// Intrusive list link descriptor.
+      /// @note Must explicitly use defaults because ICC and clang consider them inaccessible
+      /// otherwise. I consider it a bug in the compiler that a default identical to an explicit
+      /// value has different behavior.
+      using Linkage = swoc::IntrusiveLinkage<self_type, &self_type::_next, &self_type::_prev>;
+
+      /// Default constructor.
+      /// The message has default severity and empty text.
+      Annotation();
+
+      /** Construct with @a text.
+       *
+       * @param text Annotation content (literal).
+       * @param severity Local severity.
+       * @param level Nesting level.
+       *
+       * @a text is presumed to be stable for the @c Annotation lifetime - this constructor simply copies
+       * the view.
+       */
+      explicit Annotation(std::string_view text, std::optional<Severity> severity = std::optional<Severity>{},
+                          unsigned short level = 0);
+
+      friend class Errata;
+      friend class swoc::MemArena; // needed for @c MemArena::make
+    };
 
   protected:
-    std::string_view _text;            ///< Annotation text.
-    unsigned short _level{0};          ///< Nesting level for display purposes.
-    std::optional<Severity> _severity; ///< Severity.
+    using self_type = Errata; ///< Self reference type.
+    /// Storage, for list of messages.
+    /// Internally the vector is accessed backwards, in order to make it LIFO.
+    using Container = IntrusiveDList<Annotation::Linkage>;
 
-    /// @{{
-    /// Policy and links for intrusive list.
-    self_type *_next{nullptr};
-    self_type *_prev{nullptr};
-    /// @}}
-    /// Intrusive list link descriptor.
-    /// @note Must explicitly use defaults because ICC and clang consider them inaccessible
-    /// otherwise. I consider it a bug in the compiler that a default identical to an explicit
-    /// value has different behavior.
-    using Linkage = swoc::IntrusiveLinkage<self_type, &self_type::_next, &self_type::_prev>;
+    /// Implementation class.
+    struct Data {
+      using self_type = Data; ///< Self reference type.
 
-    /// Default constructor.
-    /// The message has default severity and empty text.
-    Annotation();
+      /// Construct and take ownership of @a arena.
+      /// @internal This assumes the instance is being constructed in @a arena and therefore transfers the
+      /// @a arena into internal storage so that everything is in the @a arena.
+      Data(swoc::MemArena &&arena);
 
-    /** Construct with @a text.
+      /// Check if there are any notes.
+      bool empty() const;
+
+      /** Duplicate @a src in the arena for this instance.
+       *
+       * @param src Source data.
+       * @return View of copy in this arena.
+       */
+      std::string_view localize(std::string_view src);
+
+      /// Get the remnant of the current block in the arena.
+      swoc::MemSpan<char> remnant();
+
+      /// Allocate from the arena.
+      swoc::MemSpan<char> alloc(size_t n);
+
+      TextView _annotation_glue_text          = DEFAULT_ANNOTATION_GLUE_TEXT;
+      TextView _annotation_severity_glue_text = DEFAULT_SEVERITY_GLUE_TEXT;
+      TextView _severity_glue_text            = DEFAULT_SEVERITY_GLUE_TEXT;
+      TextView _indent_text                   = DEFAULT_INDENT_TEXT;
+      bool _glue_final_p                      = true; ///< Add glue after the last annotation?
+
+      std::optional<Severity> _severity;     ///< Severity.
+      code_type _code{Errata::DEFAULT_CODE}; ///< Message code / ID
+      Container _notes;                      ///< The message stack.
+      swoc::MemArena _arena;                 ///< Annotation text storage.
+    };
+
+  public:
+    /// Default constructor - empty errata, very fast.
+    Errata()                      = default;
+    Errata(self_type const &that) = delete;               ///< No constant copy construction.
+    Errata(self_type &&that) noexcept;                    ///< Move constructor.
+    self_type &operator=(self_type const &that) = delete; // no copy assignemnt.
+    self_type &operator=(self_type &&that);               ///< Move assignment.
+    ~Errata();                                            ///< Destructor.
+
+    /** Construct with a severity.
      *
-     * @param text Annotation content (literal).
+     * @param severity Severity.
+     *
+     * No annotations are created.
+     */
+    explicit Errata(Severity severity);
+
+    /** Constructor.
+     *
+     * @param code Error code.
+     * @param severity Severity.
+     * @param text Annotation text.
+     *
+     * Constructs with error @a code and @a severity. An annotation with @a text.
+     */
+    Errata(code_type const &code, Severity severity, std::string_view const &text);
+
+    /** Constructor.
+     *
+     * @param severity Severity.
+     * @param text Annotation text.
+     *
+     * Constructs with @a severity and an annotation with @a text.
+     */
+    Errata(Severity severity, std::string_view const &text);
+
+    /** Constructor.
+     *
+     * @param code Error code.
+     * @param text
+     *
+     * Construct with error @a code and an annotation with @a text.
+     */
+    Errata(code_type const &code, std::string_view const &text);
+
+    /** Constructor.
+     *
+     * @param text Annotation text.
+     */
+    explicit Errata(std::string_view const &text);
+
+    /** Constructor.
+     *
+     * @tparam Args Format argument types.
+     * @param code Error code.
+     * @param severity Severity.
+     * @param fmt Annotation format.
+     * @param args Annotation format arguments.
+     *
+     * Cosntructs with error @a code and @a severity and an formatted annotation.
+     */
+    template <typename... Args> Errata(code_type const &code, Severity severity, std::string_view fmt, Args &&...args);
+
+    template <typename... Args> Errata(code_type const &type, std::string_view fmt, Args &&...args);
+    template <typename... Args> Errata(Severity severity, std::string_view fmt, Args &&...args);
+    template <typename... Args> explicit Errata(std::string_view fmt, Args &&...args);
+
+    /** Add an @c Annotation to the top with @a text.
+     * @param text Text of the message.
+     * @return *this
+     *
+     * The error code is set to the default.
+     * @a text is localized to @a this and does not need to be persistent.
+     */
+    self_type &note(std::string_view text);
+
+    /** Add an @c Annotation to the top with @a text and local @a severity.
+     * @param severity The local severity.
+     * @param text Text of the message.
+     * @return *this
+     *
+     * The error code is set to the default.
+     * @a text is localized to @a this and does not need to be persistent.
+     * The severity is updated to @a severity if the latter is more severe.
+     */
+    self_type &note(Severity severity, std::string_view text);
+
+    /** Add an @c Annotation to the top based on error code @a code.
+     * @param code Error code.
+     * @return *this
+     *
+     * The annotation text is constructed as the short, long, and numeric value of @a code.
+     */
+    self_type &note(code_type const &code);
+
+    /** Append an @c Annotation to the top based on error code @a code with @a severity.
      * @param severity Local severity.
-     * @param level Nesting level.
+     * @param code Error code.
+     * @return *this
      *
-     * @a text is presumed to be stable for the @c Annotation lifetime - this constructor simply copies
-     * the view.
+     * The annotation text is constructed as the short, long, and numeric value of @a code.
      */
-    explicit Annotation(std::string_view text, std::optional<Severity> severity = std::optional<Severity>{},
-                        unsigned short level = 0);
+    self_type &note(code_type const &code, Severity severity);
 
-    friend class Errata;
-    friend class swoc::MemArena; // needed for @c MemArena::make
-  };
-
-protected:
-  using self_type = Errata; ///< Self reference type.
-  /// Storage, for list of messages.
-  /// Internally the vector is accessed backwards, in order to make it LIFO.
-  using Container = IntrusiveDList<Annotation::Linkage>;
-
-  /// Implementation class.
-  struct Data {
-    using self_type = Data; ///< Self reference type.
-
-    /// Construct and take ownership of @a arena.
-    /// @internal This assumes the instance is being constructed in @a arena and therefore transfers the
-    /// @a arena into internal storage so that everything is in the @a arena.
-    Data(swoc::MemArena &&arena);
-
-    /// Check if there are any notes.
-    bool empty() const;
-
-    /** Duplicate @a src in the arena for this instance.
+    /** Append an @c Annotation to the top based with optional @a severity.
+     * @param severity Local severity.
+     * @param text Annotation text.
+     * @return *this
      *
-     * @param src Source data.
-     * @return View of copy in this arena.
+     * This is a unified interface for other fixed text @c note methods which all forward to this
+     * method. If @a severity does not have a value then the annotation is never filtered.
+     *
+     * The severity is updated to @a severity if the latter is set and more severe.
+     *
+     * @see FILTER_SEVERITY
      */
-    std::string_view localize(std::string_view src);
+    self_type &note_s(std::optional<Severity> severity, std::string_view text);
 
-    /// Get the remnant of the current block in the arena.
-    swoc::MemSpan<char> remnant();
+    /** Append an @c Annotation.
+     * @param fmt Format string (@c BufferWriter style).
+     * @param args Arguments for values in @a fmt.
+     *
+     *  @return A reference to this object.
+     */
+    template <typename... Args> self_type &note(std::string_view fmt, Args &&...args);
 
-    /// Allocate from the arena.
-    swoc::MemSpan<char> alloc(size_t n);
+    /** Append an @c Annotation.
+     * @param fmt Format string (@c BufferWriter style).
+     * @param args Arguments for values in @a fmt.
+     * @return A reference to this object.
+     *
+     * This is intended for use by external "helper" methods that pass their own arguments to this
+     * using @c forward_as_tuple.
+     */
+    template <typename... Args> self_type &note_v(std::string_view fmt, std::tuple<Args...> const &args);
 
-    TextView _annotation_glue_text = DEFAULT_ANNOTATION_GLUE_TEXT;
-    TextView _annotation_severity_glue_text = DEFAULT_SEVERITY_GLUE_TEXT;
-    TextView _severity_glue_text = DEFAULT_SEVERITY_GLUE_TEXT;
-    TextView _indent_text = DEFAULT_INDENT_TEXT;
-    bool _glue_final_p = true; ///< Add glue after the last annotation?
+    /** Append an @c Annotation.
+     * @param severity Local severity.
+     * @param fmt Format string (@c BufferWriter style).
+     * @param args Arguments for values in @a fmt.
+     * @return A reference to this object.
+     *
+     * The severity is updated to @a severity if the latter is more severe.
+     */
+    template <typename... Args> self_type &note(Severity severity, std::string_view fmt, Args &&...args);
 
-    std::optional<Severity> _severity; ///< Severity.
-    code_type _code{Errata::DEFAULT_CODE};        ///< Message code / ID
-    Container _notes;                             ///< The message stack.
-    swoc::MemArena _arena;                        ///< Annotation text storage.
-  };
+    /** Append an @c Annotation.
+     * @param severity Local severity.
+     * @param fmt Format string (@c BufferWriter style).
+     * @param args Arguments for values in @a fmt.
+     * @return A reference to this object.
+     *
+     * This is intended for use by external "helper" methods that pass their own arguments to this
+     * using @c forward_as_tuple.
+     *
+     * The severity is updated to @a severity if the latter is more severe.
+     */
+    template <typename... Args> self_type &note_v(Severity severity, std::string_view fmt, std::tuple<Args...> const &args);
 
-public:
-  /// Default constructor - empty errata, very fast.
-  Errata()                      = default;
-  Errata(self_type const &that) = delete;                          ///< No constant copy construction.
-  Errata(self_type &&that) noexcept;                               ///< Move constructor.
-  self_type &operator=(self_type const &that) = delete;            // no copy assignemnt.
-  self_type &operator                         =(self_type &&that); ///< Move assignment.
-  ~Errata();                                                       ///< Destructor.
+    /** Append an @c Annotation.
+     * @param severity Local severity.
+     * @param fmt Format string (@c BufferWriter style).
+     * @param args Arguments for values in @a fmt.
+     * @return A reference to this object.
+     *
+     * The severity is updated to @a severity if the latter is set and more severe.
+     *
+     * This the effective implementation method for all variadic styles of the @a note method.
+     */
+    template <typename... Args>
+    self_type &note_sv(std::optional<Severity> severity, std::string_view fmt, std::tuple<Args...> const &args);
 
-  /** Construct with a severity.
-   *
-   * @param severity Severity.
-   *
-   * No annotations are created.
-   */
-  explicit Errata(Severity severity);
+    /** Copy messages from @a that to @a this.
+     *
+     * @param that Source object from which to copy.
+     * @return @a *this
+     *
+     * The code and severity of @a that are discarded.
+     */
+    self_type &note(self_type const &that);
 
-  /** Constructor.
-   *
-   * @param code Error code.
-   * @param severity Severity.
-   * @param text Annotation text.
-   *
-   * Constructs with error @a code and @a severity. An annotation with @a text.
-   */
-  Errata(code_type const &code, Severity severity, std::string_view const &text);
+    /** Copy messages from @a that to @a this, then clear @a that.
+     *
+     * @param that Source object from which to copy.
+     * @return @a *this
+     *
+     * The code and severity of @a that are discarded.
+     */
+    self_type &note(self_type &&that);
 
-  /** Constructor.
-   *
-   * @param severity Severity.
-   * @param text Annotation text.
-   *
-   * Constructs with @a severity and an annotation with @a text.
-   */
-  Errata(Severity severity, std::string_view const &text);
+    /** Reset to default state.
+     *
+     * @return @a this
+     *
+     * All messages are discarded and the state is returned to success.
+     */
+    self_type &clear();
 
-  /** Constructor.
-   *
-   * @param code Error code.
-   * @param text
-   *
-   * Construct with error @a code and an annotation with @a text.
-   */
-  Errata(code_type const &code, std::string_view const &text);
+    /** Log and clear @a this.
+     *
+     * @return @a this
+     *
+     * The content is sent to the defined @c Sink instances then reset to the default state.
+     *
+     * @see register_sink
+     * @see clear
+     */
+    self_type &sink();
 
-  /** Constructor.
-   *
-   * @param text Annotation text.
-   */
-  explicit Errata(std::string_view const &text);
+    friend std::ostream &operator<<(std::ostream &, self_type const &);
 
-  /** Constructor.
-   *
-   * @tparam Args Format argument types.
-   * @param code Error code.
-   * @param severity Severity.
-   * @param fmt Annotation format.
-   * @param args Annotation format arguments.
-   *
-   * Cosntructs with error @a code and @a severity and an formatted annotation.
-   */
-  template <typename... Args> Errata(code_type const &code, Severity severity, std::string_view fmt, Args &&... args);
+    /// Default glue value (a newline) for text rendering.
+    static inline TextView DEFAULT_ANNOTATION_GLUE_TEXT = "\n";
+    /// Default glue text for use after the severity name.
+    static inline TextView DEFAULT_SEVERITY_GLUE_TEXT = ": ";
+    // Text used for each level of indent.
+    static inline TextView DEFAULT_INDENT_TEXT = "  ";
 
+    /** Test status.
 
-  template <typename... Args> Errata(code_type const &type, std::string_view fmt, Args &&... args);
-  template <typename... Args> Errata(Severity severity, std::string_view fmt, Args &&... args);
-  template <typename... Args> explicit Errata(std::string_view fmt, Args &&... args);
+        Equivalent to @c is_ok but more convenient for use in
+        control statements.
 
-  /** Add an @c Annotation to the top with @a text.
-   * @param text Text of the message.
-   * @return *this
-   *
-   * The error code is set to the default.
-   * @a text is localized to @a this and does not need to be persistent.
-   */
-  self_type &note(std::string_view text);
+     *  @return @c false at least one message has a severity of @c FAILURE_SEVERITY or greater, @c
+     *  true if not.
+     */
 
-  /** Add an @c Annotation to the top with @a text and local @a severity.
-   * @param severity The local severity.
-   * @param text Text of the message.
-   * @return *this
-   *
-   * The error code is set to the default.
-   * @a text is localized to @a this and does not need to be persistent.
-   * The severity is updated to @a severity if the latter is more severe.
-   */
-  self_type &note(Severity severity, std::string_view text);
+    explicit operator bool() const;
 
-  /** Add an @c Annotation to the top based on error code @a code.
-   * @param code Error code.
-   * @return *this
-   *
-   * The annotation text is constructed as the short, long, and numeric value of @a code.
-   */
-  self_type &note(code_type const &code);
+    /** Test status.
+     *
+     * Equivalent to <tt>!is_ok()</tt> but potentially more convenient.
+     *
+     *  @return @c true at least one message has a severity of @c FAILURE_SEVERITY or greater, @c
+     *  false if not.
+     */
+    bool operator!() const;
 
-  /** Append an @c Annotation to the top based on error code @a code with @a severity.
-   * @param severity Local severity.
-   * @param code Error code.
-   * @return *this
-   *
-   * The annotation text is constructed as the short, long, and numeric value of @a code.
-   */
-  self_type &note(code_type const &code, Severity severity);
+    /** Test errata for no failure condition.
 
-  /** Append an @c Annotation to the top based with optional @a severity.
-   * @param severity Local severity.
-   * @param text Annotation text.
-   * @return *this
-   *
-   * This is a unified interface for other fixed text @c note methods which all forward to this
-   * method. If @a severity does not have a value then the annotation is never filtered.
-   *
-   * The severity is updated to @a severity if the latter is set and more severe.
-   *
-   * @see FILTER_SEVERITY
-   */
-  self_type &note_s(std::optional<Severity> severity, std::string_view text);
+        Equivalent to @c operator @c bool but easier to invoke.
 
-  /** Append an @c Annotation.
-   * @param fmt Format string (@c BufferWriter style).
-   * @param args Arguments for values in @a fmt.
-   *
-   *  @return A reference to this object.
-   */
-  template <typename... Args> self_type &note(std::string_view fmt, Args &&... args);
+        @return @c true if no message has a severity of @c FAILURE_SEVERITY
+        or greater, @c false if at least one such message is in the stack.
+     */
+    bool is_ok() const;
 
-  /** Append an @c Annotation.
-   * @param fmt Format string (@c BufferWriter style).
-   * @param args Arguments for values in @a fmt.
-   * @return A reference to this object.
-   *
-   * This is intended for use by external "helper" methods that pass their own arguments to this
-   * using @c forward_as_tuple.
-   */
-  template <typename... Args> self_type &note_v(std::string_view fmt, std::tuple<Args...> const &args);
+    /// @return If there is top level severity.
+    bool
+    has_severity() const
+    {
+      return _data && _data->_severity.has_value();
+    }
 
-  /** Append an @c Annotation.
-   * @param severity Local severity.
-   * @param fmt Format string (@c BufferWriter style).
-   * @param args Arguments for values in @a fmt.
-   * @return A reference to this object.
-   *
-   * The severity is updated to @a severity if the latter is more severe.
-   */
-  template <typename... Args> self_type &note(Severity severity, std::string_view fmt, Args &&... args);
+    /// @return Top level severity.
+    Severity severity() const;
 
-  /** Append an @c Annotation.
-   * @param severity Local severity.
-   * @param fmt Format string (@c BufferWriter style).
-   * @param args Arguments for values in @a fmt.
-   * @return A reference to this object.
-   *
-   * This is intended for use by external "helper" methods that pass their own arguments to this
-   * using @c forward_as_tuple.
-   *
-   * The severity is updated to @a severity if the latter is more severe.
-   */
-  template <typename... Args> self_type &note_v(Severity severity, std::string_view fmt, std::tuple<Args...> const &args);
+    /** Set the @a severity.
+     *
+     * @param severity Severity value.
+     * @return @a this
+     *
+     * @see update
+     */
+    self_type &assign(Severity severity);
 
-  /** Append an @c Annotation.
-   * @param severity Local severity.
-   * @param fmt Format string (@c BufferWriter style).
-   * @param args Arguments for values in @a fmt.
-   * @return A reference to this object.
-   *
-   * The severity is updated to @a severity if the latter is set and more severe.
-   *
-   * This the effective implementation method for all variadic styles of the @a note method.
-   */
-  template <typename... Args>
-  self_type &note_sv(std::optional<Severity> severity, std::string_view fmt, std::tuple<Args...> const &args);
-
-  /** Copy messages from @a that to @a this.
-   *
-   * @param that Source object from which to copy.
-   * @return @a *this
-   *
-   * The code and severity of @a that are discarded.
-   */
-  self_type &note(self_type const &that);
-
-  /** Copy messages from @a that to @a this, then clear @a that.
-   *
-   * @param that Source object from which to copy.
-   * @return @a *this
-   *
-   * The code and severity of @a that are discarded.
-   */
-  self_type &note(self_type &&that);
-
-  /** Reset to default state.
-   *
-   * @return @a this
-   *
-   * All messages are discarded and the state is returned to success.
-   */
-  self_type &clear();
-
-  /** Log and clear @a this.
-   *
-   * @return @a this
-   *
-   * The content is sent to the defined @c Sink instances then reset to the default state.
-   *
-   * @see register_sink
-   * @see clear
-   */
-  self_type & sink();
-
-  friend std::ostream &operator<<(std::ostream &, self_type const &);
-
-  /// Default glue value (a newline) for text rendering.
-  static inline TextView DEFAULT_ANNOTATION_GLUE_TEXT = "\n";
-  /// Default glue text for use after the severity name.
-  static inline TextView DEFAULT_SEVERITY_GLUE_TEXT = ": ";
-  // Text used for each level of indent.
-  static inline TextView DEFAULT_INDENT_TEXT = "  ";
-
-  /** Test status.
-
-      Equivalent to @c is_ok but more convenient for use in
-      control statements.
-
-   *  @return @c false at least one message has a severity of @c FAILURE_SEVERITY or greater, @c
-   *  true if not.
-   */
-
-  explicit operator bool() const;
-
-  /** Test status.
-   *
-   * Equivalent to <tt>!is_ok()</tt> but potentially more convenient.
-   *
-   *  @return @c true at least one message has a severity of @c FAILURE_SEVERITY or greater, @c
-   *  false if not.
-   */
-  bool operator!() const;
-
-  /** Test errata for no failure condition.
-
-      Equivalent to @c operator @c bool but easier to invoke.
-
-      @return @c true if no message has a severity of @c FAILURE_SEVERITY
-      or greater, @c false if at least one such message is in the stack.
-   */
-  bool is_ok() const;
-
-  /// @return If there is top level severity.
-  bool has_severity() const { return _data && _data->_severity.has_value(); }
-
-  /// @return Top level severity.
-  Severity severity() const;
-
-  /** Set the @a severity.
-   *
-   * @param severity Severity value.
-   * @return @a this
-   *
-   * @see update
-   */
-  self_type & assign(Severity severity);
-
-  /** Set the severity.
+    /** Set the severity.
      *
      * @param severity Minimum severity
      * @return @a this
@@ -472,972 +480,1074 @@ public:
      * This sets the internal severity to the maximum of @a severity and the current severity.
      *
      * @see assign
+     */
+    self_type &update(Severity severity);
+
+    /// The code for the top message.
+    code_type const &code() const;
+
+    /// Set the @a code for @a this.
+    self_type &assign(code_type code);
+
+    /// Number of messages in the errata.
+    size_t length() const;
+
+    /// Check for no messages
+    /// @return @c true if there is one or messages.
+    bool empty() const;
+
+    using iterator       = Container::iterator;
+    using const_iterator = Container::const_iterator;
+
+    /// Reference to top item on the stack.
+    iterator begin();
+    /// Reference to top item on the stack.
+    const_iterator begin() const;
+    //! Reference one past bottom item on the stack.
+    iterator end();
+    //! Reference one past bottom item on the stack.
+    const_iterator end() const;
+
+    /** First annotation.
+     *
+     * @return The first annotation.
+     *
+     * It is an error to call this on an empty instance.
+     */
+    const Annotation &front() const;
+
+    /** lask annotation.
+     *
+     * @return The last annotation.
+     *
+     * It is an error to call this on an empty instance.
+     */
+    const Annotation &back() const;
+
+    // Logging support.
+
+    /// @return The annotation glue text for @a this.
+    TextView annotation_glue_text() const;
+
+    /** Assign text to use between annotations while printing.
+     *
+     * @param text Glue text.
+     * @param final_glue_p Add glue after last annotation?
+     * @return @a this
+     */
+    self_type &assign_annotation_glue_text(TextView text, bool final_glue_p = false);
+
+    /// @return Glue text for the annotation severity.
+    TextView annotation_severity_glue_text() const;
+
+    /** Assign text to use after the severity for an annoation while printing.
+     *
+     * @param text Glue text.
+     * @return @a this
+     */
+    self_type &assign_annotation_severity_glue_text(TextView text);
+
+    /// @return The severity glue text for @a this.
+    TextView severity_glue_text() const;
+
+    /** Assign text to use after the severity while printing.
+     *
+     * @param text Glue text.
+     * @return @a this
+     */
+    self_type &assign_severity_glue_text(TextView text);
+
+    /// @return The text used for each level of indentation.
+    TextView indent_text() const;
+
+    /** Assign the text used for indentation.
+     *
+     * @param text Text for each level of indentation.
+     * @return @a this.
+     */
+    self_type &assign_indent_text(TextView text);
+
+    /** Base class for erratum sink.
+
+        When an errata is abandoned, this will be called on it to perform any client specific logging.
+        It is passed around by handle so that it doesn't have to support copy semantics (and is not
+        destructed until application shutdown). Clients can subclass this class in order to preserve
+        arbitrary data for the sink or retain a handle to the sink for runtime modifications.
+     */
+    class Sink
+    {
+      using self_type = Sink;
+
+    public:
+      using Handle = std::shared_ptr<self_type>; ///< Handle type.
+
+      /// Handle an abandoned errata.
+      virtual void operator()(Errata const &) const = 0;
+      /// Force virtual destructor.
+      virtual ~Sink() {}
+    };
+
+    //! Register a sink for discarded erratum.
+    static void register_sink(Sink::Handle const &s);
+
+    /// Register a function as a sink.
+    using SinkHandler = std::function<void(Errata const &)>;
+
+    /// Convenience wrapper class to enable using functions directly for sinks.
+    struct SinkWrapper : public Sink {
+      /// Constructor.
+      SinkWrapper(SinkHandler const &f) : _f(f) {}
+      SinkWrapper(SinkHandler &&f) : _f(std::move(f)) {}
+      /// Operator to invoke the function.
+      void operator()(Errata const &e) const override;
+      SinkHandler _f; ///< Client supplied handler.
+    };
+
+    /// Register a sink function for abandonded erratum.
+    static void
+    register_sink(SinkHandler const &f)
+    {
+      register_sink(Sink::Handle(new SinkWrapper(f)));
+    }
+
+    /// Register a sink function for abandonded erratum.
+    static void
+    register_sink(SinkHandler &&f)
+    {
+      register_sink(Sink::Handle(new SinkWrapper(std::move(f))));
+    }
+
+    /** Simple formatted output.
+     */
+    std::ostream &write(std::ostream &out) const;
+
+  protected:
+    /// Construct with code and severity, but no annotations.
+    Errata(code_type const &code, Severity severity);
+
+    /// Implementation instance.
+    /// @internal Because this is used with a self-containing @c MemArena standard smart pointers do not
+    /// work correctly. Instead the @c clear method must be used to release the memory.
+    /// @see clear
+    Data *_data = nullptr;
+
+    /// Force data existence.
+    /// @return A pointer to the data.
+    Data *data();
+
+    /** Allocate a span of memory.
+     *
+     * @param n Number of bytes to allocate.
+     * @return A span of the allocated memory.
+     */
+    MemSpan<char> alloc(size_t n);
+
+    /// Add @c Annotation with already localized text.
+    self_type &note_localized(std::string_view const &text, std::optional<Severity> severity = std::optional<Severity>{});
+
+    /// Used for returns when no data is present.
+    static Annotation const NIL_NOTE;
+
+    friend struct Data;
+    friend class Item;
+    friend BufferWriter &bwformat(BufferWriter &bw, bwf::Spec const &, Errata const &errata);
+  };
+
+  extern std::ostream &operator<<(std::ostream &os, Errata const &stat);
+
+  /** Return type for returning a value and status (errata).  In general, a method wants to return
+      both a result and a status so that errors are logged properly. This structure is used to do that
+      in way that is more usable than just @c std::pair.  - Simpler and shorter typography - Force use
+      of @c errata rather than having to remember it (and the order) each time - Enable assignment
+      directly to @a R for ease of use and compatibility so clients can upgrade asynchronously.
    */
-  self_type &update(Severity severity);
+  template <typename R> class Rv
+  {
+  public:
+    using result_type = R; ///< Type of result value.
+    using code_type   = Errata::code_type;
+    using Severity    = Errata::Severity;
 
-  /// The code for the top message.
-  code_type const &code() const;
+  protected:
+    using self_type = Rv; ///< Standard self reference type.
 
-  /// Set the @a code for @a this.
-  self_type & assign(code_type code);
-
-  /// Number of messages in the errata.
-  size_t length() const;
-
-  /// Check for no messages
-  /// @return @c true if there is one or messages.
-  bool empty() const;
-
-  using iterator       = Container::iterator;
-  using const_iterator = Container::const_iterator;
-
-  /// Reference to top item on the stack.
-  iterator begin();
-  /// Reference to top item on the stack.
-  const_iterator begin() const;
-  //! Reference one past bottom item on the stack.
-  iterator end();
-  //! Reference one past bottom item on the stack.
-  const_iterator end() const;
-
-  /** First annotation.
-   *
-   * @return The first annotation.
-   *
-   * It is an error to call this on an empty instance.
-   */
-  const Annotation &front() const;
-
-  /** lask annotation.
-   *
-   * @return The last annotation.
-   *
-   * It is an error to call this on an empty instance.
-   */
-  const Annotation &back() const;
-
-  // Logging support.
-
-  /// @return The annotation glue text for @a this.
-  TextView annotation_glue_text() const;
-
-  /** Assign text to use between annotations while printing.
-   *
-   * @param text Glue text.
-   * @param final_glue_p Add glue after last annotation?
-   * @return @a this
-   */
-  self_type & assign_annotation_glue_text(TextView text, bool final_glue_p = false);
-
-  /// @return Glue text for the annotation severity.
-  TextView annotation_severity_glue_text() const;
-
-  /** Assign text to use after the severity for an annoation while printing.
-   *
-   * @param text Glue text.
-   * @return @a this
-   */
-  self_type & assign_annotation_severity_glue_text(TextView text);
-
-  /// @return The severity glue text for @a this.
-  TextView severity_glue_text() const;
-
-  /** Assign text to use after the severity while printing.
-   *
-   * @param text Glue text.
-   * @return @a this
-   */
-  self_type & assign_severity_glue_text(TextView text);
-
-  /// @return The text used for each level of indentation.
-  TextView indent_text() const;
-
-  /** Assign the text used for indentation.
-   *
-   * @param text Text for each level of indentation.
-   * @return @a this.
-   */
-  self_type & assign_indent_text(TextView text);
-
-  /** Base class for erratum sink.
-
-      When an errata is abandoned, this will be called on it to perform any client specific logging.
-      It is passed around by handle so that it doesn't have to support copy semantics (and is not
-      destructed until application shutdown). Clients can subclass this class in order to preserve
-      arbitrary data for the sink or retain a handle to the sink for runtime modifications.
-   */
-  class Sink {
-    using self_type = Sink;
+    result_type _r; ///< The result.
+    Errata _errata; ///< The errata.
 
   public:
-    using Handle = std::shared_ptr<self_type>; ///< Handle type.
+    /** Default constructor.
+        The default constructor for @a R is used.
+        The status is initialized to SUCCESS.
+    */
+    Rv();
 
-    /// Handle an abandoned errata.
-    virtual void operator()(Errata const &) const = 0;
-    /// Force virtual destructor.
-    virtual ~Sink() {}
-  };
+    /** Construct with copy of @a result and empty (successful) Errata.
+     *
+     * @param result Result of the operation.
+     */
+    Rv(result_type const &result);
 
-  //! Register a sink for discarded erratum.
-  static void register_sink(Sink::Handle const &s);
+    /** Construct with copy of @a result and move @a errata.
+     *
+     * @param result Return value / result.
+     * @param errata Source errata to move.
+     */
+    Rv(result_type const &result, Errata &&errata);
 
-  /// Register a function as a sink.
-  using SinkHandler = std::function<void(Errata const &)>;
+    /** Construct with move of @a result and empty (successful) Errata.
+     *
+     * @param result The return / result value.
+     */
+    Rv(result_type &&result);
 
-  /// Convenience wrapper class to enable using functions directly for sinks.
-  struct SinkWrapper : public Sink {
-    /// Constructor.
-    SinkWrapper(SinkHandler const& f) : _f(f) {}
-    SinkWrapper(SinkHandler && f) : _f(std::move(f)) {}
-    /// Operator to invoke the function.
-    void operator()(Errata const &e) const override;
-    SinkHandler _f; ///< Client supplied handler.
-  };
+    /** Construct with a move of result and @a errata.
+     *
+     * @param result The return / result value to move.
+     * @param errata Status to move.
+     */
+    Rv(result_type &&result, Errata &&errata);
 
-  /// Register a sink function for abandonded erratum.
-  static void
-  register_sink(SinkHandler const &f) {
-    register_sink(Sink::Handle(new SinkWrapper(f)));
-  }
+    /** Construct only from @a errata
+     *
+     * @param errata Errata instance.
+     *
+     * This is useful for error conditions. The result is default constructed and the @a errata
+     * consumed by the return value. If @c result_type is a smart pointer or other cheaply default
+     * constructed class this can make the code much cleaner;
+     *
+     * @code
+     * // Assume Thing can be default constructed cheaply.
+     * Rv<Thing> func(...) {
+     *   if (something_bad) {
+     *     return Errata("Bad thing happen!");
+     *   }
+     *   return Thing{arg1, arg2};
+     * }
+     * @endcode
+     */
+    Rv(Errata &&errata);
 
-  /// Register a sink function for abandonded erratum.
-  static void
-  register_sink(SinkHandler && f) {
-    register_sink(Sink::Handle(new SinkWrapper(std::move(f))));
-  }
+    /** Append a message in to the result.
+     *
+     * @param text Text for the error.
+     * @return @a *this
+     */
+    self_type &note(std::string_view text);
 
-  /** Simple formatted output.
-   */
-  std::ostream &write(std::ostream &out) const;
+    /** Append a message in to the result.
+     *
+     * @param severity Local severity.
+     * @param text Text for the error.
+     * @return @a *this
+     */
+    self_type &note(Severity severity, std::string_view text);
 
-protected:
-  /// Construct with code and severity, but no annotations.
-  Errata(code_type const &code, Severity severity);
+    /** Append a message in to the result.
+     *
+     * @param code the error code.
+     * @return @a *this
+     *
+     * The annotation text is constructed as the short, long, and numeric value of @a code, which is then discarded.
+     */
+    self_type &note(code_type const &code);
 
-  /// Implementation instance.
-  /// @internal Because this is used with a self-containing @c MemArena standard smart pointers do not
-  /// work correctly. Instead the @c clear method must be used to release the memory.
-  /// @see clear
-  Data *_data = nullptr;
+    /** Append a message in to the result.
+     *
+     * @param code the error code.
+     * @param severity Local severity.
+     * @return @a *this
+     *
+     * The annotation text is constructed as the short, long, and numeric value of @a code, which is then discarded.
+     */
+    self_type &note(code_type const &code, Severity severity);
 
-  /// Force data existence.
-  /// @return A pointer to the data.
-  Data *data();
+    /** Append a message in to the result.
+     *
+     * @tparam Args Format string argument types.
+     * @param fmt Format string.
+     * @param args Arguments for @a fmt.
+     * @return @a *this
+     */
+    template <typename... Args> self_type &note(std::string_view fmt, Args &&...args);
 
-  /** Allocate a span of memory.
-   *
-   * @param n Number of bytes to allocate.
-   * @return A span of the allocated memory.
-   */
-  MemSpan<char> alloc(size_t n);
+    /** Append a message in to the result.
+     *
+     * @tparam Args Format string argument types.
+     * @param severity Local severity.
+     * @param fmt Format string.
+     * @param args Arguments for @a fmt.
+     * @return @a *this
+     */
+    template <typename... Args> self_type &note(Severity severity, std::string_view fmt, Args &&...args);
 
-  /// Add @c Annotation with already localized text.
-  self_type &note_localized(std::string_view const &text, std::optional<Severity> severity = std::optional<Severity>{});
+    /** Copy messages from @a that to @a this.
+     *
+     * @param that Source object from which to copy.
+     * @return @a *this
+     *
+     * The code and severity of @a that are discarded.
+     */
+    self_type &note(Errata const &that);
 
-  /// Used for returns when no data is present.
-  static Annotation const NIL_NOTE;
+    /** Copy messages from @a that to @a this, then clear @a that.
+     *
+     * @param that Source object from which to copy.
+     * @return @a *this
+     *
+     * The code and severity of @a that are discarded.
+     */
+    self_type &note(Errata &&that);
 
-  friend struct Data;
-  friend class Item;
-  friend BufferWriter &bwformat(BufferWriter &bw, bwf::Spec const &, Errata const &errata);
-};
+    /** User conversion to the result type.
 
-extern std::ostream &operator<<(std::ostream &os, Errata const &stat);
+        This makes it easy to use the function normally or to pass the result only to other functions
+        without having to extract it by hand.
+    */
+    operator result_type const &() const;
 
-/** Return type for returning a value and status (errata).  In general, a method wants to return
-    both a result and a status so that errors are logged properly. This structure is used to do that
-    in way that is more usable than just @c std::pair.  - Simpler and shorter typography - Force use
-    of @c errata rather than having to remember it (and the order) each time - Enable assignment
-    directly to @a R for ease of use and compatibility so clients can upgrade asynchronously.
- */
-template <typename R> class Rv {
-public:
-  using result_type = R; ///< Type of result value.
-  using code_type   = Errata::code_type;
-  using Severity    = Errata::Severity;
+    /** Assignment from result type.
 
-protected:
-  using self_type = Rv; ///< Standard self reference type.
+        @param r Result.
 
-  result_type _r; ///< The result.
-  Errata _errata; ///< The errata.
+        This allows the result to be assigned to a pre-declared return value structure.  The return
+        value is a reference to the internal result so that this operator can be chained in other
+        assignments to instances of result type. This is most commonly used when the result is
+        computed in to a local variable to be both returned and stored in a member.
 
-public:
-  /** Default constructor.
-      The default constructor for @a R is used.
-      The status is initialized to SUCCESS.
-  */
-  Rv();
-
-  /** Construct with copy of @a result and empty (successful) Errata.
-   *
-   * @param result Result of the operation.
-   */
-  Rv(result_type const &result);
-
-  /** Construct with copy of @a result and move @a errata.
-   *
-   * @param result Return value / result.
-   * @param errata Source errata to move.
-   */
-  Rv(result_type const &result, Errata &&errata);
-
-  /** Construct with move of @a result and empty (successful) Errata.
-   *
-   * @param result The return / result value.
-   */
-  Rv(result_type &&result);
-
-  /** Construct with a move of result and @a errata.
-   *
-   * @param result The return / result value to move.
-   * @param errata Status to move.
-   */
-  Rv(result_type &&result, Errata &&errata);
-
-  /** Construct only from @a errata
-   *
-   * @param errata Errata instance.
-   *
-   * This is useful for error conditions. The result is default constructed and the @a errata
-   * consumed by the return value. If @c result_type is a smart pointer or other cheaply default
-   * constructed class this can make the code much cleaner;
-   *
-   * @code
-   * // Assume Thing can be default constructed cheaply.
-   * Rv<Thing> func(...) {
-   *   if (something_bad) {
-   *     return Errata("Bad thing happen!");
-   *   }
-   *   return Thing{arg1, arg2};
-   * }
-   * @endcode
-   */
-  Rv(Errata &&errata);
-
-  /** Append a message in to the result.
-   *
-   * @param text Text for the error.
-   * @return @a *this
-   */
-  self_type &note(std::string_view text);
-
-  /** Append a message in to the result.
-   *
-   * @param severity Local severity.
-   * @param text Text for the error.
-   * @return @a *this
-   */
-  self_type &note(Severity severity, std::string_view text);
-
-  /** Append a message in to the result.
-   *
-   * @param code the error code.
-   * @return @a *this
-   *
-   * The annotation text is constructed as the short, long, and numeric value of @a code, which is then discarded.
-   */
-  self_type &note(code_type const &code);
-
-  /** Append a message in to the result.
-   *
-   * @param code the error code.
-   * @param severity Local severity.
-   * @return @a *this
-   *
-   * The annotation text is constructed as the short, long, and numeric value of @a code, which is then discarded.
-   */
-  self_type &note(code_type const &code, Severity severity);
-
-  /** Append a message in to the result.
-   *
-   * @tparam Args Format string argument types.
-   * @param fmt Format string.
-   * @param args Arguments for @a fmt.
-   * @return @a *this
-   */
-  template <typename... Args> self_type &note(std::string_view fmt, Args &&... args);
-
-  /** Append a message in to the result.
-   *
-   * @tparam Args Format string argument types.
-   * @param severity Local severity.
-   * @param fmt Format string.
-   * @param args Arguments for @a fmt.
-   * @return @a *this
-   */
-  template <typename... Args> self_type &note(Severity severity, std::string_view fmt, Args &&... args);
-
-  /** Copy messages from @a that to @a this.
-   *
-   * @param that Source object from which to copy.
-   * @return @a *this
-   *
-   * The code and severity of @a that are discarded.
-   */
-  self_type &note(Errata const &that);
-
-  /** Copy messages from @a that to @a this, then clear @a that.
-   *
-   * @param that Source object from which to copy.
-   * @return @a *this
-   *
-   * The code and severity of @a that are discarded.
-   */
-  self_type &note(Errata &&that);
-
-  /** User conversion to the result type.
-
-      This makes it easy to use the function normally or to pass the result only to other functions
-      without having to extract it by hand.
-  */
-  operator result_type const &() const;
-
-  /** Assignment from result type.
-
-      @param r Result.
-
-      This allows the result to be assigned to a pre-declared return value structure.  The return
-      value is a reference to the internal result so that this operator can be chained in other
-      assignments to instances of result type. This is most commonly used when the result is
-      computed in to a local variable to be both returned and stored in a member.
-
-      @code
-      Rv<int> zret;
-      int value;
-      // ... complex computations, result in value
-      this->m_value = zret = value;
-      // ...
-      return zret;
-      @endcode
-
-      @return A reference to the copy of @a r stored in this object.
-  */
-  result_type &operator=(result_type const &r);
-
-  /** Move assign a result @a r to @a this.
-   *
-   * @param r Result.
-   * @return @a r
-   */
-  result_type &operator=(result_type &&r);
-
-  /** Set the result.
-
-      This differs from assignment of the function result in that the
-      return value is a reference to the @c Rv, not the internal
-      result. This makes it useful for assigning a result local
-      variable and then returning.
-
-   * @param result Value to move.
-   * @return @a this
-
-      @code
-      Rv<int> func(...) {
+        @code
         Rv<int> zret;
         int value;
-        // ... complex computation, result in value
-        return zret.assign(value);
-      }
-      @endcode
-  */
-  self_type &assign(result_type const &result);
+        // ... complex computations, result in value
+        this->m_value = zret = value;
+        // ...
+        return zret;
+        @endcode
 
-  /** Move the @a result to @a this.
-   *
-   * @param result Value to move.
-   * @return @a this,
+        @return A reference to the copy of @a r stored in this object.
+    */
+    result_type &operator=(result_type const &r);
+
+    /** Move assign a result @a r to @a this.
+     *
+     * @param r Result.
+     * @return @a r
+     */
+    result_type &operator=(result_type &&r);
+
+    /** Set the result.
+
+        This differs from assignment of the function result in that the
+        return value is a reference to the @c Rv, not the internal
+        result. This makes it useful for assigning a result local
+        variable and then returning.
+
+     * @param result Value to move.
+     * @return @a this
+
+        @code
+        Rv<int> func(...) {
+          Rv<int> zret;
+          int value;
+          // ... complex computation, result in value
+          return zret.assign(value);
+        }
+        @endcode
+    */
+    self_type &assign(result_type const &result);
+
+    /** Move the @a result to @a this.
+     *
+     * @param result Value to move.
+     * @return @a this,
+     */
+    self_type &assign(result_type &&result);
+
+    /** Return the result.
+        @return A reference to the result value in this object.
+    */
+    result_type &result();
+
+    /** Return the result.
+        @return A reference to the result value in this object.
+    */
+    result_type const &result() const;
+
+    /** Return the status.
+        @return A reference to the @c errata in this object.
+    */
+    Errata &errata();
+
+    /** Return the status.
+        @return A reference to the @c errata in this object.
+    */
+    Errata const &errata() const;
+
+    /** Get the internal @c Errata.
+     *
+     * @return Reference to internal @c Errata.
+     */
+    operator Errata &();
+
+    /** Replace current status with @a status.
+     *
+     * @param status Errata to move in to this instance.
+     * @return *this
+     *
+     * The current @c Errata for @a this is discarded and replaced with @a status.
+     */
+    self_type &operator=(Errata &&status);
+
+    /** Check the status of the return value.
+     *
+     * @return @a true if the value is valid / OK, @c false otherwise.
+     */
+    bool is_ok() const;
+
+    /// Clear the errata.
+    self_type &clear();
+  };
+
+  /** Combine a function result and status in to an @c Rv.
+      This is useful for clients that want to declare the status object
+      and result independently.
    */
-  self_type &assign(result_type &&result);
-
-  /** Return the result.
-      @return A reference to the result value in this object.
-  */
-  result_type &result();
-
-  /** Return the result.
-      @return A reference to the result value in this object.
-  */
-  result_type const &result() const;
-
-  /** Return the status.
-      @return A reference to the @c errata in this object.
-  */
-  Errata &errata();
-
-  /** Return the status.
-      @return A reference to the @c errata in this object.
-  */
-  Errata const &errata() const;
-
-  /** Get the internal @c Errata.
-   *
-   * @return Reference to internal @c Errata.
-   */
-  operator Errata &();
-
-  /** Replace current status with @a status.
-   *
-   * @param status Errata to move in to this instance.
-   * @return *this
-   *
-   * The current @c Errata for @a this is discarded and replaced with @a status.
-   */
-  self_type &operator=(Errata &&status);
-
-  /** Check the status of the return value.
-   *
-   * @return @a true if the value is valid / OK, @c false otherwise.
-   */
-  bool is_ok() const;
-
-  /// Clear the errata.
-  self_type &clear();
-};
-
-/** Combine a function result and status in to an @c Rv.
-    This is useful for clients that want to declare the status object
-    and result independently.
- */
-template <typename R>
-Rv<typename std::remove_reference<R>::type>
-MakeRv(R &&r,           ///< The function result
-       Errata &&erratum ///< The pre-existing status object
-) {
-  return Rv<typename std::remove_reference<R>::type>(std::forward<R>(r), std::move(erratum));
-}
-/* ----------------------------------------------------------------------- */
-// Inline methods for Annotation
-
-inline Errata::Annotation::Annotation() = default;
-
-inline Errata::Annotation::Annotation(std::string_view text, std::optional<Severity> severity, unsigned short level)
-  : _text(text), _level(level), _severity(severity) {}
-
-inline Errata::Annotation &
-Errata::Annotation::clear() {
-  _text = std::string_view{};
-  return *this;
-}
-
-inline swoc::TextView
-Errata::Annotation::text() const {
-  return _text;
-}
-
-inline unsigned short
-Errata::Annotation::level() const {
-  return _level;
-}
-
-inline bool
-Errata::Annotation::has_severity() const {
-  return _severity.has_value();
-}
-inline auto
-Errata::Annotation::severity() const -> Severity {
-  return *_severity;
-}
-inline auto
-Errata::Annotation::severity(Errata::Severity default_severity) const -> Severity {
-  return _severity.value_or(default_severity);
-}
-inline auto
-Errata::Annotation::assign(Errata::Severity severity) -> self_type & {
-  _severity = severity;
-  return *this;
-}
-
-/* ----------------------------------------------------------------------- */
-// Inline methods for Errata::Data
-
-inline Errata::Data::Data(MemArena &&arena) {
-  _arena = std::move(arena);
-}
-
-inline swoc::MemSpan<char>
-Errata::Data::remnant() {
-  return _arena.remnant().rebind<char>();
-}
-
-inline swoc::MemSpan<char>
-Errata::Data::alloc(size_t n) {
-  return _arena.alloc(n).rebind<char>();
-}
-
-inline bool
-Errata::Data::empty() const {
-  return _notes.empty();
-}
-
-/* ----------------------------------------------------------------------- */
-// Inline methods for Errata
-
-inline Errata::Errata(self_type &&that) noexcept {
-  std::swap(_data, that._data);
-}
-
-inline Errata::Errata(Severity severity) {
-  this->data()->_severity = severity;
-}
-
-inline Errata::Errata(const code_type &code, Severity severity) {
-  auto d       = this->data();
-  d->_severity = severity;
-  d->_code     = code;
-}
-
-inline Errata::Errata(const code_type &code, Severity severity, const std::string_view &text) : Errata(code, severity) {
-  this->note(text);
-}
-
-inline Errata::Errata(const std::string_view &text) : Errata(DEFAULT_CODE, DEFAULT_SEVERITY, text) {}
-inline Errata::Errata(code_type const &code, const std::string_view &text) : Errata(code, DEFAULT_SEVERITY, text) {}
-inline Errata::Errata(Severity severity, const std::string_view &text) : Errata(DEFAULT_CODE, severity, text) {}
-
-template <typename... Args>
-Errata::Errata(code_type const &code, Severity severity, std::string_view fmt, Args &&... args) : Errata(code, severity) {
-  this->note_v(fmt, std::forward_as_tuple(args...));
-}
-
-template <typename... Args>
-Errata::Errata(code_type const &code, std::string_view fmt, Args &&... args)
-  : Errata(code, DEFAULT_SEVERITY, fmt, std::forward<Args>(args)...) {}
-template <typename... Args>
-Errata::Errata(Severity severity, std::string_view fmt, Args &&... args)
-  : Errata(DEFAULT_CODE, severity, fmt, std::forward<Args>(args)...) {}
-template <typename... Args>
-Errata::Errata(std::string_view fmt, Args &&... args) : Errata(DEFAULT_CODE, DEFAULT_SEVERITY, fmt, std::forward<Args>(args)...) {}
-
-inline Errata&
-Errata::clear() {
-  if (_data) {
-    _data->~Data(); // destructs the @c MemArena in @a _data which releases memory.
-    _data = nullptr;
+  template <typename R>
+  Rv<typename std::remove_reference<R>::type>
+  MakeRv(R &&r,           ///< The function result
+         Errata &&erratum ///< The pre-existing status object
+  )
+  {
+    return Rv<typename std::remove_reference<R>::type>(std::forward<R>(r), std::move(erratum));
   }
-  return *this;
-}
+  /* ----------------------------------------------------------------------- */
+  // Inline methods for Annotation
 
-inline auto
-Errata::operator=(self_type &&that) -> self_type & {
-  if (this != &that) {
-    this->clear();
+  inline Errata::Annotation::Annotation() = default;
+
+  inline Errata::Annotation::Annotation(std::string_view text, std::optional<Severity> severity, unsigned short level)
+    : _text(text), _level(level), _severity(severity)
+  {
+  }
+
+  inline Errata::Annotation &
+  Errata::Annotation::clear()
+  {
+    _text = std::string_view{};
+    return *this;
+  }
+
+  inline swoc::TextView
+  Errata::Annotation::text() const
+  {
+    return _text;
+  }
+
+  inline unsigned short
+  Errata::Annotation::level() const
+  {
+    return _level;
+  }
+
+  inline bool
+  Errata::Annotation::has_severity() const
+  {
+    return _severity.has_value();
+  }
+  inline auto
+  Errata::Annotation::severity() const -> Severity
+  {
+    return *_severity;
+  }
+  inline auto
+  Errata::Annotation::severity(Errata::Severity default_severity) const -> Severity
+  {
+    return _severity.value_or(default_severity);
+  }
+  inline auto
+  Errata::Annotation::assign(Errata::Severity severity) -> self_type &
+  {
+    _severity = severity;
+    return *this;
+  }
+
+  /* ----------------------------------------------------------------------- */
+  // Inline methods for Errata::Data
+
+  inline Errata::Data::Data(MemArena &&arena)
+  {
+    _arena = std::move(arena);
+  }
+
+  inline swoc::MemSpan<char>
+  Errata::Data::remnant()
+  {
+    return _arena.remnant().rebind<char>();
+  }
+
+  inline swoc::MemSpan<char>
+  Errata::Data::alloc(size_t n)
+  {
+    return _arena.alloc(n).rebind<char>();
+  }
+
+  inline bool
+  Errata::Data::empty() const
+  {
+    return _notes.empty();
+  }
+
+  /* ----------------------------------------------------------------------- */
+  // Inline methods for Errata
+
+  inline Errata::Errata(self_type &&that) noexcept
+  {
     std::swap(_data, that._data);
   }
-  return *this;
-}
 
-inline Errata::operator bool() const {
-  return this->is_ok();
-}
-
-inline bool
-Errata::operator!() const {
-  return !this->is_ok();
-}
-
-inline bool
-Errata::empty() const {
-  return _data == nullptr || _data->_notes.count() == 0;
-}
-
-inline auto
-Errata::code() const -> code_type const & {
-  return this->empty() ? DEFAULT_CODE : _data->_code;
-}
-
-inline auto Errata::assign(code_type code) -> self_type & {
-  this->data()->_code = code;
-  return *this;
-}
-
-inline auto
-Errata::severity() const -> Severity {
-  return _data ? _data->_severity.value() : DEFAULT_SEVERITY;
-}
-
-inline auto Errata::assign(Severity severity) -> self_type & {
-  this->data()->_severity = severity;
-  return *this;
-}
-
-inline size_t
-Errata::length() const {
-  return _data ? _data->_notes.count() : 0;
-}
-
-inline bool
-Errata::is_ok() const {
-  return this->empty() || _data->_severity < FAILURE_SEVERITY;
-}
-
-inline const Errata::Annotation &
-Errata::front() const {
-  return *(_data->_notes.head());
-}
-
-inline const Errata::Annotation &
-Errata::back() const {
-  return *(_data->_notes.tail());
-}
-
-inline Errata &
-Errata::note(self_type &&that) {
-  this->note(that); // no longer an rvalue reference, so no recursion.
-  that.clear();
-  return *this;
-}
-
-inline Errata &
-Errata::note(std::string_view text) {
-  return this->note_s({}, text);
-}
-
-inline Errata &
-Errata::note(Severity severity, std::string_view text) {
-  return this->note_s(severity, text);
-}
-
-template <typename... Args>
-Errata &
-Errata::note_sv(std::optional<Severity> severity, std::string_view fmt, std::tuple<Args...> const &args) {
-  if (severity.has_value()) {
-    this->update(*severity);
+  inline Errata::Errata(Severity severity)
+  {
+    this->data()->_severity = severity;
   }
 
-  if (!severity.has_value() || *severity >= FILTER_SEVERITY) {
-    Data *data = this->data();
-    auto span  = data->remnant();
-    FixedBufferWriter bw{span};
-    if (!bw.print_v(fmt, args).error()) {
-      span = span.prefix(bw.extent());
-      data->alloc(bw.extent()); // require the part of the remnant actually used.
-    } else {
-      // Not enough space, get a big enough chunk and do it again.
-      span = this->alloc(bw.extent());
-      FixedBufferWriter{span}.print_v(fmt, args);
+  inline Errata::Errata(const code_type &code, Severity severity)
+  {
+    auto d       = this->data();
+    d->_severity = severity;
+    d->_code     = code;
+  }
+
+  inline Errata::Errata(const code_type &code, Severity severity, const std::string_view &text) : Errata(code, severity)
+  {
+    this->note(text);
+  }
+
+  inline Errata::Errata(const std::string_view &text) : Errata(DEFAULT_CODE, DEFAULT_SEVERITY, text) {}
+  inline Errata::Errata(code_type const &code, const std::string_view &text) : Errata(code, DEFAULT_SEVERITY, text) {}
+  inline Errata::Errata(Severity severity, const std::string_view &text) : Errata(DEFAULT_CODE, severity, text) {}
+
+  template <typename... Args>
+  Errata::Errata(code_type const &code, Severity severity, std::string_view fmt, Args &&...args) : Errata(code, severity)
+  {
+    this->note_v(fmt, std::forward_as_tuple(args...));
+  }
+
+  template <typename... Args>
+  Errata::Errata(code_type const &code, std::string_view fmt, Args &&...args)
+    : Errata(code, DEFAULT_SEVERITY, fmt, std::forward<Args>(args)...)
+  {
+  }
+  template <typename... Args>
+  Errata::Errata(Severity severity, std::string_view fmt, Args &&...args)
+    : Errata(DEFAULT_CODE, severity, fmt, std::forward<Args>(args)...)
+  {
+  }
+  template <typename... Args>
+  Errata::Errata(std::string_view fmt, Args &&...args) : Errata(DEFAULT_CODE, DEFAULT_SEVERITY, fmt, std::forward<Args>(args)...)
+  {
+  }
+
+  inline Errata &
+  Errata::clear()
+  {
+    if (_data) {
+      _data->~Data(); // destructs the @c MemArena in @a _data which releases memory.
+      _data = nullptr;
     }
-    this->note_localized(TextView(span), severity);
+    return *this;
   }
-  return *this;
-}
 
-template <typename... Args>
-Errata &
-Errata::note_v(std::string_view fmt, std::tuple<Args...> const &args) {
-  return this->note_sv({}, fmt, args);
-}
+  inline auto
+  Errata::operator=(self_type &&that) -> self_type &
+  {
+    if (this != &that) {
+      this->clear();
+      std::swap(_data, that._data);
+    }
+    return *this;
+  }
 
-template <typename... Args>
-Errata &
-Errata::note_v(Severity severity, std::string_view fmt, std::tuple<Args...> const &args) {
-  return this->note_sv(severity, fmt, args);
-}
+  inline Errata::operator bool() const
+  {
+    return this->is_ok();
+  }
 
-template <typename... Args>
-Errata &
-Errata::note(std::string_view fmt, Args &&... args) {
-  return this->note_sv({}, fmt, std::forward_as_tuple(args...));
-}
+  inline bool
+  Errata::operator!() const
+  {
+    return !this->is_ok();
+  }
 
-template <typename... Args>
-Errata &
-Errata::note(Severity severity, std::string_view fmt, Args &&... args) {
-  return this->note_sv(severity, fmt, std::forward_as_tuple(args...));
-}
+  inline bool
+  Errata::empty() const
+  {
+    return _data == nullptr || _data->_notes.count() == 0;
+  }
 
-inline Errata::iterator
-Errata::begin() {
-  return _data ? _data->_notes.begin() : iterator();
-}
+  inline auto
+  Errata::code() const -> code_type const &
+  {
+    return this->empty() ? DEFAULT_CODE : _data->_code;
+  }
 
-inline Errata::const_iterator
-Errata::begin() const {
-  return _data ? _data->_notes.begin() : const_iterator();
-}
+  inline auto
+  Errata::assign(code_type code) -> self_type &
+  {
+    this->data()->_code = code;
+    return *this;
+  }
 
-inline Errata::iterator
-Errata::end() {
-  return _data ? _data->_notes.end() : iterator();
-}
+  inline auto
+  Errata::severity() const -> Severity
+  {
+    return _data ? _data->_severity.value() : DEFAULT_SEVERITY;
+  }
 
-inline Errata::const_iterator
-Errata::end() const {
-  return _data ? _data->_notes.end() : const_iterator();
-}
+  inline auto
+  Errata::assign(Severity severity) -> self_type &
+  {
+    this->data()->_severity = severity;
+    return *this;
+  }
 
-inline TextView
-Errata::annotation_glue_text() const {
-  return _data ? _data->_annotation_glue_text : DEFAULT_ANNOTATION_GLUE_TEXT;
-}
+  inline size_t
+  Errata::length() const
+  {
+    return _data ? _data->_notes.count() : 0;
+  }
 
-inline auto
-Errata::assign_annotation_glue_text(TextView text, bool final_glue_p) -> self_type & {
-  this->data()->_annotation_glue_text = this->data()->localize(text);
-  this->data()->_glue_final_p = final_glue_p;
-  return *this;
-}
+  inline bool
+  Errata::is_ok() const
+  {
+    return this->empty() || _data->_severity < FAILURE_SEVERITY;
+  }
 
-inline TextView
-Errata::annotation_severity_glue_text() const {
-  return _data ? _data->_annotation_severity_glue_text : DEFAULT_SEVERITY_GLUE_TEXT;
-}
+  inline const Errata::Annotation &
+  Errata::front() const
+  {
+    return *(_data->_notes.head());
+  }
 
-inline auto
-Errata::assign_annotation_severity_glue_text(TextView text) -> self_type & {
-  this->data()->_annotation_severity_glue_text = this->data()->localize(text);
-  return *this;
-}
+  inline const Errata::Annotation &
+  Errata::back() const
+  {
+    return *(_data->_notes.tail());
+  }
 
-inline TextView
-Errata::severity_glue_text() const {
-  return _data ? _data->_severity_glue_text : DEFAULT_SEVERITY_GLUE_TEXT;
-}
+  inline Errata &
+  Errata::note(self_type &&that)
+  {
+    this->note(that); // no longer an rvalue reference, so no recursion.
+    that.clear();
+    return *this;
+  }
 
-inline auto
-Errata::assign_severity_glue_text(TextView text) -> self_type & {
-  this->data()->_severity_glue_text = this->data()->localize(text);
-  return *this;
-}
+  inline Errata &
+  Errata::note(std::string_view text)
+  {
+    return this->note_s({}, text);
+  }
 
-inline TextView
-Errata::indent_text() const {
-  return _data ? _data->_indent_text : DEFAULT_INDENT_TEXT;
-}
+  inline Errata &
+  Errata::note(Severity severity, std::string_view text)
+  {
+    return this->note_s(severity, text);
+  }
 
-inline auto
-Errata::assign_indent_text(TextView text) -> self_type & {
-  this->data()->_indent_text = this->data()->localize(text);
-  return *this;
-}
+  template <typename... Args>
+  Errata &
+  Errata::note_sv(std::optional<Severity> severity, std::string_view fmt, std::tuple<Args...> const &args)
+  {
+    if (severity.has_value()) {
+      this->update(*severity);
+    }
 
-inline void
-Errata::SinkWrapper::operator()(Errata const &e) const {
-  _f(e);
-}
-/* ----------------------------------------------------------------------- */
-// Inline methods for Rv
+    if (!severity.has_value() || *severity >= FILTER_SEVERITY) {
+      Data *data = this->data();
+      auto span  = data->remnant();
+      FixedBufferWriter bw{span};
+      if (!bw.print_v(fmt, args).error()) {
+        span = span.prefix(bw.extent());
+        data->alloc(bw.extent()); // require the part of the remnant actually used.
+      } else {
+        // Not enough space, get a big enough chunk and do it again.
+        span = this->alloc(bw.extent());
+        FixedBufferWriter{span}.print_v(fmt, args);
+      }
+      this->note_localized(TextView(span), severity);
+    }
+    return *this;
+  }
 
-template <typename R>
-inline auto
-Rv<R>::note(std::string_view text) -> self_type & {
-  _errata.note(text);
-  return *this;
-}
+  template <typename... Args>
+  Errata &
+  Errata::note_v(std::string_view fmt, std::tuple<Args...> const &args)
+  {
+    return this->note_sv({}, fmt, args);
+  }
 
-template <typename R>
-inline auto
-Rv<R>::note(Severity severity, std::string_view text) -> self_type & {
-  _errata.note(severity, text);
-  return *this;
-}
+  template <typename... Args>
+  Errata &
+  Errata::note_v(Severity severity, std::string_view fmt, std::tuple<Args...> const &args)
+  {
+    return this->note_sv(severity, fmt, args);
+  }
 
-template <typename R>
-auto
-Rv<R>::note(const code_type &code) -> self_type & {
-  _errata.note(code);
-  return *this;
-}
+  template <typename... Args>
+  Errata &
+  Errata::note(std::string_view fmt, Args &&...args)
+  {
+    return this->note_sv({}, fmt, std::forward_as_tuple(args...));
+  }
 
-template <typename R>
-auto
-Rv<R>::note(const code_type &code, Severity severity) -> self_type & {
-  _errata.note(code, severity);
-  return *this;
-}
+  template <typename... Args>
+  Errata &
+  Errata::note(Severity severity, std::string_view fmt, Args &&...args)
+  {
+    return this->note_sv(severity, fmt, std::forward_as_tuple(args...));
+  }
 
-template <typename R>
-template <typename... Args>
-auto
-Rv<R>::note(std::string_view fmt, Args &&... args) -> self_type & {
-  _errata.note(fmt, std::forward<Args>(args)...);
-  return *this;
-}
+  inline Errata::iterator
+  Errata::begin()
+  {
+    return _data ? _data->_notes.begin() : iterator();
+  }
 
-template <typename R>
-template <typename... Args>
-auto
-Rv<R>::note(Severity severity, std::string_view fmt, Args &&... args) -> self_type & {
-  _errata.note(severity, fmt, std::forward<Args>(args)...);
-  return *this;
-}
+  inline Errata::const_iterator
+  Errata::begin() const
+  {
+    return _data ? _data->_notes.begin() : const_iterator();
+  }
 
-template <typename R>
-bool
-Rv<R>::is_ok() const {
-  return _errata.is_ok();
-}
+  inline Errata::iterator
+  Errata::end()
+  {
+    return _data ? _data->_notes.end() : iterator();
+  }
 
-template <typename R>
-auto
-Rv<R>::clear() -> self_type & {
-  errata().clear();
-  return *this;
-}
+  inline Errata::const_iterator
+  Errata::end() const
+  {
+    return _data ? _data->_notes.end() : const_iterator();
+  }
 
-template <typename T> Rv<T>::Rv() {}
+  inline TextView
+  Errata::annotation_glue_text() const
+  {
+    return _data ? _data->_annotation_glue_text : DEFAULT_ANNOTATION_GLUE_TEXT;
+  }
 
-template <typename T> Rv<T>::Rv(result_type const &r) : _r(r) {}
+  inline auto
+  Errata::assign_annotation_glue_text(TextView text, bool final_glue_p) -> self_type &
+  {
+    this->data()->_annotation_glue_text = this->data()->localize(text);
+    this->data()->_glue_final_p         = final_glue_p;
+    return *this;
+  }
 
-template <typename T> Rv<T>::Rv(result_type const &r, Errata &&errata) : _r(r), _errata(std::move(errata)) {}
+  inline TextView
+  Errata::annotation_severity_glue_text() const
+  {
+    return _data ? _data->_annotation_severity_glue_text : DEFAULT_SEVERITY_GLUE_TEXT;
+  }
 
-template <typename R> Rv<R>::Rv(R &&r) : _r(std::move(r)) {}
+  inline auto
+  Errata::assign_annotation_severity_glue_text(TextView text) -> self_type &
+  {
+    this->data()->_annotation_severity_glue_text = this->data()->localize(text);
+    return *this;
+  }
 
-template <typename R> Rv<R>::Rv(R &&r, Errata &&errata) : _r(std::move(r)), _errata(std::move(errata)) {}
+  inline TextView
+  Errata::severity_glue_text() const
+  {
+    return _data ? _data->_severity_glue_text : DEFAULT_SEVERITY_GLUE_TEXT;
+  }
 
-template <typename R> Rv<R>::Rv(Errata &&errata) : _errata{std::move(errata)} {}
+  inline auto
+  Errata::assign_severity_glue_text(TextView text) -> self_type &
+  {
+    this->data()->_severity_glue_text = this->data()->localize(text);
+    return *this;
+  }
 
-template <typename T> Rv<T>::operator result_type const &() const {
-  return _r;
-}
+  inline TextView
+  Errata::indent_text() const
+  {
+    return _data ? _data->_indent_text : DEFAULT_INDENT_TEXT;
+  }
 
-template <typename R>
-R const &
-Rv<R>::result() const {
-  return _r;
-}
+  inline auto
+  Errata::assign_indent_text(TextView text) -> self_type &
+  {
+    this->data()->_indent_text = this->data()->localize(text);
+    return *this;
+  }
 
-template <typename R>
-R &
-Rv<R>::result() {
-  return _r;
-}
+  inline void
+  Errata::SinkWrapper::operator()(Errata const &e) const
+  {
+    _f(e);
+  }
+  /* ----------------------------------------------------------------------- */
+  // Inline methods for Rv
 
-template <typename R>
-Errata const &
-Rv<R>::errata() const {
-  return _errata;
-}
+  template <typename R>
+  inline auto
+  Rv<R>::note(std::string_view text) -> self_type &
+  {
+    _errata.note(text);
+    return *this;
+  }
 
-template <typename R>
-Errata &
-Rv<R>::errata() {
-  return _errata;
-}
+  template <typename R>
+  inline auto
+  Rv<R>::note(Severity severity, std::string_view text) -> self_type &
+  {
+    _errata.note(severity, text);
+    return *this;
+  }
 
-template <typename R> Rv<R>::operator Errata &() {
-  return _errata;
-}
+  template <typename R>
+  auto
+  Rv<R>::note(const code_type &code) -> self_type &
+  {
+    _errata.note(code);
+    return *this;
+  }
 
-template <typename R>
-Rv<R> &
-Rv<R>::assign(result_type const &r) {
-  _r = r;
-  return *this;
-}
+  template <typename R>
+  auto
+  Rv<R>::note(const code_type &code, Severity severity) -> self_type &
+  {
+    _errata.note(code, severity);
+    return *this;
+  }
 
-template <typename R>
-Rv<R> &
-Rv<R>::assign(R &&r) {
-  _r = std::move(r);
-  return *this;
-}
+  template <typename R>
+  template <typename... Args>
+  auto
+  Rv<R>::note(std::string_view fmt, Args &&...args) -> self_type &
+  {
+    _errata.note(fmt, std::forward<Args>(args)...);
+    return *this;
+  }
 
-template <typename R>
-auto
-Rv<R>::operator=(Errata &&errata) -> self_type & {
-  _errata = std::move(errata);
-  return *this;
-}
+  template <typename R>
+  template <typename... Args>
+  auto
+  Rv<R>::note(Severity severity, std::string_view fmt, Args &&...args) -> self_type &
+  {
+    _errata.note(severity, fmt, std::forward<Args>(args)...);
+    return *this;
+  }
 
-template <typename R>
-inline Rv<R> &
-Rv<R>::note(Errata const &that) {
-  this->_errata.note(that);
-  return *this;
-}
+  template <typename R>
+  bool
+  Rv<R>::is_ok() const
+  {
+    return _errata.is_ok();
+  }
 
-template <typename R>
-inline Rv<R> &
-Rv<R>::note(Errata &&that) {
-  this->_errata.note(std::move(that));
-  that.clear();
-  return *this;
-}
+  template <typename R>
+  auto
+  Rv<R>::clear() -> self_type &
+  {
+    errata().clear();
+    return *this;
+  }
 
-template <typename R>
-auto
-Rv<R>::operator=(result_type const &r) -> result_type & {
-  _r = r;
-  return _r;
-}
+  template <typename T> Rv<T>::Rv() {}
 
-template <typename R>
-auto
-Rv<R>::operator=(result_type &&r) -> result_type & {
-  _r = std::move(r);
-  return _r;
-}
+  template <typename T> Rv<T>::Rv(result_type const &r) : _r(r) {}
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, Errata::Severity);
+  template <typename T> Rv<T>::Rv(result_type const &r, Errata &&errata) : _r(r), _errata(std::move(errata)) {}
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, Errata::Annotation const &);
+  template <typename R> Rv<R>::Rv(R &&r) : _r(std::move(r)) {}
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, Errata const &);
+  template <typename R> Rv<R>::Rv(R &&r, Errata &&errata) : _r(std::move(r)), _errata(std::move(errata)) {}
 
-}} // namespace swoc::SWOC_VERSION_NS
+  template <typename R> Rv<R>::Rv(Errata &&errata) : _errata{std::move(errata)} {}
+
+  template <typename T> Rv<T>::operator result_type const &() const
+  {
+    return _r;
+  }
+
+  template <typename R>
+  R const &
+  Rv<R>::result() const
+  {
+    return _r;
+  }
+
+  template <typename R>
+  R &
+  Rv<R>::result()
+  {
+    return _r;
+  }
+
+  template <typename R>
+  Errata const &
+  Rv<R>::errata() const
+  {
+    return _errata;
+  }
+
+  template <typename R>
+  Errata &
+  Rv<R>::errata()
+  {
+    return _errata;
+  }
+
+  template <typename R> Rv<R>::operator Errata &()
+  {
+    return _errata;
+  }
+
+  template <typename R>
+  Rv<R> &
+  Rv<R>::assign(result_type const &r)
+  {
+    _r = r;
+    return *this;
+  }
+
+  template <typename R>
+  Rv<R> &
+  Rv<R>::assign(R &&r)
+  {
+    _r = std::move(r);
+    return *this;
+  }
+
+  template <typename R>
+  auto
+  Rv<R>::operator=(Errata &&errata) -> self_type &
+  {
+    _errata = std::move(errata);
+    return *this;
+  }
+
+  template <typename R>
+  inline Rv<R> &
+  Rv<R>::note(Errata const &that)
+  {
+    this->_errata.note(that);
+    return *this;
+  }
+
+  template <typename R>
+  inline Rv<R> &
+  Rv<R>::note(Errata &&that)
+  {
+    this->_errata.note(std::move(that));
+    that.clear();
+    return *this;
+  }
+
+  template <typename R>
+  auto
+  Rv<R>::operator=(result_type const &r) -> result_type &
+  {
+    _r = r;
+    return _r;
+  }
+
+  template <typename R>
+  auto
+  Rv<R>::operator=(result_type &&r) -> result_type &
+  {
+    _r = std::move(r);
+    return _r;
+  }
+
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, Errata::Severity);
+
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, Errata::Annotation const &);
+
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, Errata const &);
+
+} // namespace SWOC_VERSION_NS
+} // namespace swoc
 
 // Tuple / structured binding support.
-namespace std {
+namespace std
+{
 /// @cond INTERNAL_DETAIL
-template <size_t IDX, typename R> class tuple_element<IDX, swoc::Rv<R>> { static_assert("swoc:Rv tuple index out of range"); };
+template <size_t IDX, typename R> class tuple_element<IDX, swoc::Rv<R>>
+{
+  static_assert("swoc:Rv tuple index out of range");
+};
 
-template <typename R> class tuple_element<0, swoc::Rv<R>> {
+template <typename R> class tuple_element<0, swoc::Rv<R>>
+{
 public:
   using type = typename swoc::Rv<R>::result_type;
 };
 
-template <typename R> class tuple_element<1, swoc::Rv<R>> {
+template <typename R> class tuple_element<1, swoc::Rv<R>>
+{
 public:
   using type = swoc::Errata;
 };
 
-template <typename R> class tuple_size<swoc::Rv<R>> : public std::integral_constant<size_t, 2> {};
+template <typename R> class tuple_size<swoc::Rv<R>> : public std::integral_constant<size_t, 2>
+{
+};
 /// @endcond
 } // namespace std
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
-// Not sure how much of this is needed, but experimentally all of these were needed in one
-// use case or another of structured binding. I wasn't able to make this work if this was
-// defined in namespace @c std. Also, because functions can't be partially specialized, it is
-// necessary to use @c constexpr @c if to handle the cases. This should roll up nicely when
-// compiled.
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  // Not sure how much of this is needed, but experimentally all of these were needed in one
+  // use case or another of structured binding. I wasn't able to make this work if this was
+  // defined in namespace @c std. Also, because functions can't be partially specialized, it is
+  // necessary to use @c constexpr @c if to handle the cases. This should roll up nicely when
+  // compiled.
 
-/// @cond INTERNAL_DETAIL
-template <size_t IDX, typename R>
-typename std::tuple_element<IDX, swoc::Rv<R>>::type &
-get(swoc::Rv<R> &&rv) {
-  if constexpr (IDX == 0) {
-    return rv.result();
-  } else if constexpr (IDX == 1) {
-    return rv.errata();
+  /// @cond INTERNAL_DETAIL
+  template <size_t IDX, typename R>
+  typename std::tuple_element<IDX, swoc::Rv<R>>::type &
+  get(swoc::Rv<R> &&rv)
+  {
+    if constexpr (IDX == 0) {
+      return rv.result();
+    } else if constexpr (IDX == 1) {
+      return rv.errata();
+    }
   }
-}
 
-template <size_t IDX, typename R>
-typename std::tuple_element<IDX, swoc::Rv<R>>::type &
-get(swoc::Rv<R> &rv) {
-  static_assert(0 <= IDX && IDX <= 1, "Errata tuple index out of range (0..1)");
-  if constexpr (IDX == 0) {
-    return rv.result();
-  } else if constexpr (IDX == 1) {
-    return rv.errata();
+  template <size_t IDX, typename R>
+  typename std::tuple_element<IDX, swoc::Rv<R>>::type &
+  get(swoc::Rv<R> &rv)
+  {
+    static_assert(0 <= IDX && IDX <= 1, "Errata tuple index out of range (0..1)");
+    if constexpr (IDX == 0) {
+      return rv.result();
+    } else if constexpr (IDX == 1) {
+      return rv.errata();
+    }
+    // Shouldn't need this due to the @c static_assert but the Intel compiler requires it.
+    throw std::domain_error("Errata index value out of bounds");
   }
-  // Shouldn't need this due to the @c static_assert but the Intel compiler requires it.
-  throw std::domain_error("Errata index value out of bounds");
-}
 
-template <size_t IDX, typename R>
-typename std::tuple_element<IDX, swoc::Rv<R>>::type const &
-get(swoc::Rv<R> const &rv) {
-  static_assert(0 <= IDX && IDX <= 1, "Errata tuple index out of range (0..1)");
-  if constexpr (IDX == 0) {
-    return rv.result();
-  } else if constexpr (IDX == 1) {
-    return rv.errata();
+  template <size_t IDX, typename R>
+  typename std::tuple_element<IDX, swoc::Rv<R>>::type const &
+  get(swoc::Rv<R> const &rv)
+  {
+    static_assert(0 <= IDX && IDX <= 1, "Errata tuple index out of range (0..1)");
+    if constexpr (IDX == 0) {
+      return rv.result();
+    } else if constexpr (IDX == 1) {
+      return rv.errata();
+    }
+    // Shouldn't need this due to the @c static_assert but the Intel compiler requires it.
+    throw std::domain_error("Errata index value out of bounds");
   }
-  // Shouldn't need this due to the @c static_assert but the Intel compiler requires it.
-  throw std::domain_error("Errata index value out of bounds");
-}
-/// @endcond
-}} // namespace swoc::SWOC_VERSION_NS
+  /// @endcond
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/include/swoc/IPAddr.h
+++ b/code/include/swoc/IPAddr.h
@@ -15,1441 +15,1592 @@
 #include "swoc/swoc_meta.h"
 #include "swoc/MemSpan.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
 
-using std::string_view;
+  using std::string_view;
 
-union IPEndpoint;
-class IPAddr;
-class IPMask;
+  union IPEndpoint;
+  class IPAddr;
+  class IPMask;
 
-/** Storage for an IPv4 address.
-    Stored in host order.
- */
-class IP4Addr {
-  using self_type = IP4Addr; ///< Self reference type.
-  friend class IP4Range;
-
-public:
-  static constexpr size_t SIZE  = sizeof(in_addr_t);                                 ///< Size of IPv4 address in bytes.
-  static constexpr size_t WIDTH = std::numeric_limits<unsigned char>::digits * SIZE; ///< # of bits in an address.
-
-  static const self_type MIN;                                                        ///< Minimum value.
-  static const self_type MAX;                                                        ///< Maximum value.
-  static constexpr sa_family_t AF_value = AF_INET;                                   ///< Address family type.
-
-  constexpr IP4Addr() = default; ///< Default constructor - ANY address.
-
-  /// Copy constructor.
-  IP4Addr(self_type const& that) = default;
-
-  /// Construct using IPv4 @a addr (in host order).
-  /// @note Host order seems odd, but all of the standard network macro values such as @c INADDR_LOOPBACK
-  /// are in host order.
-  explicit constexpr IP4Addr(in_addr_t addr);
-
-  /// Construct from @c sockaddr_in.
-  explicit IP4Addr(sockaddr_in const *s);
-
-  /// Construct from text representation.
-  /// If the @a text is invalid the result is @c INADDR_ANY
-  IP4Addr(string_view const &text);
-
-  /// Self assignment.
-  self_type & operator=(self_type const& that) = default;
-
-  /// Assign from IPv4 raw address.
-  self_type &operator=(in_addr_t ip);
-
-  /// Set to the address in @a addr.
-  self_type &operator=(sockaddr_in const *sa);
-
-  /// Increment address.
-  self_type &operator++();
-
-  /// Decrement address.
-  self_type &operator--();
-
-  /** Byte access.
-   *
-   * @param idx Byte index.
-   * @return The byte at @a idx in the address (network order).
-   *
-   * For convenience, this returns in "text order" of the octets.
+  /** Storage for an IPv4 address.
+      Stored in host order.
    */
-  uint8_t operator[](unsigned idx) const;
+  class IP4Addr
+  {
+    using self_type = IP4Addr; ///< Self reference type.
+    friend class IP4Range;
 
-  /// Apply @a mask to address, leaving the network portion.
-  self_type &operator&=(IPMask const &mask);
+  public:
+    static constexpr size_t SIZE  = sizeof(in_addr_t);                                 ///< Size of IPv4 address in bytes.
+    static constexpr size_t WIDTH = std::numeric_limits<unsigned char>::digits * SIZE; ///< # of bits in an address.
 
-  /// Apply @a mask to address, creating the broadcast address.
-  self_type &operator|=(IPMask const &mask);
+    static const self_type MIN;                      ///< Minimum value.
+    static const self_type MAX;                      ///< Maximum value.
+    static constexpr sa_family_t AF_value = AF_INET; ///< Address family type.
 
-  /** Update socket address with this address.
-   *
-   * @param sa Socket address.
-   * @return @sa
-   *
-   * @a sa is assumed to be large enough to hold an IPv4 address.
+    constexpr IP4Addr() = default; ///< Default constructor - ANY address.
+
+    /// Copy constructor.
+    IP4Addr(self_type const &that) = default;
+
+    /// Construct using IPv4 @a addr (in host order).
+    /// @note Host order seems odd, but all of the standard network macro values such as @c INADDR_LOOPBACK
+    /// are in host order.
+    explicit constexpr IP4Addr(in_addr_t addr);
+
+    /// Construct from @c sockaddr_in.
+    explicit IP4Addr(sockaddr_in const *s);
+
+    /// Construct from text representation.
+    /// If the @a text is invalid the result is @c INADDR_ANY
+    IP4Addr(string_view const &text);
+
+    /// Self assignment.
+    self_type &operator=(self_type const &that) = default;
+
+    /// Assign from IPv4 raw address.
+    self_type &operator=(in_addr_t ip);
+
+    /// Set to the address in @a addr.
+    self_type &operator=(sockaddr_in const *sa);
+
+    /// Increment address.
+    self_type &operator++();
+
+    /// Decrement address.
+    self_type &operator--();
+
+    /** Byte access.
+     *
+     * @param idx Byte index.
+     * @return The byte at @a idx in the address (network order).
+     *
+     * For convenience, this returns in "text order" of the octets.
+     */
+    uint8_t operator[](unsigned idx) const;
+
+    /// Apply @a mask to address, leaving the network portion.
+    self_type &operator&=(IPMask const &mask);
+
+    /// Apply @a mask to address, creating the broadcast address.
+    self_type &operator|=(IPMask const &mask);
+
+    /** Update socket address with this address.
+     *
+     * @param sa Socket address.
+     * @return @sa
+     *
+     * @a sa is assumed to be large enough to hold an IPv4 address.
+     */
+    sockaddr *copy_to(sockaddr *sa) const;
+
+    /** Update socket address with this address.
+     *
+     * @param sin IPv4 socket address.
+     * @return @sin
+     */
+    sockaddr_in *copy_to(sockaddr_in *sin) const;
+
+    /// @return The address in network order.
+    in_addr_t network_order() const;
+
+    /// @return The address in host order.
+    in_addr_t host_order() const;
+
+    /** Parse IPv4 address.
+     *
+     * @param text Text to parse.
+     *
+     * @return @c true if @a text is a valid IPv4 address, @c false otherwise.
+     *
+     * Whitespace is trimmed from @text before parsing. If the parse fails @a this is set to @c INADDR_ANY.
+     */
+    bool load(string_view const &text);
+
+    /// Standard ternary compare.
+    int cmp(self_type const &that) const;
+
+    /// Get the IP address family.
+    /// @return @c AF_INET
+    /// @note Useful primarily for template classes.
+    constexpr sa_family_t family() const;
+
+    /// @return @c true if this is the "any" address, @c false if not.
+    bool is_any() const;
+
+    /// @return @c true if this is a multicast address, @c false if not.
+    bool is_multicast() const;
+
+    /// @return @c true if this is a loopback address, @c false if not.
+    bool is_loopback() const;
+
+    /// @return @c true if the address is in the link local network.
+    bool is_link_local() const;
+
+    /// @return @c true if the address is private.
+    bool is_private() const;
+
+    /** Left shift.
+     *
+     * @param n Number of bits to shift left.
+     * @return @a this.
+     */
+    self_type &operator<<=(unsigned n);
+
+    /** Right shift.
+     *
+     * @param n Number of bits to shift right.
+     * @return @a this.
+     */
+    self_type &operator>>=(unsigned n);
+
+    /** Bitwise AND.
+     *
+     * @param that Source address.
+     * @return @a this.
+     *
+     * The bits in @a this are set to the bitwise AND of the corresponding bits in @a this and @a that.
+     */
+    self_type &operator&=(self_type const &that);
+
+    /** Bitwise OR.
+     *
+     * @param that Source address.
+     * @return @a this.
+     *
+     * The bits in @a this are set to the bitwise OR of the corresponding bits in @a this and @a that.
+     */
+    self_type &operator|=(self_type const &that);
+
+    /** Convert between network and host order.
+     *
+     * @param src Input address.
+     * @return @a src with the byte reversed.
+     *
+     * This performs the same computation as @c ntohl and @c htonl but is @c constexpr to be usable
+     * in situations those two functions are not.
+     */
+    constexpr static in_addr_t reorder(in_addr_t src);
+
+  protected:
+    /// Access by bytes.
+    using bytes = std::array<uint8_t, 4>;
+
+    friend bool operator==(self_type const &, self_type const &);
+    friend bool operator!=(self_type const &, self_type const &);
+    friend bool operator<(self_type const &, self_type const &);
+    friend bool operator<=(self_type const &, self_type const &);
+
+    in_addr_t _addr = INADDR_ANY; ///< Address in host order.
+  };
+
+  /** Storage for an IPv6 address.
+      Internal storage is not necessarily network ordered.
+      @see network_order
+      @see copy_to
    */
-  sockaddr *copy_to(sockaddr *sa) const;
-
-  /** Update socket address with this address.
-   *
-   * @param sin IPv4 socket address.
-   * @return @sin
-   */
-  sockaddr_in *copy_to(sockaddr_in *sin) const;
-
-  /// @return The address in network order.
-  in_addr_t network_order() const;
-
-  /// @return The address in host order.
-  in_addr_t host_order() const;
-
-  /** Parse IPv4 address.
-   *
-   * @param text Text to parse.
-   *
-   * @return @c true if @a text is a valid IPv4 address, @c false otherwise.
-   *
-   * Whitespace is trimmed from @text before parsing. If the parse fails @a this is set to @c INADDR_ANY.
-  */
-  bool load(string_view const &text);
-
-  /// Standard ternary compare.
-  int cmp(self_type const &that) const;
-
-  /// Get the IP address family.
-  /// @return @c AF_INET
-  /// @note Useful primarily for template classes.
-  constexpr sa_family_t family() const;
-
-  /// @return @c true if this is the "any" address, @c false if not.
-  bool is_any() const;
-
-  /// @return @c true if this is a multicast address, @c false if not.
-  bool is_multicast() const;
-
-  /// @return @c true if this is a loopback address, @c false if not.
-  bool is_loopback() const;
-
-  /// @return @c true if the address is in the link local network.
-  bool is_link_local() const;
-
-  /// @return @c true if the address is private.
-  bool is_private() const;
-
-  /** Left shift.
-   *
-   * @param n Number of bits to shift left.
-   * @return @a this.
-   */
-  self_type &operator<<=(unsigned n);
-
-  /** Right shift.
-   *
-   * @param n Number of bits to shift right.
-   * @return @a this.
-   */
-  self_type &operator>>=(unsigned n);
-
-  /** Bitwise AND.
-   *
-   * @param that Source address.
-   * @return @a this.
-   *
-   * The bits in @a this are set to the bitwise AND of the corresponding bits in @a this and @a that.
-   */
-  self_type &operator&=(self_type const &that);
-
-  /** Bitwise OR.
-   *
-   * @param that Source address.
-   * @return @a this.
-   *
-   * The bits in @a this are set to the bitwise OR of the corresponding bits in @a this and @a that.
-   */
-  self_type &operator|=(self_type const &that);
-
-  /** Convert between network and host order.
-   *
-   * @param src Input address.
-   * @return @a src with the byte reversed.
-   *
-   * This performs the same computation as @c ntohl and @c htonl but is @c constexpr to be usable
-   * in situations those two functions are not.
-   */
-  constexpr static in_addr_t reorder(in_addr_t src);
-
-protected:
-  /// Access by bytes.
-  using bytes = std::array<uint8_t, 4>;
-
-  friend bool operator==(self_type const &, self_type const &);
-  friend bool operator!=(self_type const &, self_type const &);
-  friend bool operator<(self_type const &, self_type const &);
-  friend bool operator<=(self_type const &, self_type const &);
-
-  in_addr_t _addr = INADDR_ANY; ///< Address in host order.
-};
-
-/** Storage for an IPv6 address.
-    Internal storage is not necessarily network ordered.
-    @see network_order
-    @see copy_to
- */
-class IP6Addr {
-  using self_type = IP6Addr; ///< Self reference type.
-
-  friend class IP6Range;
-  friend class IPMask;
-
-public:
-  static constexpr size_t WIDTH         = 128;                                          ///< Number of bits in the address.
-  static constexpr size_t SIZE          = WIDTH / std::numeric_limits<uint8_t>::digits; ///< Size of address in bytes.
-  static constexpr sa_family_t AF_value = AF_INET6;                                     ///< Address family type.
-
-  using quad_type                 = uint16_t;                 ///< Size of one segment of an IPv6 address.
-  static constexpr size_t N_QUADS = SIZE / sizeof(quad_type); ///< # of quads in an IPv6 address.
-  /// Number of bits per quad.
-  static constexpr size_t QUAD_WIDTH = std::numeric_limits<uint8_t>::digits * sizeof(quad_type);
-
-  /// Direct access type for the address.
-  /// Equivalent to the data type for data member @c s6_addr in @c in6_addr.
-  using raw_type = std::array<uint8_t, SIZE>;
-
-  /// Minimum value of an address.
-  static const self_type MIN;
-  /// Maximum value of an address.
-  static const self_type MAX;
-
-  IP6Addr()            = default; ///< Default constructor - ANY address.
-  IP6Addr(self_type const &that) = default;
-
-  /// Construct using IPv6 @a addr.
-  explicit IP6Addr(in6_addr const &addr);
-
-  /// Construct from @c sockaddr_in.
-  explicit IP6Addr(sockaddr_in6 const *addr) { *this = addr; }
-
-  /// Construct from text representation.
-  /// If the @a text is invalid the result is any address.
-  /// @see load
-  IP6Addr(string_view const &text);
-
-  /** Construct mapped IPv4 address.
-   *
-   * @param addr IPv4 address
-   */
-  explicit IP6Addr(IP4Addr addr);
-
-  /// Self assignment.
-  self_type & operator=(self_type const& that) = default;
-
-  /** Left shift.
-   *
-   * @param n Number of bits to shift left.
-   * @return @a this.
-   */
-  self_type &operator<<=(unsigned n);
-
-  /** Right shift.
-   *
-   * @param n Number of bits to shift right.
-   * @return @a this.
-   */
-  self_type &operator>>=(unsigned n);
-
-  /** Bitwise AND.
-   *
-   * @param that Source address.
-   * @return @a this.
-   *
-   * The bits in @a this are set to the bitwise AND of the corresponding bits in @a this and @a that.
-   */
-  self_type &operator&=(self_type const &that);
-
-  /** Bitwise OR.
-   *
-   * @param that Source address.
-   * @return @a this.
-   *
-   * The bits in @a this are set to the bitwise OR of the corresponding bits in @a this and @a that.
-   */
-  self_type &operator|=(self_type const &that);
-
-  /// Increment address.
-  self_type &operator++();
-
-  /// Decrement address.
-  self_type &operator--();
-
-  /// Assign from IPv6 raw address.
-  self_type &operator=(in6_addr const &addr);
-
-  /// Set to the address in @a addr.
-  self_type &operator=(sockaddr_in6 const *addr);
-
-  /** Access a byte in the address.
-   *
-   * @param idx Byte index.
-   * @return The "text order" byte.
-   */
-  constexpr uint8_t operator [] (int idx) const;
-
-  /** Update socket address with this address.
-   *
-   * @param sin IPv6 socket address.
-   * @return @sin
-   */
-  sockaddr_in6 *copy_to(sockaddr_in6 *sin6) const;
-
-  /** Update socket address with this address.
-   *
-   * @param sa Socket address.
-   * @return @sin
-   *
-   * @a sa is assumed to be large enough to hold an IPv6 address.
-   */
-  sockaddr *copy_to(sockaddr *sa) const;
-
-  /// Return the address in host order.
-  in6_addr host_order() const;
-
-  /** Copy the address in host order.
-   *
-   * @param dst Destination for host order address.
-   * @return @a dst
-   */
-  in6_addr& host_order(in6_addr & dst) const;
-
-  /// Return the address in network order.
-  in6_addr network_order() const;
-
-  /** Copy the address in network order.
-   *
-   * @param dst Destination for network order address.
-   * @return @a dst
-   */
-  in6_addr &network_order(in6_addr &dst) const;
-
-  /** Parse a string for an IP address.
-
-      The address resuling from the parse is copied to this object if the conversion is successful,
-      otherwise this object is invalidated.
-
-      @return @c true on success, @c false otherwise.
-  */
-  bool load(string_view const &str);
-
-  /// Generic three value compare.
-  int cmp(self_type const &that) const;
-
-  /// @return The address family.
-  constexpr sa_family_t family() const;
-
-  /// @return @c true if this is the "any" address, @c false if not.
-  bool is_any() const;
-
-  /// @return @c true if this is a loopback address, @c false if not.
-  bool is_loopback() const;
-
-  /// @return @c true if this is a multicast address, @c false if not.
-  bool is_multicast() const;
-
-  /// @return @c true if this is a link local address, @c false if not.
-  bool is_link_local() const;
-
-  /// @return @c true if the address is private.
-  bool is_private() const;
-
-  ///  @return @c true if this is an IPv4 addressed mapped to IPv6, @c false if not.
-  bool is_mapped_ip4() const;
-
-  /** Reset to default constructed state.
-   *
-   * @return @a this
-   */
-  self_type & clear();
-
-  /** Bitwise AND.
-   *
-   * @param that Source mask.
-   * @return @a this.
-   *
-   * The bits in @a this are set to the bitwise AND of the corresponding bits in @a this and @a that.
-   */
-  self_type &operator&=(IPMask const &that);
-
-  /** Bitwise OR.
-   *
-   * @param that Source mask.
-   * @return @a this.
-   *
-   * The bits in @a this are set to the bitwise OR of the corresponding bits in @a this and @a that.
-   */
-  self_type &operator|=(IPMask const &that);
-
-  /** Convert between network and host ordering.
-   *
-   * @param dst Destination for re-ordered address.
-   * @param src Original address.
-   */
-  static void reorder(in6_addr &dst, raw_type const &src);
-
-  /** Convert between network and host ordering.
-   *
-   * @param dst Destination for re-ordered address.
-   * @param src Original address.
-   */
-  static void reorder(raw_type &dst, in6_addr const &src);
-
-  template < typename T > auto as_span() -> std::enable_if_t<swoc::meta::is_any_of_v<T, std::byte, uint8_t, uint16_t, uint32_t, uint64_t>, swoc::MemSpan<T>> {
-    return swoc::MemSpan(_addr._store).template rebind<T>();
-  }
-
-  template < typename T > auto as_span() const -> std::enable_if_t<swoc::meta::is_any_of_v<typename std::remove_const_t<T>, std::byte, uint8_t, uint16_t, uint32_t, uint64_t>, swoc::MemSpan<T const>> {
-    return swoc::MemSpan<uint64_t const>(_addr._store).template rebind<T const>();
-  }
-
-protected:
-  friend bool operator==(self_type const &, self_type const &);
-
-  friend bool operator!=(self_type const &, self_type const &);
-
-  friend bool operator<(self_type const &, self_type const &);
-
-  friend bool operator<=(self_type const &, self_type const &);
-
-  /// Direct access type for the address by quads (16 bits).
-  /// This corresponds to the elements of the text format of the address.
-  using quad_store_type = std::array<quad_type, N_QUADS>;
-
-  /// A bit mask of all 1 bits the size of a quad.
-  static constexpr quad_type QUAD_MASK = ~quad_type{0};
-
-  /// Type used as a "word", the natural working unit of the address.
-  using word_type = uint64_t;
-
-  static constexpr size_t WORD_SIZE = sizeof(word_type);
-
-  /// Number of bits per word.
-  static constexpr size_t WORD_WIDTH = std::numeric_limits<uint8_t>::digits * WORD_SIZE;
-
-  /// Mask the size of a word.
-  static constexpr word_type WORD_MASK = ~word_type(0);
-
-  /// Number of words used for basic address storage.
-  static constexpr size_t N_STORE = SIZE / WORD_SIZE;
-
-  /// Type used to store the address.
-  using word_store_type = std::array<word_type, N_STORE>;
-
-  /// Type for digging around inside the address, with the various forms of access.
-  /// These are in sort of host order - @a _store elements are host order, but the
-  /// MSW and LSW are swapped (big-endian). This makes various bits of the implementation
-  /// easier. Conversion to and from network order is via the @c reorder method.
-  union Addr {
-    word_store_type _store = {0}; ///< 0 is MSW, 1 is LSW.
-    quad_store_type _quad;        ///< By quad.
-    raw_type _raw;                ///< By byte.
-    in6_addr _in6;                ///< By networking type (but in host order!)
-  } _addr;
-  static_assert(sizeof(in6_addr) == sizeof(raw_type));
-
-  static constexpr unsigned LSW = 1; ///< Least significant word index.
-  static constexpr unsigned MSW = 0; ///< Most significant word index.
-
-  /// Index of quads in @a _addr._quad.
-  /// This converts from the position in the text format to the quads in the binary format.
-  static constexpr std::array<unsigned, N_QUADS> QUAD_IDX = {3, 2, 1, 0, 7, 6, 5, 4};
-
-  /// Index of bytes in @a _addr._raw
-  /// This converts MSB (0) to LSB (15) indices to the bytes in the binary format.
-  static constexpr std::array<unsigned, SIZE> RAW_IDX = { 7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8 };
-
-  /// Convert between network and host order.
-  /// The conversion is symmetric.
-  /// @param dst Output where reordered value is placed.
-  /// @param src Input value to resorder.
-  static void reorder(unsigned char dst[WORD_SIZE], unsigned char const src[WORD_SIZE]);
-
-  /** Construct from two 64 bit values.
-   *
-   * @param msw The most significant 64 bits, host order.
-   * @param lsw The least significant 64 bits, host order.
-   */
-  IP6Addr(word_store_type::value_type msw, word_store_type::value_type lsw) : _addr{{msw, lsw}} {}
-
-  friend IP6Addr operator&(IP6Addr const &addr, IPMask const &mask);
-
-  friend IP6Addr operator|(IP6Addr const &addr, IPMask const &mask);
-};
-
-/** An IPv4 or IPv6 address.
- *
- * The family type is stored. For comparisons, invalid < IPv4 < IPv6. All invalid instances are equal.
- */
-class IPAddr {
-  friend class IPRange;
-
-  using self_type = IPAddr; ///< Self reference type.
-public:
-  IPAddr()                      = default; ///< Default constructor - invalid result.
-  IPAddr(self_type const &that) = default; ///< Copy constructor.
-  self_type & operator = (self_type const& that) = default; ///< Copy assignment.
-
-  /// Construct using IPv4 @a addr.
-  explicit IPAddr(in_addr_t addr);
-
-  /// Construct using an IPv4 @a addr
-  IPAddr(IP4Addr const &addr) : _addr{addr}, _family(IP4Addr::AF_value) {}
-
-  /// Construct using IPv6 @a addr.
-  explicit IPAddr(in6_addr const &addr);
-
-  /// construct using an IPv6 @a addr
-  IPAddr(IP6Addr const &addr) : _addr{addr}, _family(IP6Addr::AF_value) {}
-
-  /// Construct from @c sockaddr.
-  explicit IPAddr(sockaddr const *addr);
-
-  /// Construct from @c IPEndpoint.
-  explicit IPAddr(IPEndpoint const &addr);
-
-  /// Construct from text representation.
-  /// If the @a text is invalid the result is an invalid instance.
-  explicit IPAddr(string_view const &text);
-
-  /// Set to the address in @a addr.
-  self_type &assign(sockaddr const *addr);
-
-  /// Set to the address in @a addr.
-  self_type &assign(sockaddr_in const *addr);
-
-  /// Set to the address in @a addr.
-  self_type &assign(sockaddr_in6 const *addr);
-
-  /// Set to IPv4 @a addr.
-  self_type &assign(in_addr_t addr);
-
-  /// Set to IPv6 @a addr
-  self_type &assign(in6_addr const &addr);
-
-  /// Assign from end point.
-  self_type &operator=(IPEndpoint const &ip);
-
-  /// Assign from IPv4 raw address.
-  self_type &operator=(in_addr_t ip);
-
-  /// Assign from IPv6 raw address.
-  self_type &operator=(in6_addr const &addr);
-
-  bool operator==(self_type const &that) const;
-
-  bool operator!=(self_type const &that) const;
-
-  bool operator<(self_type const &that) const;
-
-  bool operator>(self_type const &that) const;
-
-  bool operator<=(self_type const &that) const;
-
-  bool operator>=(self_type const &that) const;
-
-  /// Assign from @c sockaddr
-  self_type &operator=(sockaddr const *addr);
-
-  self_type &operator&=(IPMask const &mask);
-
-  self_type &operator|=(IPMask const &mask);
-
-  /** Copy the address to a socket address.
-   *
-   * @param sa Destination.
-   * @return @a sa
-   */
-  sockaddr * copy_to(sockaddr * sa);
-
-  /** Parse a string and load the result in @a this.
-   *
-   * @param text Text to parse.
-   * @return  @c true on success, @c false otherwise.
-   */
-  bool load(string_view const &text);
-
-  /// Generic compare.
-  int cmp(self_type const &that) const;
-
-  /// Test for same address family.
-  /// @c return @c true if @a that is the same address family as @a this.
-  bool is_same_family(self_type const &that);
-
-  /// Get the address family.
-  /// @return The address family.
-  sa_family_t family() const;
-
-  /// Test for IPv4.
-  bool is_ip4() const;
-
-  /// Test for IPv6.
-  bool is_ip6() const;
-
-  /// @return As IPv4 address - results are undefined if it is not actually IPv4.
-  IP4Addr const &ip4() const;
-
-  /// @return As IPv4 address - results are undefined if it is not actually IPv4.
-  explicit operator IP4Addr() const;
-
-  /// @return As IPv6 address - results are undefined if it is not actually IPv6.
-  IP6Addr const &ip6() const;
-
-  /// @return As IPv6 address - results are undefined if it is not actually IPv6.
-  explicit operator IP6Addr() const;
-
-  /// Test for validity.
-  bool is_valid() const;
-
-  /// Make invalid.
-  self_type &invalidate();
-
-  /// Test for loopback
-  bool is_loopback() const;
-
-  /// Test for multicast
-  bool is_multicast() const;
-
-  /// @return @c true if this is a link local address, @c false if not.
-  bool is_link_local() const;
-
-  /// @return @c true if this is a private address, @c false if not.
-  bool is_private() const;
-
-  ///< Pre-constructed invalid instance.
-  static self_type const INVALID;
-
-protected:
-  friend IP4Addr;
-  friend IP6Addr;
-
-  /// Address data.
-  union raw_addr_type {
-    IP4Addr _ip4;                                    ///< IPv4 address (host)
-    IP6Addr _ip6;                                    ///< IPv6 address (host)
-
-    constexpr raw_addr_type();
-
-    raw_addr_type(in_addr_t addr) : _ip4(addr) {}
-
-    raw_addr_type(in6_addr const &addr) : _ip6(addr) {}
-
-    raw_addr_type(IP4Addr const &addr) : _ip4(addr) {}
-
-    raw_addr_type(IP6Addr const &addr) : _ip6(addr) {}
-  } _addr;
-
-  sa_family_t _family{AF_UNSPEC}; ///< Protocol family.
-};
-
-/** An IP address mask.
- *
- * This is essentially a width for a bit mask.
- */
-class IPMask {
-  using self_type = IPMask; ///< Self reference type.
-
-  friend class IP4Addr;
-  friend class IP6Addr;
-
-public:
-  using raw_type = uint8_t; ///< Storage for mask width.
-
-  IPMask() = default; ///< Default construct to invalid mask.
-
-  /** Construct a mask of @a width.
-   *
-   * @param width Number of bits in the mask.
-   *
-   * @note Because this is a network mask, it is always left justified.
-   */
-  explicit IPMask(raw_type width);
-
-  /// @return @c true if the mask is valid, @c false if not.
-  bool is_valid() const;
-
-  /** Parse mask from @a text.
-   *
-   * @param text A number in string format.
-   * @return @a true if a valid CIDR value, @c false if not.
-   */
-  bool load(string_view const &text);
-
-  /** Copmute a mask for the network at @a addr.
-   * @param addr Lower bound of network.
-   * @return A mask with the width of the largest network starting at @a addr.
-   */
-  static self_type mask_for(IPAddr const &addr);
-
-  /** Copmute a mask for the network at @a addr.
-   * @param addr Lower bound of network.
-   * @return A mask with the width of the largest network starting at @a addr.
-   */
-  static self_type mask_for(IP4Addr const &addr);
-
-  /** Copmute a mask for the network at @a addr.
-   * @param addr Lower bound of network.
-   * @return A mask with the width of the largest network starting at @a addr.
-   */
-  static self_type mask_for(IP6Addr const &addr);
-
-  /// Change to default constructed state (invalid).
-  self_type & clear();
-
-  /// The width of the mask.
-  raw_type width() const;
-
-  /** Extend the mask (cover more addresses).
-   *
-   * @param n Number of bits to extend.
-   * @return @a this
-   *
-   * Effectively shifts the mask left, bringing in 0 bits on the right.
-   */
-  self_type & operator<<=(raw_type n);
-
-  /** Narrow the mask (cover fewer addresses).
-   *
-   * @param n Number of bits to narrow.
-   * @return @a this
-   *
-   * Effectively shift the mask right, bringing in 1 bits on the left.
-   */
-  self_type & operator>>=(raw_type n);
-
-  /** The mask as an IPv4 address.
-   *
-   * @return An IPv4 address that is the mask.
-   *
-   * If the mask is wider than an IPv4 address, the maximum mask is returned.
-   */
-  IP4Addr as_ip4() const;
-
-  /** The mask as an IPv6 address.
-   *
-   * @return An IPv6 address that is the mask.
-   *
-   * If the mask is wider than an IPv6 address, the maximum mask is returned.
-   */
-  IP6Addr as_ip6() const;
-
-protected:
-  /// Marker value for an invalid mask.
-  static constexpr auto INVALID = std::numeric_limits<raw_type>::max();
-
-  raw_type _cidr = INVALID; ///< Mask width in bits.
-
-  /// Compute a partial IPv6 mask, sized for the basic storage type.
-  static raw_type mask_for_quad(IP6Addr::quad_type q);
-};
-
-// --- Implementation
-
-inline constexpr IP4Addr::IP4Addr(in_addr_t addr) : _addr(addr) {}
-
-inline IP4Addr::IP4Addr(string_view const &text) {
-  if (!this->load(text)) {
-    _addr = INADDR_ANY;
-  }
-}
-
-inline constexpr sa_family_t
-IP4Addr::family() const {
-  return AF_value;
-}
-
-inline auto
-IP4Addr::operator<<=(unsigned n) -> self_type & {
-  _addr <<= n;
-  return *this;
-}
-
-inline auto
-IP4Addr::operator>>=(unsigned n) -> self_type & {
-  _addr >>= n;
-  return *this;
-}
-
-inline auto
-IP4Addr::operator&=(self_type const &that) -> self_type & {
-  _addr &= that._addr;
-  return *this;
-}
-
-inline auto
-IP4Addr::operator|=(self_type const &that) -> self_type & {
-  _addr |= that._addr;
-  return *this;
-}
-
-inline auto
-IP4Addr::operator++() -> self_type & {
-  ++_addr;
-  return *this;
-}
-
-inline auto
-IP4Addr::operator--() -> self_type & {
-  --_addr;
-  return *this;
-}
-
-inline in_addr_t
-IP4Addr::network_order() const {
-  return htonl(_addr);
-}
-
-inline in_addr_t
-IP4Addr::host_order() const {
-  return _addr;
-}
-
-inline auto
-IP4Addr::operator=(in_addr_t ip) -> self_type & {
-  _addr = ntohl(ip);
-  return *this;
-}
-
-inline sockaddr *
-IP4Addr::copy_to(sockaddr *sa) const {
-  this->copy_to(reinterpret_cast<sockaddr_in*>(sa));
-  return sa;
-}
-
-/// Equality.
-inline bool
-operator==(IP4Addr const &lhs, IP4Addr const &rhs) {
-  return lhs._addr == rhs._addr;
-}
-
-/// @return @c true if @a lhs is equal to @a rhs.
-inline bool
-operator!=(IP4Addr const &lhs, IP4Addr const &rhs) {
-  return lhs._addr != rhs._addr;
-}
-
-/// @return @c true if @a lhs is less than @a rhs (host order).
-inline bool
-operator<(IP4Addr const &lhs, IP4Addr const &rhs) {
-  return lhs._addr < rhs._addr;
-}
-
-/// @return @c true if @a lhs is less than or equal to@a rhs (host order).
-inline bool
-operator<=(IP4Addr const &lhs, IP4Addr const &rhs) {
-  return lhs._addr <= rhs._addr;
-}
-
-/// @return @c true if @a lhs is greater than @a rhs (host order).
-inline bool
-operator>(IP4Addr const &lhs, IP4Addr const &rhs) {
-  return rhs < lhs;
-}
-
-/// @return @c true if @a lhs is greater than or equal to @a rhs (host order).
-inline bool
-operator>=(IP4Addr const &lhs, IP4Addr const &rhs) {
-  return rhs <= lhs;
-}
-
-inline IP4Addr &
-IP4Addr::operator&=(IPMask const &mask) {
-  _addr &= mask.as_ip4()._addr;
-  return *this;
-}
-
-inline IP4Addr &
-IP4Addr::operator|=(IPMask const &mask) {
-  _addr |= ~(mask.as_ip4()._addr);
-  return *this;
-}
-
-inline bool
-IP4Addr::is_any() const {
-  return _addr == INADDR_ANY;
-}
-
-inline bool
-IP4Addr::is_loopback() const {
-  return (*this)[0] == IN_LOOPBACKNET;
-}
-
-inline bool
-IP4Addr::is_multicast() const {
-  return IN_MULTICAST(_addr);
-}
-
-inline bool
-IP4Addr::is_link_local() const {
-  return (_addr & 0xFFFF0000) == 0xA9FE0000; // 169.254.0.0/16
-}
-
-inline bool IP4Addr::is_private() const {
-  return (((_addr & 0xFF000000) == 0x0A000000) ||        // 10.0.0.0/8
-          ((_addr & 0xFFC00000) == 0x64400000) ||        // 100.64.0.0/10
-          ((_addr & 0xFFF00000) == 0xAC100000) || // 172.16.0.0/12
-          ((_addr & 0xFFFF0000) == 0xC0A80000)           // 192.168.0.0/16
-  );
-}
-
-inline uint8_t
-IP4Addr::operator[](unsigned int idx) const {
-  return reinterpret_cast<bytes const &>(_addr)[3 - idx];
-}
-
-inline int
-IP4Addr::cmp(IP4Addr::self_type const &that) const {
-  return _addr < that._addr ? -1 : _addr > that._addr ? 1 : 0;
-}
-
-constexpr in_addr_t
-IP4Addr::reorder(in_addr_t src) {
-  return ((src & 0xFF) << 24) | (((src >> 8) & 0xFF) << 16) | (((src >> 16) & 0xFF) << 8) | ((src >> 24) & 0xFF);
-}
-
-// +++ IP6Addr +++
-
-inline constexpr sa_family_t
-IP6Addr::family() const {
-  return AF_value;
-}
-
-inline IP6Addr::IP6Addr(in6_addr const &addr) {
-  *this = addr;
-}
-
-inline IP6Addr::IP6Addr(string_view const &text) {
-  if (!this->load(text)) {
-    this->clear();
-  }
-}
-
-inline IP6Addr::IP6Addr(IP4Addr addr) {
-  _addr._store[MSW] = 0;
-  _addr._quad[QUAD_IDX[4]] = 0;
-  _addr._quad[QUAD_IDX[5]] = 0xffff;
-  _addr._quad[QUAD_IDX[6]] = addr.host_order() >> QUAD_WIDTH;
-  _addr._quad[QUAD_IDX[7]] = addr.host_order();
-}
-
-inline bool
-IP6Addr::is_loopback() const {
-  return _addr._store[MSW] == 0 && _addr._store[LSW] == 1;
-}
-
-inline bool
-IP6Addr::is_multicast() const {
-  return _addr._raw[RAW_IDX[0]] == 0xFF;
-}
-
-inline bool
-IP6Addr::is_any() const {
-  return _addr._store[MSW] == 0 && _addr._store[LSW] == 0;
-}
-
-inline bool
-IP6Addr::is_mapped_ip4() const {
-  return 0 == _addr._store[MSW] && (_addr._quad[QUAD_IDX[4]] == 0 && _addr._quad[QUAD_IDX[5]] == 0xFFFF);
-}
-
-inline bool
-IP6Addr::is_link_local() const {
-  return _addr._raw[RAW_IDX[0]] == 0xFE && (_addr._raw[RAW_IDX[1]] & 0xC0) == 0x80; // fe80::/10
-}
-
-inline bool IP6Addr::is_private() const {
-  return (_addr._raw[RAW_IDX[0]]& 0xFE) == 0xFC; // fc00::/7
-}
-
-inline in6_addr
-IP6Addr::host_order() const {
-  Addr zret { {_addr._store[LSW], _addr._store[MSW] }};
-  return zret._in6;
-}
-
-inline in6_addr &
-IP6Addr::host_order(in6_addr & dst) const {
-  Addr * addr = reinterpret_cast<Addr*>(&dst);
-  addr->_store[0] = _addr._store[LSW];
-  addr->_store[1] = _addr._store[MSW];
-  return dst;
-}
-
-inline in6_addr
-IP6Addr::network_order() const {
-  in6_addr zret;
-  return this->network_order(zret);
-}
-
-inline in6_addr &
-IP6Addr::network_order(in6_addr & dst) const {
-  self_type::reorder(dst, _addr._raw);
-  return dst;
-}
-
-inline auto
-IP6Addr::clear() -> self_type & {
-  _addr._store[MSW] = _addr._store[LSW] = 0;
-  return *this;
-}
-
-inline auto
-IP6Addr::operator=(in6_addr const &addr) -> self_type & {
-  self_type::reorder(_addr._raw, addr);
-  return *this;
-}
-
-inline auto
-IP6Addr::operator=(sockaddr_in6 const *addr) -> self_type & {
-  if (addr) {
-    *this = addr->sin6_addr;
-  } else {
-    this->clear();
-  }
-  return *this;
-}
-
-inline auto
-IP6Addr::operator++() -> self_type & {
-  if (++(_addr._store[LSW]) == 0) {
-    ++(_addr._store[MSW]);
-  }
-  return *this;
-}
-
-inline auto
-IP6Addr::operator--() -> self_type & {
-  if (--(_addr._store[LSW]) == ~static_cast<uint64_t>(0)) {
-    --(_addr._store[MSW]);
-  }
-  return *this;
-}
-
-inline void
-IP6Addr::reorder(unsigned char dst[WORD_SIZE], unsigned char const src[WORD_SIZE]) {
-  for (size_t idx = 0; idx < WORD_SIZE; ++idx) {
-    dst[idx] = src[WORD_SIZE - (idx + 1)];
-  }
-}
-
-/// @return @c true if @a lhs is equal to @a rhs.
-inline bool
-operator==(IP6Addr const &lhs, IP6Addr const &rhs) {
-  return lhs._addr._store[IP6Addr::MSW] == rhs._addr._store[IP6Addr::MSW] && lhs._addr._store[IP6Addr::LSW] == rhs._addr._store[IP6Addr::LSW];
-}
-
-/// @return @c true if @a lhs is not equal to @a rhs.
-inline bool
-operator!=(IP6Addr const &lhs, IP6Addr const &rhs) {
-  return lhs._addr._store[IP6Addr::MSW] != rhs._addr._store[IP6Addr::MSW] || lhs._addr._store[IP6Addr::LSW] != rhs._addr._store[IP6Addr::LSW];
-}
-
-/// @return @c true if @a lhs is less than @a rhs.
-inline bool
-operator<(IP6Addr const &lhs, IP6Addr const &rhs) {
-  return lhs._addr._store[IP6Addr::MSW] < rhs._addr._store[IP6Addr::MSW] ||
-  (lhs._addr._store[IP6Addr::MSW] == rhs._addr._store[IP6Addr::MSW] && lhs._addr._store[IP6Addr::LSW] < rhs._addr._store[IP6Addr::LSW]);
-}
-
-/// @return @c true if @a lhs is greater than @a rhs.
-inline bool
-operator>(IP6Addr const &lhs, IP6Addr const &rhs) {
-  return rhs < lhs;
-}
-
-/// @return @c true if @a lhs is less than or equal to @a rhs.
-inline bool
-operator<=(IP6Addr const &lhs, IP6Addr const &rhs) {
-  return lhs._addr._store[IP6Addr::MSW] < rhs._addr._store[IP6Addr::MSW] ||
-  (lhs._addr._store[IP6Addr::MSW] == rhs._addr._store[IP6Addr::MSW] && lhs._addr._store[IP6Addr::LSW] <= rhs._addr._store[IP6Addr::LSW]);
-}
-
-/// @return @c true if @a lhs is greater than or equal to @a rhs.
-inline bool
-operator>=(IP6Addr const &lhs, IP6Addr const &rhs) {
-  return rhs <= lhs;
-}
-
-inline sockaddr *
-IP6Addr::copy_to(sockaddr *sa) const {
-  this->copy_to(reinterpret_cast<sockaddr_in6*>(sa));
-  return sa;
-}
-
-inline auto
-IP6Addr::operator&=(IPMask const &mask) -> self_type & {
-  if (mask._cidr <= WORD_WIDTH) {
-    _addr._store[LSW] = 0;
-    if (0 == mask._cidr) {
-      _addr._store[MSW] = 0;
-    } else if (mask._cidr < WORD_WIDTH) {
-      _addr._store[MSW] &= (WORD_MASK << (WORD_WIDTH - mask._cidr));
+  class IP6Addr
+  {
+    using self_type = IP6Addr; ///< Self reference type.
+
+    friend class IP6Range;
+    friend class IPMask;
+
+  public:
+    static constexpr size_t WIDTH         = 128;                                          ///< Number of bits in the address.
+    static constexpr size_t SIZE          = WIDTH / std::numeric_limits<uint8_t>::digits; ///< Size of address in bytes.
+    static constexpr sa_family_t AF_value = AF_INET6;                                     ///< Address family type.
+
+    using quad_type                 = uint16_t;                 ///< Size of one segment of an IPv6 address.
+    static constexpr size_t N_QUADS = SIZE / sizeof(quad_type); ///< # of quads in an IPv6 address.
+    /// Number of bits per quad.
+    static constexpr size_t QUAD_WIDTH = std::numeric_limits<uint8_t>::digits * sizeof(quad_type);
+
+    /// Direct access type for the address.
+    /// Equivalent to the data type for data member @c s6_addr in @c in6_addr.
+    using raw_type = std::array<uint8_t, SIZE>;
+
+    /// Minimum value of an address.
+    static const self_type MIN;
+    /// Maximum value of an address.
+    static const self_type MAX;
+
+    IP6Addr()                      = default; ///< Default constructor - ANY address.
+    IP6Addr(self_type const &that) = default;
+
+    /// Construct using IPv6 @a addr.
+    explicit IP6Addr(in6_addr const &addr);
+
+    /// Construct from @c sockaddr_in.
+    explicit IP6Addr(sockaddr_in6 const *addr) { *this = addr; }
+
+    /// Construct from text representation.
+    /// If the @a text is invalid the result is any address.
+    /// @see load
+    IP6Addr(string_view const &text);
+
+    /** Construct mapped IPv4 address.
+     *
+     * @param addr IPv4 address
+     */
+    explicit IP6Addr(IP4Addr addr);
+
+    /// Self assignment.
+    self_type &operator=(self_type const &that) = default;
+
+    /** Left shift.
+     *
+     * @param n Number of bits to shift left.
+     * @return @a this.
+     */
+    self_type &operator<<=(unsigned n);
+
+    /** Right shift.
+     *
+     * @param n Number of bits to shift right.
+     * @return @a this.
+     */
+    self_type &operator>>=(unsigned n);
+
+    /** Bitwise AND.
+     *
+     * @param that Source address.
+     * @return @a this.
+     *
+     * The bits in @a this are set to the bitwise AND of the corresponding bits in @a this and @a that.
+     */
+    self_type &operator&=(self_type const &that);
+
+    /** Bitwise OR.
+     *
+     * @param that Source address.
+     * @return @a this.
+     *
+     * The bits in @a this are set to the bitwise OR of the corresponding bits in @a this and @a that.
+     */
+    self_type &operator|=(self_type const &that);
+
+    /// Increment address.
+    self_type &operator++();
+
+    /// Decrement address.
+    self_type &operator--();
+
+    /// Assign from IPv6 raw address.
+    self_type &operator=(in6_addr const &addr);
+
+    /// Set to the address in @a addr.
+    self_type &operator=(sockaddr_in6 const *addr);
+
+    /** Access a byte in the address.
+     *
+     * @param idx Byte index.
+     * @return The "text order" byte.
+     */
+    constexpr uint8_t operator[](int idx) const;
+
+    /** Update socket address with this address.
+     *
+     * @param sin IPv6 socket address.
+     * @return @sin
+     */
+    sockaddr_in6 *copy_to(sockaddr_in6 *sin6) const;
+
+    /** Update socket address with this address.
+     *
+     * @param sa Socket address.
+     * @return @sin
+     *
+     * @a sa is assumed to be large enough to hold an IPv6 address.
+     */
+    sockaddr *copy_to(sockaddr *sa) const;
+
+    /// Return the address in host order.
+    in6_addr host_order() const;
+
+    /** Copy the address in host order.
+     *
+     * @param dst Destination for host order address.
+     * @return @a dst
+     */
+    in6_addr &host_order(in6_addr &dst) const;
+
+    /// Return the address in network order.
+    in6_addr network_order() const;
+
+    /** Copy the address in network order.
+     *
+     * @param dst Destination for network order address.
+     * @return @a dst
+     */
+    in6_addr &network_order(in6_addr &dst) const;
+
+    /** Parse a string for an IP address.
+
+        The address resuling from the parse is copied to this object if the conversion is successful,
+        otherwise this object is invalidated.
+
+        @return @c true on success, @c false otherwise.
+    */
+    bool load(string_view const &str);
+
+    /// Generic three value compare.
+    int cmp(self_type const &that) const;
+
+    /// @return The address family.
+    constexpr sa_family_t family() const;
+
+    /// @return @c true if this is the "any" address, @c false if not.
+    bool is_any() const;
+
+    /// @return @c true if this is a loopback address, @c false if not.
+    bool is_loopback() const;
+
+    /// @return @c true if this is a multicast address, @c false if not.
+    bool is_multicast() const;
+
+    /// @return @c true if this is a link local address, @c false if not.
+    bool is_link_local() const;
+
+    /// @return @c true if the address is private.
+    bool is_private() const;
+
+    ///  @return @c true if this is an IPv4 addressed mapped to IPv6, @c false if not.
+    bool is_mapped_ip4() const;
+
+    /** Reset to default constructed state.
+     *
+     * @return @a this
+     */
+    self_type &clear();
+
+    /** Bitwise AND.
+     *
+     * @param that Source mask.
+     * @return @a this.
+     *
+     * The bits in @a this are set to the bitwise AND of the corresponding bits in @a this and @a that.
+     */
+    self_type &operator&=(IPMask const &that);
+
+    /** Bitwise OR.
+     *
+     * @param that Source mask.
+     * @return @a this.
+     *
+     * The bits in @a this are set to the bitwise OR of the corresponding bits in @a this and @a that.
+     */
+    self_type &operator|=(IPMask const &that);
+
+    /** Convert between network and host ordering.
+     *
+     * @param dst Destination for re-ordered address.
+     * @param src Original address.
+     */
+    static void reorder(in6_addr &dst, raw_type const &src);
+
+    /** Convert between network and host ordering.
+     *
+     * @param dst Destination for re-ordered address.
+     * @param src Original address.
+     */
+    static void reorder(raw_type &dst, in6_addr const &src);
+
+    template <typename T>
+    auto
+    as_span() -> std::enable_if_t<swoc::meta::is_any_of_v<T, std::byte, uint8_t, uint16_t, uint32_t, uint64_t>, swoc::MemSpan<T>>
+    {
+      return swoc::MemSpan(_addr._store).template rebind<T>();
     }
-  } else if (mask._cidr < WIDTH) {
-    _addr._store[LSW] &= (WORD_MASK << (2 * WORD_WIDTH - mask._cidr));
-  }
-  return *this;
-}
 
-inline auto
-IP6Addr::operator|=(IPMask const &mask) -> self_type & {
-  if (mask._cidr > WORD_WIDTH) {
-    if (mask._cidr < WIDTH) {
-      _addr._store[LSW] |= (WORD_MASK >> (mask._cidr - WORD_WIDTH));
+    template <typename T>
+    auto
+    as_span() const -> std::enable_if_t<
+      swoc::meta::is_any_of_v<typename std::remove_const_t<T>, std::byte, uint8_t, uint16_t, uint32_t, uint64_t>,
+      swoc::MemSpan<T const>>
+    {
+      return swoc::MemSpan<uint64_t const>(_addr._store).template rebind<T const>();
     }
-  } else {
-    _addr._store[LSW] = WORD_MASK;
-    if (0 == mask._cidr) {
-      _addr._store[MSW] = WORD_MASK;
-    } else if (mask._cidr < WORD_WIDTH) {
-      _addr._store[MSW] |= (WORD_MASK >> mask._cidr);
+
+  protected:
+    friend bool operator==(self_type const &, self_type const &);
+
+    friend bool operator!=(self_type const &, self_type const &);
+
+    friend bool operator<(self_type const &, self_type const &);
+
+    friend bool operator<=(self_type const &, self_type const &);
+
+    /// Direct access type for the address by quads (16 bits).
+    /// This corresponds to the elements of the text format of the address.
+    using quad_store_type = std::array<quad_type, N_QUADS>;
+
+    /// A bit mask of all 1 bits the size of a quad.
+    static constexpr quad_type QUAD_MASK = ~quad_type{0};
+
+    /// Type used as a "word", the natural working unit of the address.
+    using word_type = uint64_t;
+
+    static constexpr size_t WORD_SIZE = sizeof(word_type);
+
+    /// Number of bits per word.
+    static constexpr size_t WORD_WIDTH = std::numeric_limits<uint8_t>::digits * WORD_SIZE;
+
+    /// Mask the size of a word.
+    static constexpr word_type WORD_MASK = ~word_type(0);
+
+    /// Number of words used for basic address storage.
+    static constexpr size_t N_STORE = SIZE / WORD_SIZE;
+
+    /// Type used to store the address.
+    using word_store_type = std::array<word_type, N_STORE>;
+
+    /// Type for digging around inside the address, with the various forms of access.
+    /// These are in sort of host order - @a _store elements are host order, but the
+    /// MSW and LSW are swapped (big-endian). This makes various bits of the implementation
+    /// easier. Conversion to and from network order is via the @c reorder method.
+    union Addr {
+      word_store_type _store = {0}; ///< 0 is MSW, 1 is LSW.
+      quad_store_type _quad;        ///< By quad.
+      raw_type _raw;                ///< By byte.
+      in6_addr _in6;                ///< By networking type (but in host order!)
+    } _addr;
+    static_assert(sizeof(in6_addr) == sizeof(raw_type));
+
+    static constexpr unsigned LSW = 1; ///< Least significant word index.
+    static constexpr unsigned MSW = 0; ///< Most significant word index.
+
+    /// Index of quads in @a _addr._quad.
+    /// This converts from the position in the text format to the quads in the binary format.
+    static constexpr std::array<unsigned, N_QUADS> QUAD_IDX = {3, 2, 1, 0, 7, 6, 5, 4};
+
+    /// Index of bytes in @a _addr._raw
+    /// This converts MSB (0) to LSB (15) indices to the bytes in the binary format.
+    static constexpr std::array<unsigned, SIZE> RAW_IDX = {7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8};
+
+    /// Convert between network and host order.
+    /// The conversion is symmetric.
+    /// @param dst Output where reordered value is placed.
+    /// @param src Input value to resorder.
+    static void reorder(unsigned char dst[WORD_SIZE], unsigned char const src[WORD_SIZE]);
+
+    /** Construct from two 64 bit values.
+     *
+     * @param msw The most significant 64 bits, host order.
+     * @param lsw The least significant 64 bits, host order.
+     */
+    IP6Addr(word_store_type::value_type msw, word_store_type::value_type lsw)
+      : _addr{
+          {msw, lsw}
+    }
+    {
+    }
+
+    friend IP6Addr operator&(IP6Addr const &addr, IPMask const &mask);
+
+    friend IP6Addr operator|(IP6Addr const &addr, IPMask const &mask);
+  };
+
+  /** An IPv4 or IPv6 address.
+   *
+   * The family type is stored. For comparisons, invalid < IPv4 < IPv6. All invalid instances are equal.
+   */
+  class IPAddr
+  {
+    friend class IPRange;
+
+    using self_type = IPAddr; ///< Self reference type.
+  public:
+    IPAddr()                                    = default; ///< Default constructor - invalid result.
+    IPAddr(self_type const &that)               = default; ///< Copy constructor.
+    self_type &operator=(self_type const &that) = default; ///< Copy assignment.
+
+    /// Construct using IPv4 @a addr.
+    explicit IPAddr(in_addr_t addr);
+
+    /// Construct using an IPv4 @a addr
+    IPAddr(IP4Addr const &addr) : _addr{addr}, _family(IP4Addr::AF_value) {}
+
+    /// Construct using IPv6 @a addr.
+    explicit IPAddr(in6_addr const &addr);
+
+    /// construct using an IPv6 @a addr
+    IPAddr(IP6Addr const &addr) : _addr{addr}, _family(IP6Addr::AF_value) {}
+
+    /// Construct from @c sockaddr.
+    explicit IPAddr(sockaddr const *addr);
+
+    /// Construct from @c IPEndpoint.
+    explicit IPAddr(IPEndpoint const &addr);
+
+    /// Construct from text representation.
+    /// If the @a text is invalid the result is an invalid instance.
+    explicit IPAddr(string_view const &text);
+
+    /// Set to the address in @a addr.
+    self_type &assign(sockaddr const *addr);
+
+    /// Set to the address in @a addr.
+    self_type &assign(sockaddr_in const *addr);
+
+    /// Set to the address in @a addr.
+    self_type &assign(sockaddr_in6 const *addr);
+
+    /// Set to IPv4 @a addr.
+    self_type &assign(in_addr_t addr);
+
+    /// Set to IPv6 @a addr
+    self_type &assign(in6_addr const &addr);
+
+    /// Assign from end point.
+    self_type &operator=(IPEndpoint const &ip);
+
+    /// Assign from IPv4 raw address.
+    self_type &operator=(in_addr_t ip);
+
+    /// Assign from IPv6 raw address.
+    self_type &operator=(in6_addr const &addr);
+
+    bool operator==(self_type const &that) const;
+
+    bool operator!=(self_type const &that) const;
+
+    bool operator<(self_type const &that) const;
+
+    bool operator>(self_type const &that) const;
+
+    bool operator<=(self_type const &that) const;
+
+    bool operator>=(self_type const &that) const;
+
+    /// Assign from @c sockaddr
+    self_type &operator=(sockaddr const *addr);
+
+    self_type &operator&=(IPMask const &mask);
+
+    self_type &operator|=(IPMask const &mask);
+
+    /** Copy the address to a socket address.
+     *
+     * @param sa Destination.
+     * @return @a sa
+     */
+    sockaddr *copy_to(sockaddr *sa);
+
+    /** Parse a string and load the result in @a this.
+     *
+     * @param text Text to parse.
+     * @return  @c true on success, @c false otherwise.
+     */
+    bool load(string_view const &text);
+
+    /// Generic compare.
+    int cmp(self_type const &that) const;
+
+    /// Test for same address family.
+    /// @c return @c true if @a that is the same address family as @a this.
+    bool is_same_family(self_type const &that);
+
+    /// Get the address family.
+    /// @return The address family.
+    sa_family_t family() const;
+
+    /// Test for IPv4.
+    bool is_ip4() const;
+
+    /// Test for IPv6.
+    bool is_ip6() const;
+
+    /// @return As IPv4 address - results are undefined if it is not actually IPv4.
+    IP4Addr const &ip4() const;
+
+    /// @return As IPv4 address - results are undefined if it is not actually IPv4.
+    explicit operator IP4Addr() const;
+
+    /// @return As IPv6 address - results are undefined if it is not actually IPv6.
+    IP6Addr const &ip6() const;
+
+    /// @return As IPv6 address - results are undefined if it is not actually IPv6.
+    explicit operator IP6Addr() const;
+
+    /// Test for validity.
+    bool is_valid() const;
+
+    /// Make invalid.
+    self_type &invalidate();
+
+    /// Test for loopback
+    bool is_loopback() const;
+
+    /// Test for multicast
+    bool is_multicast() const;
+
+    /// @return @c true if this is a link local address, @c false if not.
+    bool is_link_local() const;
+
+    /// @return @c true if this is a private address, @c false if not.
+    bool is_private() const;
+
+    ///< Pre-constructed invalid instance.
+    static self_type const INVALID;
+
+  protected:
+    friend IP4Addr;
+    friend IP6Addr;
+
+    /// Address data.
+    union raw_addr_type {
+      IP4Addr _ip4; ///< IPv4 address (host)
+      IP6Addr _ip6; ///< IPv6 address (host)
+
+      constexpr raw_addr_type();
+
+      raw_addr_type(in_addr_t addr) : _ip4(addr) {}
+
+      raw_addr_type(in6_addr const &addr) : _ip6(addr) {}
+
+      raw_addr_type(IP4Addr const &addr) : _ip4(addr) {}
+
+      raw_addr_type(IP6Addr const &addr) : _ip6(addr) {}
+    } _addr;
+
+    sa_family_t _family{AF_UNSPEC}; ///< Protocol family.
+  };
+
+  /** An IP address mask.
+   *
+   * This is essentially a width for a bit mask.
+   */
+  class IPMask
+  {
+    using self_type = IPMask; ///< Self reference type.
+
+    friend class IP4Addr;
+    friend class IP6Addr;
+
+  public:
+    using raw_type = uint8_t; ///< Storage for mask width.
+
+    IPMask() = default; ///< Default construct to invalid mask.
+
+    /** Construct a mask of @a width.
+     *
+     * @param width Number of bits in the mask.
+     *
+     * @note Because this is a network mask, it is always left justified.
+     */
+    explicit IPMask(raw_type width);
+
+    /// @return @c true if the mask is valid, @c false if not.
+    bool is_valid() const;
+
+    /** Parse mask from @a text.
+     *
+     * @param text A number in string format.
+     * @return @a true if a valid CIDR value, @c false if not.
+     */
+    bool load(string_view const &text);
+
+    /** Copmute a mask for the network at @a addr.
+     * @param addr Lower bound of network.
+     * @return A mask with the width of the largest network starting at @a addr.
+     */
+    static self_type mask_for(IPAddr const &addr);
+
+    /** Copmute a mask for the network at @a addr.
+     * @param addr Lower bound of network.
+     * @return A mask with the width of the largest network starting at @a addr.
+     */
+    static self_type mask_for(IP4Addr const &addr);
+
+    /** Copmute a mask for the network at @a addr.
+     * @param addr Lower bound of network.
+     * @return A mask with the width of the largest network starting at @a addr.
+     */
+    static self_type mask_for(IP6Addr const &addr);
+
+    /// Change to default constructed state (invalid).
+    self_type &clear();
+
+    /// The width of the mask.
+    raw_type width() const;
+
+    /** Extend the mask (cover more addresses).
+     *
+     * @param n Number of bits to extend.
+     * @return @a this
+     *
+     * Effectively shifts the mask left, bringing in 0 bits on the right.
+     */
+    self_type &operator<<=(raw_type n);
+
+    /** Narrow the mask (cover fewer addresses).
+     *
+     * @param n Number of bits to narrow.
+     * @return @a this
+     *
+     * Effectively shift the mask right, bringing in 1 bits on the left.
+     */
+    self_type &operator>>=(raw_type n);
+
+    /** The mask as an IPv4 address.
+     *
+     * @return An IPv4 address that is the mask.
+     *
+     * If the mask is wider than an IPv4 address, the maximum mask is returned.
+     */
+    IP4Addr as_ip4() const;
+
+    /** The mask as an IPv6 address.
+     *
+     * @return An IPv6 address that is the mask.
+     *
+     * If the mask is wider than an IPv6 address, the maximum mask is returned.
+     */
+    IP6Addr as_ip6() const;
+
+  protected:
+    /// Marker value for an invalid mask.
+    static constexpr auto INVALID = std::numeric_limits<raw_type>::max();
+
+    raw_type _cidr = INVALID; ///< Mask width in bits.
+
+    /// Compute a partial IPv6 mask, sized for the basic storage type.
+    static raw_type mask_for_quad(IP6Addr::quad_type q);
+  };
+
+  // --- Implementation
+
+  inline constexpr IP4Addr::IP4Addr(in_addr_t addr) : _addr(addr) {}
+
+  inline IP4Addr::IP4Addr(string_view const &text)
+  {
+    if (!this->load(text)) {
+      _addr = INADDR_ANY;
     }
   }
-  return *this;
-}
 
-// +++ IPMask +++
-
-inline IPMask::IPMask(raw_type width) : _cidr(width) {}
-
-inline bool
-IPMask::is_valid() const {
-  return _cidr < INVALID;
-}
-
-inline auto
-IPMask::width() const -> raw_type {
-  return _cidr;
-}
-
-inline bool
-operator==(IPMask const &lhs, IPMask const &rhs) {
-  return lhs.width() == rhs.width();
-}
-
-inline bool
-operator!=(IPMask const &lhs, IPMask const &rhs) {
-  return lhs.width() != rhs.width();
-}
-
-inline bool
-operator<(IPMask const &lhs, IPMask const &rhs) {
-  return lhs.width() < rhs.width();
-}
-
-inline IP4Addr
-IPMask::as_ip4() const {
-  static constexpr auto MASK = ~in_addr_t{0};
-  in_addr_t addr             = MASK;
-  if (0 == _cidr) {
-    addr = in_addr_t(0);
-  } else if (_cidr < IP4Addr::WIDTH) {
-    addr <<= IP4Addr::WIDTH - _cidr;
+  inline constexpr sa_family_t
+  IP4Addr::family() const
+  {
+    return AF_value;
   }
-  return IP4Addr{addr};
-}
 
-inline auto
-IPMask::clear() ->  self_type & {
-  _cidr = INVALID;
-  return *this;
-}
+  inline auto
+  IP4Addr::operator<<=(unsigned n) -> self_type &
+  {
+    _addr <<= n;
+    return *this;
+  }
 
-inline auto
-IPMask::operator<<=(raw_type n) -> self_type & {
-  _cidr -= n;
-  return *this;
-}
+  inline auto
+  IP4Addr::operator>>=(unsigned n) -> self_type &
+  {
+    _addr >>= n;
+    return *this;
+  }
 
-inline auto
-IPMask::operator>>=(IPMask::raw_type n) -> self_type & {
-  _cidr += n;
-  return *this;
-}
+  inline auto
+  IP4Addr::operator&=(self_type const &that) -> self_type &
+  {
+    _addr &= that._addr;
+    return *this;
+  }
 
-// +++ mixed mask operators +++
+  inline auto
+  IP4Addr::operator|=(self_type const &that) -> self_type &
+  {
+    _addr |= that._addr;
+    return *this;
+  }
 
-inline IP4Addr
-operator&(IP4Addr const &addr, IPMask const &mask) {
-  return IP4Addr{addr} &= mask;
-}
+  inline auto
+  IP4Addr::operator++() -> self_type &
+  {
+    ++_addr;
+    return *this;
+  }
 
-inline IP4Addr
-operator|(IP4Addr const &addr, IPMask const &mask) {
-  return IP4Addr{addr} |= mask;
-}
+  inline auto
+  IP4Addr::operator--() -> self_type &
+  {
+    --_addr;
+    return *this;
+  }
 
-inline IP6Addr
-operator&(IP6Addr const &addr, IPMask const &mask) {
-  return IP6Addr{addr} &= mask;
-}
+  inline in_addr_t
+  IP4Addr::network_order() const
+  {
+    return htonl(_addr);
+  }
 
-inline IP6Addr
-operator|(IP6Addr const &addr, IPMask const &mask) {
-  return IP6Addr{addr} |= mask;
-}
+  inline in_addr_t
+  IP4Addr::host_order() const
+  {
+    return _addr;
+  }
 
-constexpr uint8_t
-IP6Addr::operator[](int idx) const {
-  return _addr._raw[RAW_IDX[idx]];
-}
+  inline auto
+  IP4Addr::operator=(in_addr_t ip) -> self_type &
+  {
+    _addr = ntohl(ip);
+    return *this;
+  }
 
-inline IPAddr
-operator&(IPAddr const &addr, IPMask const &mask) {
-  return IPAddr{addr} &= mask;
-}
+  inline sockaddr *
+  IP4Addr::copy_to(sockaddr *sa) const
+  {
+    this->copy_to(reinterpret_cast<sockaddr_in *>(sa));
+    return sa;
+  }
 
-inline IPAddr
-operator|(IPAddr const &addr, IPMask const &mask) {
-  return IPAddr{addr} |= mask;
-}
+  /// Equality.
+  inline bool
+  operator==(IP4Addr const &lhs, IP4Addr const &rhs)
+  {
+    return lhs._addr == rhs._addr;
+  }
 
-// @c constexpr constructor is required to initialize _something_, it can't be completely uninitializing.
-inline constexpr IPAddr::raw_addr_type::raw_addr_type() : _ip4(INADDR_ANY) {}
+  /// @return @c true if @a lhs is equal to @a rhs.
+  inline bool
+  operator!=(IP4Addr const &lhs, IP4Addr const &rhs)
+  {
+    return lhs._addr != rhs._addr;
+  }
 
-inline IPAddr::IPAddr(in_addr_t addr) : _addr(addr), _family(IP4Addr::AF_value) {}
+  /// @return @c true if @a lhs is less than @a rhs (host order).
+  inline bool
+  operator<(IP4Addr const &lhs, IP4Addr const &rhs)
+  {
+    return lhs._addr < rhs._addr;
+  }
 
-inline IPAddr::IPAddr(in6_addr const &addr) : _addr(addr), _family(IP6Addr::AF_value) {}
+  /// @return @c true if @a lhs is less than or equal to@a rhs (host order).
+  inline bool
+  operator<=(IP4Addr const &lhs, IP4Addr const &rhs)
+  {
+    return lhs._addr <= rhs._addr;
+  }
 
-inline IPAddr::IPAddr(sockaddr const *addr) {
-  this->assign(addr);
-}
+  /// @return @c true if @a lhs is greater than @a rhs (host order).
+  inline bool
+  operator>(IP4Addr const &lhs, IP4Addr const &rhs)
+  {
+    return rhs < lhs;
+  }
 
-inline IPAddr::IPAddr(string_view const &text) {
-  this->load(text);
-}
+  /// @return @c true if @a lhs is greater than or equal to @a rhs (host order).
+  inline bool
+  operator>=(IP4Addr const &lhs, IP4Addr const &rhs)
+  {
+    return rhs <= lhs;
+  }
 
-inline IPAddr &
-IPAddr::operator=(in_addr_t addr) {
-  _family    = AF_INET;
-  _addr._ip4 = addr;
-  return *this;
-}
+  inline IP4Addr &
+  IP4Addr::operator&=(IPMask const &mask)
+  {
+    _addr &= mask.as_ip4()._addr;
+    return *this;
+  }
 
-inline IPAddr &
-IPAddr::operator=(in6_addr const &addr) {
-  _family    = AF_INET6;
-  _addr._ip6 = addr;
-  return *this;
-}
+  inline IP4Addr &
+  IP4Addr::operator|=(IPMask const &mask)
+  {
+    _addr |= ~(mask.as_ip4()._addr);
+    return *this;
+  }
 
-inline IPAddr &
-IPAddr::operator=(sockaddr const *addr) {
-  return this->assign(addr);
-}
+  inline bool
+  IP4Addr::is_any() const
+  {
+    return _addr == INADDR_ANY;
+  }
 
-inline sa_family_t
-IPAddr::family() const {
-  return _family;
-}
+  inline bool
+  IP4Addr::is_loopback() const
+  {
+    return (*this)[0] == IN_LOOPBACKNET;
+  }
 
-inline bool
-IPAddr::is_ip4() const {
-  return AF_INET == _family;
-}
+  inline bool
+  IP4Addr::is_multicast() const
+  {
+    return IN_MULTICAST(_addr);
+  }
 
-inline bool
-IPAddr::is_ip6() const {
-  return AF_INET6 == _family;
-}
+  inline bool
+  IP4Addr::is_link_local() const
+  {
+    return (_addr & 0xFFFF0000) == 0xA9FE0000; // 169.254.0.0/16
+  }
 
-inline bool
-IPAddr::is_same_family(self_type const &that) {
-  return this->is_valid() && _family == that._family;
-}
+  inline bool
+  IP4Addr::is_private() const
+  {
+    return (((_addr & 0xFF000000) == 0x0A000000) || // 10.0.0.0/8
+            ((_addr & 0xFFC00000) == 0x64400000) || // 100.64.0.0/10
+            ((_addr & 0xFFF00000) == 0xAC100000) || // 172.16.0.0/12
+            ((_addr & 0xFFFF0000) == 0xC0A80000)    // 192.168.0.0/16
+    );
+  }
 
-inline bool
-IPAddr::is_loopback() const {
-  return (AF_INET == _family && _addr._ip4.is_loopback()) || (AF_INET6 == _family && _addr._ip6.is_loopback());
-}
+  inline uint8_t
+  IP4Addr::operator[](unsigned int idx) const
+  {
+    return reinterpret_cast<bytes const &>(_addr)[3 - idx];
+  }
 
-inline bool
-IPAddr::is_link_local() const {
-  return this->is_ip4() ? this->ip4().is_link_local()
-         : this->is_ip6() ? this->ip6().is_link_local()
-                          : false;
-}
+  inline int
+  IP4Addr::cmp(IP4Addr::self_type const &that) const
+  {
+    return _addr < that._addr ? -1 : _addr > that._addr ? 1 : 0;
+  }
 
-inline bool
-IPAddr::is_private() const {
-  return this->is_ip4() ? this->ip4().is_private()
-         : this->is_ip6() ? this->ip6().is_private()
-                          : false;
-}
+  constexpr in_addr_t
+  IP4Addr::reorder(in_addr_t src)
+  {
+    return ((src & 0xFF) << 24) | (((src >> 8) & 0xFF) << 16) | (((src >> 16) & 0xFF) << 8) | ((src >> 24) & 0xFF);
+  }
 
-inline IPAddr &
-IPAddr::assign(in_addr_t addr) {
-  _family    = AF_INET;
-  _addr._ip4 = addr;
-  return *this;
-}
+  // +++ IP6Addr +++
 
-inline IPAddr &
-IPAddr::assign(in6_addr const &addr) {
-  _family    = AF_INET6;
-  _addr._ip6 = addr;
-  return *this;
-}
+  inline constexpr sa_family_t
+  IP6Addr::family() const
+  {
+    return AF_value;
+  }
 
-inline IPAddr &
-IPAddr::assign(sockaddr_in const *addr) {
-  if (addr) {
+  inline IP6Addr::IP6Addr(in6_addr const &addr)
+  {
+    *this = addr;
+  }
+
+  inline IP6Addr::IP6Addr(string_view const &text)
+  {
+    if (!this->load(text)) {
+      this->clear();
+    }
+  }
+
+  inline IP6Addr::IP6Addr(IP4Addr addr)
+  {
+    _addr._store[MSW]        = 0;
+    _addr._quad[QUAD_IDX[4]] = 0;
+    _addr._quad[QUAD_IDX[5]] = 0xffff;
+    _addr._quad[QUAD_IDX[6]] = addr.host_order() >> QUAD_WIDTH;
+    _addr._quad[QUAD_IDX[7]] = addr.host_order();
+  }
+
+  inline bool
+  IP6Addr::is_loopback() const
+  {
+    return _addr._store[MSW] == 0 && _addr._store[LSW] == 1;
+  }
+
+  inline bool
+  IP6Addr::is_multicast() const
+  {
+    return _addr._raw[RAW_IDX[0]] == 0xFF;
+  }
+
+  inline bool
+  IP6Addr::is_any() const
+  {
+    return _addr._store[MSW] == 0 && _addr._store[LSW] == 0;
+  }
+
+  inline bool
+  IP6Addr::is_mapped_ip4() const
+  {
+    return 0 == _addr._store[MSW] && (_addr._quad[QUAD_IDX[4]] == 0 && _addr._quad[QUAD_IDX[5]] == 0xFFFF);
+  }
+
+  inline bool
+  IP6Addr::is_link_local() const
+  {
+    return _addr._raw[RAW_IDX[0]] == 0xFE && (_addr._raw[RAW_IDX[1]] & 0xC0) == 0x80; // fe80::/10
+  }
+
+  inline bool
+  IP6Addr::is_private() const
+  {
+    return (_addr._raw[RAW_IDX[0]] & 0xFE) == 0xFC; // fc00::/7
+  }
+
+  inline in6_addr
+  IP6Addr::host_order() const
+  {
+    Addr zret{
+      {_addr._store[LSW], _addr._store[MSW]}
+    };
+    return zret._in6;
+  }
+
+  inline in6_addr &
+  IP6Addr::host_order(in6_addr &dst) const
+  {
+    Addr *addr      = reinterpret_cast<Addr *>(&dst);
+    addr->_store[0] = _addr._store[LSW];
+    addr->_store[1] = _addr._store[MSW];
+    return dst;
+  }
+
+  inline in6_addr
+  IP6Addr::network_order() const
+  {
+    in6_addr zret;
+    return this->network_order(zret);
+  }
+
+  inline in6_addr &
+  IP6Addr::network_order(in6_addr &dst) const
+  {
+    self_type::reorder(dst, _addr._raw);
+    return dst;
+  }
+
+  inline auto
+  IP6Addr::clear() -> self_type &
+  {
+    _addr._store[MSW] = _addr._store[LSW] = 0;
+    return *this;
+  }
+
+  inline auto
+  IP6Addr::operator=(in6_addr const &addr) -> self_type &
+  {
+    self_type::reorder(_addr._raw, addr);
+    return *this;
+  }
+
+  inline auto
+  IP6Addr::operator=(sockaddr_in6 const *addr) -> self_type &
+  {
+    if (addr) {
+      *this = addr->sin6_addr;
+    } else {
+      this->clear();
+    }
+    return *this;
+  }
+
+  inline auto
+  IP6Addr::operator++() -> self_type &
+  {
+    if (++(_addr._store[LSW]) == 0) {
+      ++(_addr._store[MSW]);
+    }
+    return *this;
+  }
+
+  inline auto
+  IP6Addr::operator--() -> self_type &
+  {
+    if (--(_addr._store[LSW]) == ~static_cast<uint64_t>(0)) {
+      --(_addr._store[MSW]);
+    }
+    return *this;
+  }
+
+  inline void
+  IP6Addr::reorder(unsigned char dst[WORD_SIZE], unsigned char const src[WORD_SIZE])
+  {
+    for (size_t idx = 0; idx < WORD_SIZE; ++idx) {
+      dst[idx] = src[WORD_SIZE - (idx + 1)];
+    }
+  }
+
+  /// @return @c true if @a lhs is equal to @a rhs.
+  inline bool
+  operator==(IP6Addr const &lhs, IP6Addr const &rhs)
+  {
+    return lhs._addr._store[IP6Addr::MSW] == rhs._addr._store[IP6Addr::MSW] &&
+           lhs._addr._store[IP6Addr::LSW] == rhs._addr._store[IP6Addr::LSW];
+  }
+
+  /// @return @c true if @a lhs is not equal to @a rhs.
+  inline bool
+  operator!=(IP6Addr const &lhs, IP6Addr const &rhs)
+  {
+    return lhs._addr._store[IP6Addr::MSW] != rhs._addr._store[IP6Addr::MSW] ||
+           lhs._addr._store[IP6Addr::LSW] != rhs._addr._store[IP6Addr::LSW];
+  }
+
+  /// @return @c true if @a lhs is less than @a rhs.
+  inline bool
+  operator<(IP6Addr const &lhs, IP6Addr const &rhs)
+  {
+    return lhs._addr._store[IP6Addr::MSW] < rhs._addr._store[IP6Addr::MSW] ||
+           (lhs._addr._store[IP6Addr::MSW] == rhs._addr._store[IP6Addr::MSW] &&
+            lhs._addr._store[IP6Addr::LSW] < rhs._addr._store[IP6Addr::LSW]);
+  }
+
+  /// @return @c true if @a lhs is greater than @a rhs.
+  inline bool
+  operator>(IP6Addr const &lhs, IP6Addr const &rhs)
+  {
+    return rhs < lhs;
+  }
+
+  /// @return @c true if @a lhs is less than or equal to @a rhs.
+  inline bool
+  operator<=(IP6Addr const &lhs, IP6Addr const &rhs)
+  {
+    return lhs._addr._store[IP6Addr::MSW] < rhs._addr._store[IP6Addr::MSW] ||
+           (lhs._addr._store[IP6Addr::MSW] == rhs._addr._store[IP6Addr::MSW] &&
+            lhs._addr._store[IP6Addr::LSW] <= rhs._addr._store[IP6Addr::LSW]);
+  }
+
+  /// @return @c true if @a lhs is greater than or equal to @a rhs.
+  inline bool
+  operator>=(IP6Addr const &lhs, IP6Addr const &rhs)
+  {
+    return rhs <= lhs;
+  }
+
+  inline sockaddr *
+  IP6Addr::copy_to(sockaddr *sa) const
+  {
+    this->copy_to(reinterpret_cast<sockaddr_in6 *>(sa));
+    return sa;
+  }
+
+  inline auto
+  IP6Addr::operator&=(IPMask const &mask) -> self_type &
+  {
+    if (mask._cidr <= WORD_WIDTH) {
+      _addr._store[LSW] = 0;
+      if (0 == mask._cidr) {
+        _addr._store[MSW] = 0;
+      } else if (mask._cidr < WORD_WIDTH) {
+        _addr._store[MSW] &= (WORD_MASK << (WORD_WIDTH - mask._cidr));
+      }
+    } else if (mask._cidr < WIDTH) {
+      _addr._store[LSW] &= (WORD_MASK << (2 * WORD_WIDTH - mask._cidr));
+    }
+    return *this;
+  }
+
+  inline auto
+  IP6Addr::operator|=(IPMask const &mask) -> self_type &
+  {
+    if (mask._cidr > WORD_WIDTH) {
+      if (mask._cidr < WIDTH) {
+        _addr._store[LSW] |= (WORD_MASK >> (mask._cidr - WORD_WIDTH));
+      }
+    } else {
+      _addr._store[LSW] = WORD_MASK;
+      if (0 == mask._cidr) {
+        _addr._store[MSW] = WORD_MASK;
+      } else if (mask._cidr < WORD_WIDTH) {
+        _addr._store[MSW] |= (WORD_MASK >> mask._cidr);
+      }
+    }
+    return *this;
+  }
+
+  // +++ IPMask +++
+
+  inline IPMask::IPMask(raw_type width) : _cidr(width) {}
+
+  inline bool
+  IPMask::is_valid() const
+  {
+    return _cidr < INVALID;
+  }
+
+  inline auto
+  IPMask::width() const -> raw_type
+  {
+    return _cidr;
+  }
+
+  inline bool
+  operator==(IPMask const &lhs, IPMask const &rhs)
+  {
+    return lhs.width() == rhs.width();
+  }
+
+  inline bool
+  operator!=(IPMask const &lhs, IPMask const &rhs)
+  {
+    return lhs.width() != rhs.width();
+  }
+
+  inline bool
+  operator<(IPMask const &lhs, IPMask const &rhs)
+  {
+    return lhs.width() < rhs.width();
+  }
+
+  inline IP4Addr
+  IPMask::as_ip4() const
+  {
+    static constexpr auto MASK = ~in_addr_t{0};
+    in_addr_t addr             = MASK;
+    if (0 == _cidr) {
+      addr = in_addr_t(0);
+    } else if (_cidr < IP4Addr::WIDTH) {
+      addr <<= IP4Addr::WIDTH - _cidr;
+    }
+    return IP4Addr{addr};
+  }
+
+  inline auto
+  IPMask::clear() -> self_type &
+  {
+    _cidr = INVALID;
+    return *this;
+  }
+
+  inline auto
+  IPMask::operator<<=(raw_type n) -> self_type &
+  {
+    _cidr -= n;
+    return *this;
+  }
+
+  inline auto
+  IPMask::operator>>=(IPMask::raw_type n) -> self_type &
+  {
+    _cidr += n;
+    return *this;
+  }
+
+  // +++ mixed mask operators +++
+
+  inline IP4Addr
+  operator&(IP4Addr const &addr, IPMask const &mask)
+  {
+    return IP4Addr{addr} &= mask;
+  }
+
+  inline IP4Addr
+  operator|(IP4Addr const &addr, IPMask const &mask)
+  {
+    return IP4Addr{addr} |= mask;
+  }
+
+  inline IP6Addr
+  operator&(IP6Addr const &addr, IPMask const &mask)
+  {
+    return IP6Addr{addr} &= mask;
+  }
+
+  inline IP6Addr
+  operator|(IP6Addr const &addr, IPMask const &mask)
+  {
+    return IP6Addr{addr} |= mask;
+  }
+
+  constexpr uint8_t
+  IP6Addr::operator[](int idx) const
+  {
+    return _addr._raw[RAW_IDX[idx]];
+  }
+
+  inline IPAddr
+  operator&(IPAddr const &addr, IPMask const &mask)
+  {
+    return IPAddr{addr} &= mask;
+  }
+
+  inline IPAddr
+  operator|(IPAddr const &addr, IPMask const &mask)
+  {
+    return IPAddr{addr} |= mask;
+  }
+
+  // @c constexpr constructor is required to initialize _something_, it can't be completely uninitializing.
+  inline constexpr IPAddr::raw_addr_type::raw_addr_type() : _ip4(INADDR_ANY) {}
+
+  inline IPAddr::IPAddr(in_addr_t addr) : _addr(addr), _family(IP4Addr::AF_value) {}
+
+  inline IPAddr::IPAddr(in6_addr const &addr) : _addr(addr), _family(IP6Addr::AF_value) {}
+
+  inline IPAddr::IPAddr(sockaddr const *addr)
+  {
+    this->assign(addr);
+  }
+
+  inline IPAddr::IPAddr(string_view const &text)
+  {
+    this->load(text);
+  }
+
+  inline IPAddr &
+  IPAddr::operator=(in_addr_t addr)
+  {
     _family    = AF_INET;
     _addr._ip4 = addr;
-  } else {
-    _family = AF_UNSPEC;
+    return *this;
   }
-  return *this;
-}
 
-inline IPAddr &
-IPAddr::assign(sockaddr_in6 const *addr) {
-  if (addr) {
+  inline IPAddr &
+  IPAddr::operator=(in6_addr const &addr)
+  {
     _family    = AF_INET6;
-    _addr._ip6 = addr->sin6_addr;
-  } else {
-    _family = AF_UNSPEC;
+    _addr._ip6 = addr;
+    return *this;
   }
-  return *this;
-}
 
-inline bool
-IPAddr::is_valid() const {
-  return _family == AF_INET || _family == AF_INET6;
-}
+  inline IPAddr &
+  IPAddr::operator=(sockaddr const *addr)
+  {
+    return this->assign(addr);
+  }
 
-inline IPAddr &
-IPAddr::invalidate() {
-  _family = AF_UNSPEC;
-  return *this;
-}
+  inline sa_family_t
+  IPAddr::family() const
+  {
+    return _family;
+  }
 
-// Associated operators.
+  inline bool
+  IPAddr::is_ip4() const
+  {
+    return AF_INET == _family;
+  }
 
-/// Equality.
-bool operator==(IPAddr const &lhs, sockaddr const *rhs);
+  inline bool
+  IPAddr::is_ip6() const
+  {
+    return AF_INET6 == _family;
+  }
 
-/// Equality.
-inline bool
-operator==(sockaddr const *lhs, IPAddr const &rhs) {
-  return rhs == lhs;
-}
+  inline bool
+  IPAddr::is_same_family(self_type const &that)
+  {
+    return this->is_valid() && _family == that._family;
+  }
 
-/// Inequality.
-inline bool
-operator!=(IPAddr const &lhs, sockaddr const *rhs) {
-  return !(lhs == rhs);
-}
+  inline bool
+  IPAddr::is_loopback() const
+  {
+    return (AF_INET == _family && _addr._ip4.is_loopback()) || (AF_INET6 == _family && _addr._ip6.is_loopback());
+  }
 
-/// Inequality.
-inline bool
-operator!=(sockaddr const *lhs, IPAddr const &rhs) {
-  return !(rhs == lhs);
-}
+  inline bool
+  IPAddr::is_link_local() const
+  {
+    return this->is_ip4() ? this->ip4().is_link_local() : this->is_ip6() ? this->ip6().is_link_local() : false;
+  }
 
-inline IP4Addr const & IPAddr::ip4() const { return _addr._ip4; }
-inline IPAddr::operator IP4Addr() const { return _addr._ip4; }
+  inline bool
+  IPAddr::is_private() const
+  {
+    return this->is_ip4() ? this->ip4().is_private() : this->is_ip6() ? this->ip6().is_private() : false;
+  }
 
-inline IP6Addr const & IPAddr::ip6() const { return _addr._ip6; }
-inline IPAddr::operator IP6Addr() const { return _addr._ip6; }
+  inline IPAddr &
+  IPAddr::assign(in_addr_t addr)
+  {
+    _family    = AF_INET;
+    _addr._ip4 = addr;
+    return *this;
+  }
 
-inline bool
-IPAddr::operator==(self_type const &that) const {
-  switch (_family) {
-  case AF_INET:
-    return that._family == AF_INET && _addr._ip4 == that._addr._ip4;
+  inline IPAddr &
+  IPAddr::assign(in6_addr const &addr)
+  {
+    _family    = AF_INET6;
+    _addr._ip6 = addr;
+    return *this;
+  }
+
+  inline IPAddr &
+  IPAddr::assign(sockaddr_in const *addr)
+  {
+    if (addr) {
+      _family    = AF_INET;
+      _addr._ip4 = addr;
+    } else {
+      _family = AF_UNSPEC;
+    }
+    return *this;
+  }
+
+  inline IPAddr &
+  IPAddr::assign(sockaddr_in6 const *addr)
+  {
+    if (addr) {
+      _family    = AF_INET6;
+      _addr._ip6 = addr->sin6_addr;
+    } else {
+      _family = AF_UNSPEC;
+    }
+    return *this;
+  }
+
+  inline bool
+  IPAddr::is_valid() const
+  {
+    return _family == AF_INET || _family == AF_INET6;
+  }
+
+  inline IPAddr &
+  IPAddr::invalidate()
+  {
+    _family = AF_UNSPEC;
+    return *this;
+  }
+
+  // Associated operators.
+
+  /// Equality.
+  bool operator==(IPAddr const &lhs, sockaddr const *rhs);
+
+  /// Equality.
+  inline bool
+  operator==(sockaddr const *lhs, IPAddr const &rhs)
+  {
+    return rhs == lhs;
+  }
+
+  /// Inequality.
+  inline bool
+  operator!=(IPAddr const &lhs, sockaddr const *rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+  /// Inequality.
+  inline bool
+  operator!=(sockaddr const *lhs, IPAddr const &rhs)
+  {
+    return !(rhs == lhs);
+  }
+
+  inline IP4Addr const &
+  IPAddr::ip4() const
+  {
+    return _addr._ip4;
+  }
+  inline IPAddr::operator IP4Addr() const
+  {
+    return _addr._ip4;
+  }
+
+  inline IP6Addr const &
+  IPAddr::ip6() const
+  {
+    return _addr._ip6;
+  }
+  inline IPAddr::operator IP6Addr() const
+  {
+    return _addr._ip6;
+  }
+
+  inline bool
+  IPAddr::operator==(self_type const &that) const
+  {
+    switch (_family) {
+    case AF_INET:
+      return that._family == AF_INET && _addr._ip4 == that._addr._ip4;
     case AF_INET6:
       return that._family == AF_INET6 && _addr._ip6 == that._addr._ip6;
-      default:
-        return ! that.is_valid();
+    default:
+      return !that.is_valid();
+    }
   }
-}
 
-inline bool
-IPAddr::operator!=(self_type const &that) const {
-  return !(*this == that);
-}
+  inline bool
+  IPAddr::operator!=(self_type const &that) const
+  {
+    return !(*this == that);
+  }
 
-inline bool
-IPAddr::operator>(self_type const &that) const {
-  return that < *this;
-}
+  inline bool
+  IPAddr::operator>(self_type const &that) const
+  {
+    return that < *this;
+  }
 
-inline bool
-IPAddr::operator<=(self_type const &that) const {
-  return !(that < *this);
-}
+  inline bool
+  IPAddr::operator<=(self_type const &that) const
+  {
+    return !(that < *this);
+  }
 
-inline bool
-IPAddr::operator>=(self_type const &that) const {
-  return !(*this < that);
-}
+  inline bool
+  IPAddr::operator>=(self_type const &that) const
+  {
+    return !(*this < that);
+  }
 
-// Disambiguating between comparisons and implicit conversions.
+  // Disambiguating between comparisons and implicit conversions.
 
-inline bool
-operator==(IPAddr const &lhs, IP4Addr const &rhs) {
-  return lhs.is_ip4() && lhs.ip4() == rhs;
-}
+  inline bool
+  operator==(IPAddr const &lhs, IP4Addr const &rhs)
+  {
+    return lhs.is_ip4() && lhs.ip4() == rhs;
+  }
 
-inline bool
-operator!=(IPAddr const &lhs, IP4Addr const &rhs) {
-  return !lhs.is_ip4() || lhs.ip4() != rhs;
-}
+  inline bool
+  operator!=(IPAddr const &lhs, IP4Addr const &rhs)
+  {
+    return !lhs.is_ip4() || lhs.ip4() != rhs;
+  }
 
-inline bool
-operator==(IP4Addr const &lhs, IPAddr const &rhs) {
-  return rhs.is_ip4() && lhs == rhs.ip4();
-}
+  inline bool
+  operator==(IP4Addr const &lhs, IPAddr const &rhs)
+  {
+    return rhs.is_ip4() && lhs == rhs.ip4();
+  }
 
-inline bool
-operator!=(IP4Addr const &lhs, IPAddr const &rhs) {
-  return !rhs.is_ip4() || lhs != rhs.ip4();
-}
+  inline bool
+  operator!=(IP4Addr const &lhs, IPAddr const &rhs)
+  {
+    return !rhs.is_ip4() || lhs != rhs.ip4();
+  }
 
-inline bool
-operator==(IPAddr const &lhs, IP6Addr const &rhs) {
-  return lhs.is_ip6() && lhs.ip6() == rhs;
-}
+  inline bool
+  operator==(IPAddr const &lhs, IP6Addr const &rhs)
+  {
+    return lhs.is_ip6() && lhs.ip6() == rhs;
+  }
 
-inline bool
-operator!=(IPAddr const &lhs, IP6Addr const &rhs) {
-  return !lhs.is_ip6() || lhs.ip6() != rhs;
-}
+  inline bool
+  operator!=(IPAddr const &lhs, IP6Addr const &rhs)
+  {
+    return !lhs.is_ip6() || lhs.ip6() != rhs;
+  }
 
-inline bool
-operator==(IP6Addr const &lhs, IPAddr const &rhs) {
-  return rhs.is_ip6() && lhs == rhs.ip6();
-}
+  inline bool
+  operator==(IP6Addr const &lhs, IPAddr const &rhs)
+  {
+    return rhs.is_ip6() && lhs == rhs.ip6();
+  }
 
-inline bool
-operator!=(IP6Addr const &lhs, IPAddr const &rhs) {
-  return !rhs.is_ip6() || lhs != rhs.ip6();
-}
-}} // namespace swoc::SWOC_VERSION_NS
+  inline bool
+  operator!=(IP6Addr const &lhs, IPAddr const &rhs)
+  {
+    return !rhs.is_ip6() || lhs != rhs.ip6();
+  }
+} // namespace SWOC_VERSION_NS
+} // namespace swoc
 
-namespace std {
+namespace std
+{
 
 /// Standard hash support for @a IP4Addr.
 template <> struct hash<swoc::IP4Addr> {
-  size_t operator()(swoc::IP4Addr const &addr) const {
+  size_t
+  operator()(swoc::IP4Addr const &addr) const
+  {
     return addr.network_order();
   }
 };
 
 /// Standard hash support for @a IP6Addr.
 template <> struct hash<swoc::IP6Addr> {
-  size_t operator()(swoc::IP6Addr const &addr) const {
+  size_t
+  operator()(swoc::IP6Addr const &addr) const
+  {
     // XOR the 64 chunks
     auto words = addr.as_span<uint64_t>();
     return words[0] ^ words[1];
@@ -1458,7 +1609,9 @@ template <> struct hash<swoc::IP6Addr> {
 
 /// Standard hash support for @a IPAddr.
 template <> struct hash<swoc::IPAddr> {
-  size_t operator()(swoc::IPAddr const &addr) const {
+  size_t
+  operator()(swoc::IPAddr const &addr) const
+  {
     return addr.is_ip4() ? hash<swoc::IP4Addr>()(addr.ip4()) : addr.is_ip6() ? hash<swoc::IP6Addr>()(addr.ip6()) : 0;
   }
 };

--- a/code/include/swoc/IPEndpoint.h
+++ b/code/include/swoc/IPEndpoint.h
@@ -16,387 +16,419 @@
 #include "swoc/TextView.h"
 #include "swoc/string_view_util.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
 
-class IPAddr;
-class IP4Addr;
-class IP6Addr;
+  class IPAddr;
+  class IP4Addr;
+  class IP6Addr;
 
-class IPSrv;
-class IP4Srv;
-class IP6Srv;
+  class IPSrv;
+  class IP4Srv;
+  class IP6Srv;
 
-/** A union to hold @c sockaddr compliant IP address structures.
+  /** A union to hold @c sockaddr compliant IP address structures.
 
-    This class contains a number of static methods to perform operations on external @c sockaddr
-    instances. These are all duplicates of methods that operate on the internal @c sockaddr and
-    are provided primarily for backwards compatibility during the shift to using this class.
+      This class contains a number of static methods to perform operations on external @c sockaddr
+      instances. These are all duplicates of methods that operate on the internal @c sockaddr and
+      are provided primarily for backwards compatibility during the shift to using this class.
 
-    We use the term "endpoint" because these contain more than just the raw address, all of the data
-    for an IP endpoint is present.
- */
-union IPEndpoint {
-  using self_type = IPEndpoint; ///< Self reference type.
-  using string_view = std::string_view;
-
-  struct sockaddr sa;      ///< Generic address.
-  struct sockaddr_in sa4;  ///< IPv4
-  struct sockaddr_in6 sa6; ///< IPv6
-
-  /// Default construct invalid instance.
-  IPEndpoint();
-  IPEndpoint(self_type const &that); ///< Copy constructor.
-  ~IPEndpoint() = default;
-
-  /// Construct from the @a text representation of an address.
-  explicit IPEndpoint(string_view const &text);
-
-  /// Construct from an address.
-  explicit IPEndpoint(IPAddr const &addr);
-
-  /// Construct from address and port.
-  explicit IPEndpoint(IPSrv const& srv);
-
-  /// Construct from generic socket address.
-  IPEndpoint(sockaddr const *addr);
-
-  /// Construct from @a sockaddr_in
-  IPEndpoint(sockaddr_in const* sin);
-
-  /// Construct from @a sockaddr_in6
-  IPEndpoint(sockaddr_in6 const * sin6);
-
-  /// Copy assignment.
-  self_type &operator=(self_type const &that);
-
-  /** Break a string in to IP address relevant tokens.
-   *
-   * @param src Source text. [in]
-   * @param host The host / address. [out]
-   * @param port The host_order_port. [out]
-   * @param rest Any text past the end of the IP address. [out]
-   * @return @c true if an IP address was found, @c false otherwise.
-   *
-   * Any of the out parameters can be @c nullptr in which case they are not updated.
-   * This parses and discards the IPv6 brackets.
-   *
-   * @note This is intended for internal use to do address parsing, but it can be useful in other contexts.
+      We use the term "endpoint" because these contain more than just the raw address, all of the data
+      for an IP endpoint is present.
    */
-  static bool tokenize(string_view src, string_view *host = nullptr, string_view *port = nullptr, string_view *rest = nullptr);
+  union IPEndpoint {
+    using self_type   = IPEndpoint; ///< Self reference type.
+    using string_view = std::string_view;
+
+    struct sockaddr sa;      ///< Generic address.
+    struct sockaddr_in sa4;  ///< IPv4
+    struct sockaddr_in6 sa6; ///< IPv6
+
+    /// Default construct invalid instance.
+    IPEndpoint();
+    IPEndpoint(self_type const &that); ///< Copy constructor.
+    ~IPEndpoint() = default;
+
+    /// Construct from the @a text representation of an address.
+    explicit IPEndpoint(string_view const &text);
+
+    /// Construct from an address.
+    explicit IPEndpoint(IPAddr const &addr);
+
+    /// Construct from address and port.
+    explicit IPEndpoint(IPSrv const &srv);
+
+    /// Construct from generic socket address.
+    IPEndpoint(sockaddr const *addr);
+
+    /// Construct from @a sockaddr_in
+    IPEndpoint(sockaddr_in const *sin);
+
+    /// Construct from @a sockaddr_in6
+    IPEndpoint(sockaddr_in6 const *sin6);
+
+    /// Copy assignment.
+    self_type &operator=(self_type const &that);
+
+    /** Break a string in to IP address relevant tokens.
+     *
+     * @param src Source text. [in]
+     * @param host The host / address. [out]
+     * @param port The host_order_port. [out]
+     * @param rest Any text past the end of the IP address. [out]
+     * @return @c true if an IP address was found, @c false otherwise.
+     *
+     * Any of the out parameters can be @c nullptr in which case they are not updated.
+     * This parses and discards the IPv6 brackets.
+     *
+     * @note This is intended for internal use to do address parsing, but it can be useful in other contexts.
+     */
+    static bool tokenize(string_view src, string_view *host = nullptr, string_view *port = nullptr, string_view *rest = nullptr);
 
-  /** Parse a string for an IP address.
+    /** Parse a string for an IP address.
+
+        The address resulting from the parse is copied to this object if the conversion is successful,
+        otherwise this object is invalidated.
+
+        @return @c true on success, @c false otherwise.
+    */
+    bool parse(string_view const &str);
+
+    /// Invalidate a @c sockaddr.
+    static void invalidate(sockaddr *addr);
 
-      The address resulting from the parse is copied to this object if the conversion is successful,
-      otherwise this object is invalidated.
+    /// Invalidate this endpoint.
+    self_type &invalidate();
 
-      @return @c true on success, @c false otherwise.
-  */
-  bool parse(string_view const &str);
+    /** Copy (assign) the contents of @a src to @a dst.
+     *
+     * The caller must ensure @a dst is large enough to hold the contents of @a src, the size of which
+     * can vary depending on the type of address in @a dst.
+     *
+     * @param dst Destination.
+     * @param src Source.
+     * @return @c true if @a dst is a valid IP address, @c false otherwise.
+     */
+    static bool assign(sockaddr *dst, sockaddr const *src);
+
+    /** Assign from a socket address.
+        The entire address (all parts) are copied if the @a ip is valid.
+    */
+    self_type &assign(sockaddr const *addr);
+
+    /** Assign from IPv4 socket address.
+     *
+     * @param sin IPv4 socket address.
+     * @return @a this
+     */
+    self_type &assign(sockaddr_in const *sin);
+
+    /** Assign from IPv6 socket address.
+     *
+     * @param sin6 IPv6 socket address.
+     * @return @a this
+     */
+    self_type &assign(sockaddr_in6 const *sin6);
+
+    /// Assign from IP address.
+    self_type &assign(IPAddr const &addr);
+
+    [[deprecated("Use IPSrv")]] self_type &assign(IPAddr const &addr, in_port_t port);
+
+    /// Assign from IPv4 address.
+    self_type &assign(IP4Addr const &addr);
+
+    /// Assign from IPv4 address.
+    self_type &assign(IP6Addr const &addr);
 
-  /// Invalidate a @c sockaddr.
-  static void invalidate(sockaddr *addr);
+    /// Assign from IPv4 service.
+    self_type &assign(IP4Srv const &srv);
 
-  /// Invalidate this endpoint.
-  self_type &invalidate();
-
-  /** Copy (assign) the contents of @a src to @a dst.
-   *
-   * The caller must ensure @a dst is large enough to hold the contents of @a src, the size of which
-   * can vary depending on the type of address in @a dst.
-   *
-   * @param dst Destination.
-   * @param src Source.
-   * @return @c true if @a dst is a valid IP address, @c false otherwise.
-   */
-  static bool assign(sockaddr *dst, sockaddr const *src);
-
-  /** Assign from a socket address.
-      The entire address (all parts) are copied if the @a ip is valid.
-  */
-  self_type &assign(sockaddr const *addr);
-
-  /** Assign from IPv4 socket address.
-   *
-   * @param sin IPv4 socket address.
-   * @return @a this
-   */
-  self_type &assign(sockaddr_in const * sin);
-
-  /** Assign from IPv6 socket address.
-   *
-   * @param sin6 IPv6 socket address.
-   * @return @a this
-   */
-  self_type &assign(sockaddr_in6 const * sin6);
-
-  /// Assign from IP address.
-  self_type &assign(IPAddr const &addr);
-
-  [[deprecated("Use IPSrv")]] self_type &assign(IPAddr const& addr, in_port_t port);
-
-  /// Assign from IPv4 address.
-  self_type &assign(IP4Addr const& addr);
-
-  /// Assign from IPv4 address.
-  self_type &assign(IP6Addr const& addr);
-
-  /// Assign from IPv4 service.
-  self_type &assign(IP4Srv const& srv);
-
-  /// Assign from IPv6 service.
-  self_type &assign(IP6Srv const& srv);
-
-  /// Assign from IP service.
-  self_type &assign(IPSrv const& srv);
-
-  /// Copy to @a sa.
-  const self_type &copy_to(sockaddr *addr) const;
-
-  /// Test for valid IP address.
-  bool is_valid() const;
-
-  /// Test for IPv4.
-  bool is_ip4() const;
-
-  /// Test for IPv6.
-  bool is_ip6() const;
-
-  /** Effectively size of the address.
-   *
-   * @return The size of the structure appropriate for the address family of the stored address.
-   */
-  socklen_t size() const;
-
-  /// @return The IP address family.
-  sa_family_t family() const;
-
-  /// @return A pointer to a @c sockaddr_in or @c nullptr if not IPv4.
-  sockaddr_in * ip4();
-
-  /// @return A pointer to a @c sockaddr_in or @c nullptr if not IPv4.
-  sockaddr_in const * ip4() const;
-
-  /// @return A pointer to a @c sockaddr_in6 or @c nullptr if not IPv6.
-  sockaddr_in6 * ip6();
-
-  /// @return A pointer to a @c sockaddr_in6 or @c nullptr if not IPv6.
-  sockaddr_in6 const * ip6() const;
-
-  /// Set to be the ANY address for family @a family.
-  /// @a family must be @c AF_INET or @c AF_INET6.
-  /// @return This object.
-  self_type &set_to_any(int family);
-
-  /// @return @c true if this is the ANY address, @c false if not.
-  bool is_any() const;
-
-  /// Set to be loopback address for family @a family.
-  /// @a family must be @c AF_INET or @c AF_INET6.
-  /// @return This object.
-  self_type &set_to_loopback(int family);
-
-  /// @return @c true if this is a loopback address, @c false if not.
-  bool is_loopback() const;
-
-  /** Port in network order.
-   *
-   * @return The port or 0 if not a valid IP address.
-   */
-  in_port_t network_order_port() const;
-
-  /** Port in host order.
-   *
-   * @return The port or 0 if not a valid IP address.
-   */
-  in_port_t host_order_port() const;
-
-  /// Test for valid IP address.
-  /// @param sa The socket address.
-  /// @return @c true if @a sa contains a valid IP address, @c false if not.
-  /// @a sa can be @c nullptr in which case @c false is returned.
-  static bool is_valid(sockaddr const *sa);
-
-  /// Direct access to port.
-  /// @return Refernec to the port in the socket address.
-  /// @note If @a sa is not a valid IP address an assertion is thrown.
-  /// @a is_valid
-  static in_port_t &port(sockaddr *sa);
-
-  /** Port in network order.
-   *
-   * @param sa The socket address.
-   * @return The port or 0 if @a sa is not a valid IP address.
-   */
-  static in_port_t network_order_port(sockaddr const *sa);
-
-  /** Port in host order.
-   *
-   * @param sa The socket address.
-   * @return The port or 0 if @a sa is not a valid IP address.
-   */
-  static in_port_t host_order_port(sockaddr const *sa);
-
-  /// Automatic conversion to @c sockaddr.
-  operator sockaddr *() { return &sa; }
-
-  /// Automatic conversion to @c sockaddr.
-  operator sockaddr const *() const { return &sa; }
-
-  /** The address as a byte sequence.
-   *
-   * @return Span of the address memory.
-   *
-   * This is raw access. If the contained data is not a valid address family an empty span is returned.
-   */
-  swoc::MemSpan<void const> raw_addr() const;
-
-  /// The string name of the address family.
-  static string_view family_name(sa_family_t family);
-};
-
-inline IPEndpoint::IPEndpoint() {
-  sa.sa_family = AF_UNSPEC;
-}
-
-inline IPEndpoint::IPEndpoint(IPAddr const &addr) {
-  this->assign(addr);
-}
-
-inline IPEndpoint::IPEndpoint(IPSrv const& srv) {
-  this->assign(srv);
-}
-
-inline IPEndpoint::IPEndpoint(sockaddr const *addr) {
-  this->assign(addr);
-}
-
-inline IPEndpoint::IPEndpoint(IPEndpoint::self_type const &that) : self_type(&that.sa) {}
-
-inline IPEndpoint &
-IPEndpoint::invalidate() {
-  sa.sa_family = AF_UNSPEC;
-  return *this;
-}
-
-inline void
-IPEndpoint::invalidate(sockaddr *addr) {
-  addr->sa_family = AF_UNSPEC;
-}
-
-inline bool
-IPEndpoint::is_valid() const {
-  return sa.sa_family == AF_INET || sa.sa_family == AF_INET6;
-}
-
-inline IPEndpoint &
-IPEndpoint::operator=(self_type const &that) {
-  self_type::assign(&sa, &that.sa);
-  return *this;
-}
-
-inline IPEndpoint &
-IPEndpoint::assign(sockaddr_in const * sin) {
-  std::memcpy(&sa4, sin, sizeof(sockaddr_in));
-  return *this;
-}
-
-inline IPEndpoint &
-IPEndpoint::assign(sockaddr_in6 const * sin6) {
-  std::memcpy(&sa6, sin6, sizeof(sockaddr_in6));
-  return *this;
-}
-
-inline IPEndpoint &
-IPEndpoint::assign(sockaddr const *src) {
-  self_type::assign(&sa, src);
-  return *this;
-}
-
-inline IPEndpoint const &
-IPEndpoint::copy_to(sockaddr *addr) const {
-  self_type::assign(addr, &sa);
-  return *this;
-}
-
-inline bool
-IPEndpoint::is_ip4() const {
-  return AF_INET == sa.sa_family;
-}
-
-inline bool
-IPEndpoint::is_ip6() const {
-  return AF_INET6 == sa.sa_family;
-}
-
-inline sa_family_t
-IPEndpoint::family() const {
-  return sa.sa_family;
-}
-
-inline sockaddr_in *
-IPEndpoint::ip4() {
-  return this->is_ip4() ? &sa4 : nullptr;
-}
-
-inline sockaddr_in const *
-IPEndpoint::ip4() const {
-  return this->is_ip4() ? &sa4 : nullptr;
-}
-
-inline sockaddr_in6 *
-IPEndpoint::ip6() {
-  return this->is_ip6() ? &sa6 : nullptr;
-}
-
-inline sockaddr_in6 const *
-IPEndpoint::ip6() const {
-  return this->is_ip6() ? &sa6 : nullptr;
-}
-
-inline in_port_t
-IPEndpoint::network_order_port() const {
-  return this->is_valid() ? this->port(const_cast<sockaddr*>(&sa)) : 0;
-}
-
-inline in_port_t
-IPEndpoint::host_order_port() const {
-  return ntohs(this->network_order_port());
-}
-
-inline bool
-IPEndpoint::is_valid(sockaddr const *sa) {
-  return sa && (sa->sa_family == AF_INET || sa->sa_family == AF_INET6);
-}
-
-inline in_port_t &
-IPEndpoint::port(sockaddr *sa) {
-  switch (sa->sa_family) {
-  case AF_INET:
-    return reinterpret_cast<sockaddr_in *>(sa)->sin_port;
+    /// Assign from IPv6 service.
+    self_type &assign(IP6Srv const &srv);
+
+    /// Assign from IP service.
+    self_type &assign(IPSrv const &srv);
+
+    /// Copy to @a sa.
+    const self_type &copy_to(sockaddr *addr) const;
+
+    /// Test for valid IP address.
+    bool is_valid() const;
+
+    /// Test for IPv4.
+    bool is_ip4() const;
+
+    /// Test for IPv6.
+    bool is_ip6() const;
+
+    /** Effectively size of the address.
+     *
+     * @return The size of the structure appropriate for the address family of the stored address.
+     */
+    socklen_t size() const;
+
+    /// @return The IP address family.
+    sa_family_t family() const;
+
+    /// @return A pointer to a @c sockaddr_in or @c nullptr if not IPv4.
+    sockaddr_in *ip4();
+
+    /// @return A pointer to a @c sockaddr_in or @c nullptr if not IPv4.
+    sockaddr_in const *ip4() const;
+
+    /// @return A pointer to a @c sockaddr_in6 or @c nullptr if not IPv6.
+    sockaddr_in6 *ip6();
+
+    /// @return A pointer to a @c sockaddr_in6 or @c nullptr if not IPv6.
+    sockaddr_in6 const *ip6() const;
+
+    /// Set to be the ANY address for family @a family.
+    /// @a family must be @c AF_INET or @c AF_INET6.
+    /// @return This object.
+    self_type &set_to_any(int family);
+
+    /// @return @c true if this is the ANY address, @c false if not.
+    bool is_any() const;
+
+    /// Set to be loopback address for family @a family.
+    /// @a family must be @c AF_INET or @c AF_INET6.
+    /// @return This object.
+    self_type &set_to_loopback(int family);
+
+    /// @return @c true if this is a loopback address, @c false if not.
+    bool is_loopback() const;
+
+    /** Port in network order.
+     *
+     * @return The port or 0 if not a valid IP address.
+     */
+    in_port_t network_order_port() const;
+
+    /** Port in host order.
+     *
+     * @return The port or 0 if not a valid IP address.
+     */
+    in_port_t host_order_port() const;
+
+    /// Test for valid IP address.
+    /// @param sa The socket address.
+    /// @return @c true if @a sa contains a valid IP address, @c false if not.
+    /// @a sa can be @c nullptr in which case @c false is returned.
+    static bool is_valid(sockaddr const *sa);
+
+    /// Direct access to port.
+    /// @return Refernec to the port in the socket address.
+    /// @note If @a sa is not a valid IP address an assertion is thrown.
+    /// @a is_valid
+    static in_port_t &port(sockaddr *sa);
+
+    /** Port in network order.
+     *
+     * @param sa The socket address.
+     * @return The port or 0 if @a sa is not a valid IP address.
+     */
+    static in_port_t network_order_port(sockaddr const *sa);
+
+    /** Port in host order.
+     *
+     * @param sa The socket address.
+     * @return The port or 0 if @a sa is not a valid IP address.
+     */
+    static in_port_t host_order_port(sockaddr const *sa);
+
+    /// Automatic conversion to @c sockaddr.
+    operator sockaddr *() { return &sa; }
+
+    /// Automatic conversion to @c sockaddr.
+    operator sockaddr const *() const { return &sa; }
+
+    /** The address as a byte sequence.
+     *
+     * @return Span of the address memory.
+     *
+     * This is raw access. If the contained data is not a valid address family an empty span is returned.
+     */
+    swoc::MemSpan<void const> raw_addr() const;
+
+    /// The string name of the address family.
+    static string_view family_name(sa_family_t family);
+  };
+
+  inline IPEndpoint::IPEndpoint()
+  {
+    sa.sa_family = AF_UNSPEC;
+  }
+
+  inline IPEndpoint::IPEndpoint(IPAddr const &addr)
+  {
+    this->assign(addr);
+  }
+
+  inline IPEndpoint::IPEndpoint(IPSrv const &srv)
+  {
+    this->assign(srv);
+  }
+
+  inline IPEndpoint::IPEndpoint(sockaddr const *addr)
+  {
+    this->assign(addr);
+  }
+
+  inline IPEndpoint::IPEndpoint(IPEndpoint::self_type const &that) : self_type(&that.sa) {}
+
+  inline IPEndpoint &
+  IPEndpoint::invalidate()
+  {
+    sa.sa_family = AF_UNSPEC;
+    return *this;
+  }
+
+  inline void
+  IPEndpoint::invalidate(sockaddr *addr)
+  {
+    addr->sa_family = AF_UNSPEC;
+  }
+
+  inline bool
+  IPEndpoint::is_valid() const
+  {
+    return sa.sa_family == AF_INET || sa.sa_family == AF_INET6;
+  }
+
+  inline IPEndpoint &
+  IPEndpoint::operator=(self_type const &that)
+  {
+    self_type::assign(&sa, &that.sa);
+    return *this;
+  }
+
+  inline IPEndpoint &
+  IPEndpoint::assign(sockaddr_in const *sin)
+  {
+    std::memcpy(&sa4, sin, sizeof(sockaddr_in));
+    return *this;
+  }
+
+  inline IPEndpoint &
+  IPEndpoint::assign(sockaddr_in6 const *sin6)
+  {
+    std::memcpy(&sa6, sin6, sizeof(sockaddr_in6));
+    return *this;
+  }
+
+  inline IPEndpoint &
+  IPEndpoint::assign(sockaddr const *src)
+  {
+    self_type::assign(&sa, src);
+    return *this;
+  }
+
+  inline IPEndpoint const &
+  IPEndpoint::copy_to(sockaddr *addr) const
+  {
+    self_type::assign(addr, &sa);
+    return *this;
+  }
+
+  inline bool
+  IPEndpoint::is_ip4() const
+  {
+    return AF_INET == sa.sa_family;
+  }
+
+  inline bool
+  IPEndpoint::is_ip6() const
+  {
+    return AF_INET6 == sa.sa_family;
+  }
+
+  inline sa_family_t
+  IPEndpoint::family() const
+  {
+    return sa.sa_family;
+  }
+
+  inline sockaddr_in *
+  IPEndpoint::ip4()
+  {
+    return this->is_ip4() ? &sa4 : nullptr;
+  }
+
+  inline sockaddr_in const *
+  IPEndpoint::ip4() const
+  {
+    return this->is_ip4() ? &sa4 : nullptr;
+  }
+
+  inline sockaddr_in6 *
+  IPEndpoint::ip6()
+  {
+    return this->is_ip6() ? &sa6 : nullptr;
+  }
+
+  inline sockaddr_in6 const *
+  IPEndpoint::ip6() const
+  {
+    return this->is_ip6() ? &sa6 : nullptr;
+  }
+
+  inline in_port_t
+  IPEndpoint::network_order_port() const
+  {
+    return this->is_valid() ? this->port(const_cast<sockaddr *>(&sa)) : 0;
+  }
+
+  inline in_port_t
+  IPEndpoint::host_order_port() const
+  {
+    return ntohs(this->network_order_port());
+  }
+
+  inline bool
+  IPEndpoint::is_valid(sockaddr const *sa)
+  {
+    return sa && (sa->sa_family == AF_INET || sa->sa_family == AF_INET6);
+  }
+
+  inline in_port_t &
+  IPEndpoint::port(sockaddr *sa)
+  {
+    switch (sa->sa_family) {
+    case AF_INET:
+      return reinterpret_cast<sockaddr_in *>(sa)->sin_port;
     case AF_INET6:
       return reinterpret_cast<sockaddr_in6 *>(sa)->sin6_port;
+    }
+    // Force a failure upstream by returning a null reference.
+    throw std::domain_error("sockaddr does not contain a valid IP address");
   }
-  // Force a failure upstream by returning a null reference.
-  throw std::domain_error("sockaddr does not contain a valid IP address");
-}
 
-inline in_port_t
-IPEndpoint::network_order_port(sockaddr const *sa) {
-  return self_type::is_valid(sa) ? self_type::port(const_cast<sockaddr*>(sa)) : 0;
-}
-
-inline in_port_t
-IPEndpoint::host_order_port(sockaddr const *sa) {
-  return self_type::is_valid(sa) ? ntohs(self_type::port(const_cast<sockaddr*>(sa))) : 0;
-}
-
-inline swoc::MemSpan<void const>
-IPEndpoint::raw_addr() const {
-  switch (sa.sa_family) {
-  case AF_INET: return { &sa4.sin_addr , sizeof(sa4.sin_addr) };
-  case AF_INET6: return { &sa6.sin6_addr, sizeof(sa6.sin6_addr) };
+  inline in_port_t
+  IPEndpoint::network_order_port(sockaddr const *sa)
+  {
+    return self_type::is_valid(sa) ? self_type::port(const_cast<sockaddr *>(sa)) : 0;
   }
-  return {};
-}
 
-}} // namespace swoc::SWOC_VERSION_NS
+  inline in_port_t
+  IPEndpoint::host_order_port(sockaddr const *sa)
+  {
+    return self_type::is_valid(sa) ? ntohs(self_type::port(const_cast<sockaddr *>(sa))) : 0;
+  }
+
+  inline swoc::MemSpan<void const>
+  IPEndpoint::raw_addr() const
+  {
+    switch (sa.sa_family) {
+    case AF_INET:
+      return {&sa4.sin_addr, sizeof(sa4.sin_addr)};
+    case AF_INET6:
+      return {&sa6.sin6_addr, sizeof(sa6.sin6_addr)};
+    }
+    return {};
+  }
+
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/include/swoc/IPRange.h
+++ b/code/include/swoc/IPRange.h
@@ -13,2689 +13,3063 @@
 #include <swoc/DiscreteRange.h>
 #include <swoc/IPAddr.h>
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
 
-using std::string_view;
+  using std::string_view;
 
-class IP4Net;
-class IP6Net;
-class IPNet;
+  class IP4Net;
+  class IP6Net;
+  class IPNet;
 
-/** An inclusive range of IPv4 addresses.
- */
-class IP4Range : public DiscreteRange<IP4Addr> {
-  using self_type   = IP4Range;
-  using super_type  = DiscreteRange<IP4Addr>;
-  using metric_type = IP4Addr;
-
-public:
-  /// Default constructor, invalid range.
-  constexpr IP4Range() = default;
-
-  /// Construct from an network expressed as @a addr and @a mask.
-  IP4Range(IP4Addr const &addr, IPMask const &mask);
-
-  /// Construct from super type.
-  /// @internal Why do I have to do this, even though the super type constructors are inherited?
-  IP4Range(super_type const &r) : super_type(r) {}
-
-  /** Construct range from @a text.
-   *
-   * @param text Range text.
-   * @see IP4Range::load
-   *
-   * This results in an empty range if @a text is not a valid string. If this should be checked,
-   * use @c load.
-   *
-   * @see load
+  /** An inclusive range of IPv4 addresses.
    */
-  IP4Range(string_view const &text);
-
-  using super_type::super_type; ///< Import super class constructors.
-
-  /** Set @a this range.
-   *
-   * @param addr Minimum address.
-   * @param mask CIDR mask to compute maximum adddress from @a addr.
-   * @return @a this
-   */
-  self_type &assign(IP4Addr const &addr, IPMask const &mask);
-
-  using super_type::assign; ///< Import assign methods.
-
-  /** Assign to this range from text.
-   *
-   * @param text Range text.
-   *
-   * The text must be in one of three formats.
-   * - A dashed range, "addr1-addr2"
-   * - A singleton, "addr". This is treated as if it were "addr-addr", a range of size 1.
-   * - CIDR notation, "addr/cidr" where "cidr" is a number from 0 to the number of bits in the address.
-   */
-  bool load(string_view text);
-
-  /** Compute the mask for @a this as a network.
-   *
-   * @return If @a this is a network, the mask for that network. Otherwise an invalid mask.
-   *
-   * @see IPMask::is_valid
-   */
-  IPMask network_mask() const;
-
-  /// @return The range family.
-  sa_family_t family() const { return AF_INET; }
-
-  class NetSource;
-
-  /** Generate a list of networks covering @a this range.
-   *
-   * @return A network generator.
-   *
-   * The returned object can be used as an iterator, or as a container to iterating over
-   * the unique minimal set of networks that cover @a this range.
-   *
-   * @code
-   * void (IP4Range const& range) {
-   *   for ( auto const& net : range ) {
-   *     net.addr(); // network address.
-   *     net.mask(); // network mask;
-   *   }
-   * }
-   * @endcode
-   */
-  NetSource networks() const;
-};
-
-/** Network generator class.
- * This generates networks from a range and acts as both a forward iterator and a container.
- *
- * @see IP4Range::networks
- */
-class IP4Range::NetSource {
-  using self_type = NetSource; ///< Self reference type.
-public:
-  using range_type = IP4Range; ///< Import base range type.
-
-  /// Construct from @a range.
-  explicit NetSource(range_type const &range);
-
-  /// Copy constructor.
-  NetSource(self_type const &that) = default;
-
-  /// This class acts as a container and an iterator.
-  using iterator = self_type;
-  /// All iteration is constant so no distinction between iterators.
-  using const_iterator = iterator;
-
-  iterator begin() const; ///< First network.
-  static iterator end() ;   ///< Past last network.
-
-  /// Return @c true if there are valid networks, @c false if not.
-  bool empty() const;
-
-  /// @return The current network.
-  IP4Net operator*() const;
-
-  /// Access @a this as if it were an @c IP4Net.
-  self_type *operator->();
-
-  /// Iterator support.
-  /// @return The current network address.
-  IP4Addr const &addr() const;
-
-  /// Iterator support.
-  /// @return The current network mask.
-  IPMask mask() const;
-
-  /// Move to next network.
-  self_type &operator++();
-
-  /// Move to next network.
-  self_type operator++(int);
-
-  /// Equality.
-  bool operator==(self_type const &that) const;
-
-  /// Inequality.
-  bool operator!=(self_type const &that) const;
-
-protected:
-  IP4Range _range; ///< Remaining range.
-  /// Mask for current network.
-  IP4Addr _mask{~static_cast<in_addr_t>(0)};
-  IPMask::raw_type _cidr = IP4Addr::WIDTH; ///< Current CIDR value.
-
-  void search_wider();
-
-  void search_narrower();
-
-  bool is_valid(IP4Addr mask) const;
-};
-
-/// Inclusive range of IPv6 addresses.
-class IP6Range : public DiscreteRange<IP6Addr> {
-  using self_type  = IP6Range;
-  using super_type = DiscreteRange<IP6Addr>;
-
-public:
-  /// Construct from super type.
-  /// @internal Why do I have to do this, even though the super type constructors are inherited?
-  IP6Range(super_type const &r) : super_type(r) {}
-
-  /** Construct range from @a text.
-   *
-   * @param text Range text.
-   * @see IP6Range::load
-   *
-   * This results in an empty range if @a text is not a valid string. If this should be checked,
-   * use @c load.
-   */
-  IP6Range(string_view const &text);
-
-  using super_type::super_type; ///< Import super class constructors.
-
-  /** Set @a this range.
-   *
-   * @param addr Minimum address.
-   * @param mask CIDR mask to compute maximum adddress from @a addr.
-   * @return @a this
-   */
-  self_type &assign(IP6Addr const &addr, IPMask const &mask);
-
-  using super_type::assign; ///< Import assign methods.
-
-  /** Assign to this range from text.
-   *
-   * @param text Range text.
-   *
-   * The text must be in one of three formats.
-   * - A dashed range, "addr1-addr2"
-   * - A singleton, "addr". This is treated as if it were "addr-addr", a range of size 1.
-   * - CIDR notation, "addr/cidr" where "cidr" is a number from 0 to the number of bits in the address.
-   */
-  bool load(string_view text);
-
-  /** Compute the mask for @a this as a network.
-   *
-   * @return If @a this is a network, the mask for that network. Otherwise an invalid mask.
-   *
-   * @see IPMask::is_valid
-   */
-  IPMask network_mask() const;
-
-  /// @return The range family.
-  sa_family_t family() const { return AF_INET6; }
-
-  class NetSource;
-
-  /** Generate a list of networks covering @a this range.
-   *
-   * @return A network generator.
-   *
-   * The returned object can be used as an iterator, or as a container to iterating over
-   * the unique minimal set of networks that cover @a this range.
-   *
-   * @code
-   * void (IP6Range const& range) {
-   *   for ( auto const& net : range ) {
-   *     net.addr(); // network address.
-   *     net.mask(); // network mask;
-   *   }
-   * }
-   * @endcode
-   */
-  NetSource networks() const;
-};
-
-/** Network generator class.
- * This generates networks from a range and acts as both a forward iterator and a container.
- *
- * @see IP6Range::networks
- */
-class IP6Range::NetSource {
-  using self_type = NetSource; ///< Self reference type.
-public:
-  using range_type = IP6Range; ///< Import base range type.
-
-  /// Construct from @a range.
-  explicit NetSource(range_type const &range);
-
-  /// Copy constructor.
-  NetSource(self_type const &that) = default;
-
-  /// This class acts as a container and an iterator.
-  using iterator = self_type;
-  /// All iteration is constant so no distinction between iterators.
-  using const_iterator = iterator;
-
-  iterator begin() const; ///< First network.
-  iterator end() const;   ///< Past last network.
-
-  /// @return @c true if there are valid networks, @c false if not.
-  bool empty() const;
-
-  /// @return The current network.
-  IP6Net operator*() const;
-
-  /// Access @a this as if it were an @c IP6Net.
-  self_type *operator->();
-
-  /// @return The current network address.
-  IP6Addr const & addr() const;
-
-  /// Iterator support.
-  /// @return The current network mask.
-  IPMask mask() const;
-
-  /// Move to next network.
-  self_type &operator++();
-
-  /// Move to next network.
-  self_type operator++(int);
-
-  /// Equality.
-  bool operator==(self_type const &that) const;
-
-  /// Inequality.
-  bool operator!=(self_type const &that) const;
-
-protected:
-  IP6Range _range;              ///< Remaining range.
-  IPMask _mask{IP6Addr::WIDTH}; ///< Current CIDR value.
-
-  void search_wider();
-
-  void search_narrower();
-
-  bool is_valid(IPMask const &mask);
-};
-
-class IPRangeView; // Forward declare.
-
-/** Range of IP addresses.
- * Although this can hold IPv4 or IPv6, any specific instance is one or the other, this can never contain
- * a range of different address families.
- */
-class IPRange {
-  using self_type = IPRange;
-
-public:
-  /// Default constructor - construct invalid range.
-  IPRange() = default;
-
-  /** Construct an inclusive range.
-   *
-   * @param min Minimum range value.
-   * @param max Maximum range value.
-   */
-  IPRange(IPAddr const &min, IPAddr const &max);
-
-  /** Construct an inclusive range.
-   *
-   * @param min Minimum range value.
-   * @param max Maximum range value.
-   */
-  IPRange(IP4Addr const &min, IP4Addr const &max);
-
-  /** Construct an inclusive range.
-   *
-   * @param min Minimum range value.
-   * @param max Maximum range value.
-   */
-  IPRange(IP6Addr const &min, IP6Addr const &max);
-
-  /** Construct a singleton range.
-   *
-   * @param addr Address of range.
-   */
-  IPRange(IPAddr const& addr) : IPRange(addr, addr) {}
-
-  /** Construct a singleton range.
-   *
-   * @param addr Address of range.
-   */
-  IPRange(IP4Addr addr) : IPRange(addr, addr) {}
-
-  /** Construct a singleton range.
-   *
-   * @param addr Address of range.
-   */
-  IPRange(IP6Addr const & addr) : IPRange(addr, addr) {}
-
-  /// Construct from an IPv4 @a range.
-  IPRange(IP4Range const &range);
-
-  /// Construct from an IPv6 @a range.
-  IPRange(IP6Range const &range);
-
-  /// Construct from view.
-  IPRange(IPRangeView const& view);
-
-  /** Construct from a string format.
-   *
-   * @param text Text form of range.
-   *
-   * The string can be a single address, two addresses separated by a dash '-' or a CIDR network.
-   */
-  IPRange(string_view const &text);
-
-  /** Update with an IPv4 range.
-   *
-   * @param min Minimum value.
-   * @param max Maximum value.
-   * @return @a this.
-   */
-  self_type & assign(IP4Addr const& min, IP4Addr const& max);
-
-  /** Update with an IPv6 range.
-   *
-   * @param min Minimum address.
-   * @param max Maximum address.
-   * @return @a this
-   */
-  self_type & assign(IP6Addr const& min, IP6Addr const& max);
-
-  /// Assign from view.
-  self_type & operator = (IPRangeView const& rv);
-
-  /// Equality
-  bool operator==(self_type const &that) const;
-  /// Inequality
-  bool operator!=(self_type const& that) const;
-
-  /// @return @c true if this is an IPv4 range, @c false if not.
-  bool is_ip4() const;
-
-  /// @return @c true if this is an IPv6 range, @c false if not.
-  bool is_ip6() const;
-
-  /** Check if @a this range is the IP address @a family.
-   *
-   * @param family IP address family.
-   * @return @c true if this is @a family, @c false if not.
-   */
-  bool is(sa_family_t family) const;
-
-  /** Load the range from @a text.
-   *
-   * @param text Range specifier in text format.
-   * @return @c true if @a text was successfully parsed, @c false if not.
-   *
-   * A successful parse means @a this was loaded with the specified range. If not the range is
-   * marked as invalid.
-   */
-  bool load(std::string_view const &text);
-
-  /// @return The minimum address in the range.
-  IPAddr min() const;
-
-  /// @return The maximum address in the range.
-  IPAddr max() const;
-
-  /// @return @c true if there are no addresses in the range.
-  bool empty() const;
-
-  /// Make the range empty / invalid.
-  self_type & clear();
-
-  /// @return The IPv4 range.
-  IP4Range const & ip4() const { return _range._ip4; }
-
-  /// @return The IPv6 range.
-  IP6Range const & ip6() const { return _range._ip6; }
-
-  /// @return The range family.
-  sa_family_t family() const { return _family; }
-
-  /** Compute the mask for @a this as a network.
-   *
-   * @return If @a this is a network, the mask for that network. Otherwise an invalid mask.
-   *
-   * @see IPMask::is_valid
-   */
-  IPMask network_mask() const;
-
-  /// Container for remaining range for network generation.
-  class NetSource;
-
-  /** Generate a list of networks covering @a this range.
-   *
-   * @return A network generator.
-   *
-   * The returned object can be used as an iterator, or as a container to iterating over
-   * the unique minimal set of networks that cover @a this range.
-   *
-   * @code
-   * void (IPRange const& range) {
-   *   for ( auto const& net : range ) {
-   *     net.addr(); // network address.
-   *     net.mask(); // network mask;
-   *   }
-   * }
-   * @endcode
-   */
-  NetSource networks() const;
-
-protected:
-  /** Range container.
-   *
-   * @internal
-   *
-   * This was a @c std::variant at one point, but the complexity got in the way because
-   * - These objects have no state, need no destruction.
-   * - Construction was problematic because @c variant requires construction, then access,
-   *   whereas this needs access to construct (e.g. via the @c load method).
-   */
-  union {
-    std::monostate _nil; ///< Make constructor easier to implement.
-    IP4Range _ip4;       ///< IPv4 range.
-    IP6Range _ip6;       ///< IPv6 range.
-  } _range{std::monostate{}};
-
-  /// Family of @a _range.
-  sa_family_t _family{AF_UNSPEC};
-};
-
-/** Network generator class.
- * This generates networks from a range and acts as both a forward iterator and a container.
- *
- * @see IPRange::networks
- */
-class IPRange::NetSource {
-  using self_type = NetSource; ///< Self reference type.
-public:
-  using range_type = IPRange; ///< Import base range type.
-
-  /// Construct from @a range.
-  explicit NetSource(range_type const &range);
-
-  /// Construct from view.
-  explicit NetSource(IPRangeView const& rv);
-
-  /// Copy constructor.
-  NetSource(self_type const &that) = default;
-
-  /// This class acts as a container and an iterator.
-  using iterator = self_type;
-  /// All iteration is constant so no distinction between iterators.
-  using const_iterator = iterator;
-
-  iterator begin() const; ///< First network.
-  iterator end() const;   ///< Past last network.
-
-  /// @return The current network.
-  IPNet operator*() const;
-
-  /// Access @a this as if it were an @c IP6Net.
-  self_type *operator->();
-
-  /// Iterator support.
-  /// @return The current network address.
-  IPAddr addr() const;
-
-  /// Iterator support.
-  /// @return The current network mask.
-  IPMask mask() const;
-
-  /// Move to next network.
-  self_type &operator++();
-
-  /// Move to next network.
-  self_type operator++(int);
-
-  /// Equality.
-  bool operator==(self_type const &that) const;
-
-  /// Inequality.
-  bool operator!=(self_type const &that) const;
-
-protected:
-  union {
-    std::monostate _nil; ///< Default value, no addresses.
-    IP4Range::NetSource _ip4; ///< IPv4 addresses.
-    IP6Range::NetSource _ip6; ///< IPv6 addresses.
+  class IP4Range : public DiscreteRange<IP4Addr>
+  {
+    using self_type   = IP4Range;
+    using super_type  = DiscreteRange<IP4Addr>;
+    using metric_type = IP4Addr;
+
+  public:
+    /// Default constructor, invalid range.
+    constexpr IP4Range() = default;
+
+    /// Construct from an network expressed as @a addr and @a mask.
+    IP4Range(IP4Addr const &addr, IPMask const &mask);
+
+    /// Construct from super type.
+    /// @internal Why do I have to do this, even though the super type constructors are inherited?
+    IP4Range(super_type const &r) : super_type(r) {}
+
+    /** Construct range from @a text.
+     *
+     * @param text Range text.
+     * @see IP4Range::load
+     *
+     * This results in an empty range if @a text is not a valid string. If this should be checked,
+     * use @c load.
+     *
+     * @see load
+     */
+    IP4Range(string_view const &text);
+
+    using super_type::super_type; ///< Import super class constructors.
+
+    /** Set @a this range.
+     *
+     * @param addr Minimum address.
+     * @param mask CIDR mask to compute maximum adddress from @a addr.
+     * @return @a this
+     */
+    self_type &assign(IP4Addr const &addr, IPMask const &mask);
+
+    using super_type::assign; ///< Import assign methods.
+
+    /** Assign to this range from text.
+     *
+     * @param text Range text.
+     *
+     * The text must be in one of three formats.
+     * - A dashed range, "addr1-addr2"
+     * - A singleton, "addr". This is treated as if it were "addr-addr", a range of size 1.
+     * - CIDR notation, "addr/cidr" where "cidr" is a number from 0 to the number of bits in the address.
+     */
+    bool load(string_view text);
+
+    /** Compute the mask for @a this as a network.
+     *
+     * @return If @a this is a network, the mask for that network. Otherwise an invalid mask.
+     *
+     * @see IPMask::is_valid
+     */
+    IPMask network_mask() const;
+
+    /// @return The range family.
+    sa_family_t
+    family() const
+    {
+      return AF_INET;
+    }
+
+    class NetSource;
+
+    /** Generate a list of networks covering @a this range.
+     *
+     * @return A network generator.
+     *
+     * The returned object can be used as an iterator, or as a container to iterating over
+     * the unique minimal set of networks that cover @a this range.
+     *
+     * @code
+     * void (IP4Range const& range) {
+     *   for ( auto const& net : range ) {
+     *     net.addr(); // network address.
+     *     net.mask(); // network mask;
+     *   }
+     * }
+     * @endcode
+     */
+    NetSource networks() const;
   };
 
-  sa_family_t _family = AF_UNSPEC; ///< Mark for union content.
-};
+  /** Network generator class.
+   * This generates networks from a range and acts as both a forward iterator and a container.
+   *
+   * @see IP4Range::networks
+   */
+  class IP4Range::NetSource
+  {
+    using self_type = NetSource; ///< Self reference type.
+  public:
+    using range_type = IP4Range; ///< Import base range type.
 
-/** View of a range.
- *
- * The point of this is @c IPRange is really a union on top of @c IP4Range and @c IP6Range therefore
- * using it requires copying. A view enable using an IPv4 or IPv6 range as a generic range without
- * the copy. This is useful in situations where performance is critical.
- *
- * Used primarily for iterator implementation where the ranges are stored in family specific ranges
- * in the container. The iterator can use this to provide access as an @c IPRange without a copying
- * every iteration.
- *
- * @note An earlier implementation used references and updated those to achieve this same effect but
- * that appeared to confusion the optimizer and odd effects would happen at higher optimization levels
- * (in particular, iterators would appear to not actually increment even thought the increment code
- * was invoked).
- */
-class IPRangeView {
-  using self_type = IPRangeView;
-  friend IPRange;
-  /// Storage for the view pointer - union because only one can be valid.
-  union storage_type {
-    std::monostate _nil; ///< No data present.
-    IP4Range const * _4; ///< IPv4 range.
-    IP6Range const * _6; ///< IPv6 range.
-    void const * _void; ///< Used only for fast copy in construction and assignment.
+    /// Construct from @a range.
+    explicit NetSource(range_type const &range);
 
-    // These constructors are needed to make the default construction / assignent methods work.
-    // Otherwise the compiler thinks the union isn't initialized.
-    storage_type() = default;
-    storage_type(std::monostate) {}
-    storage_type(storage_type const& that) : _void(that._void) {}
+    /// Copy constructor.
+    NetSource(self_type const &that) = default;
+
+    /// This class acts as a container and an iterator.
+    using iterator = self_type;
+    /// All iteration is constant so no distinction between iterators.
+    using const_iterator = iterator;
+
+    iterator begin() const; ///< First network.
+    static iterator end();  ///< Past last network.
+
+    /// Return @c true if there are valid networks, @c false if not.
+    bool empty() const;
+
+    /// @return The current network.
+    IP4Net operator*() const;
+
+    /// Access @a this as if it were an @c IP4Net.
+    self_type *operator->();
+
+    /// Iterator support.
+    /// @return The current network address.
+    IP4Addr const &addr() const;
+
+    /// Iterator support.
+    /// @return The current network mask.
+    IPMask mask() const;
+
+    /// Move to next network.
+    self_type &operator++();
+
+    /// Move to next network.
+    self_type operator++(int);
+
+    /// Equality.
+    bool operator==(self_type const &that) const;
+
+    /// Inequality.
+    bool operator!=(self_type const &that) const;
+
+  protected:
+    IP4Range _range; ///< Remaining range.
+    /// Mask for current network.
+    IP4Addr _mask{~static_cast<in_addr_t>(0)};
+    IPMask::raw_type _cidr = IP4Addr::WIDTH; ///< Current CIDR value.
+
+    void search_wider();
+
+    void search_narrower();
+
+    bool is_valid(IP4Addr mask) const;
   };
 
-public:
-  /// Default constructor - invalid view.
-  IPRangeView() = default;
+  /// Inclusive range of IPv6 addresses.
+  class IP6Range : public DiscreteRange<IP6Addr>
+  {
+    using self_type  = IP6Range;
+    using super_type = DiscreteRange<IP6Addr>;
 
-  /// Compare to a range.
-  bool operator == (IPRange const& r) const;
+  public:
+    /// Construct from super type.
+    /// @internal Why do I have to do this, even though the super type constructors are inherited?
+    IP6Range(super_type const &r) : super_type(r) {}
 
-  /// @return @c true if there is no valid view to a range.
-  bool valid() const;
+    /** Construct range from @a text.
+     *
+     * @param text Range text.
+     * @see IP6Range::load
+     *
+     * This results in an empty range if @a text is not a valid string. If this should be checked,
+     * use @c load.
+     */
+    IP6Range(string_view const &text);
 
-  // @return @c true if the range is empty (invalid views are empty)
-  bool empty() const;
+    using super_type::super_type; ///< Import super class constructors.
 
-  /// Reset to invalid view.
-  self_type & clear();
+    /** Set @a this range.
+     *
+     * @param addr Minimum address.
+     * @param mask CIDR mask to compute maximum adddress from @a addr.
+     * @return @a this
+     */
+    self_type &assign(IP6Addr const &addr, IPMask const &mask);
 
-  /// Update the view.
-  self_type & assign(IP4Range const& r);
+    using super_type::assign; ///< Import assign methods.
 
-  /// Update the view.
-  self_type & assign(IP6Range const& r);
+    /** Assign to this range from text.
+     *
+     * @param text Range text.
+     *
+     * The text must be in one of three formats.
+     * - A dashed range, "addr1-addr2"
+     * - A singleton, "addr". This is treated as if it were "addr-addr", a range of size 1.
+     * - CIDR notation, "addr/cidr" where "cidr" is a number from 0 to the number of bits in the address.
+     */
+    bool load(string_view text);
 
-  /// @return @c true if this is an IPv4 range.
-  bool is_ip4() const;
+    /** Compute the mask for @a this as a network.
+     *
+     * @return If @a this is a network, the mask for that network. Otherwise an invalid mask.
+     *
+     * @see IPMask::is_valid
+     */
+    IPMask network_mask() const;
 
-  /// @return @c true if this is an IPv6 range.
-  bool is_ip6() const;
+    /// @return The range family.
+    sa_family_t
+    family() const
+    {
+      return AF_INET6;
+    }
 
-  /** Check if @a this range is the IP address @a family.
+    class NetSource;
+
+    /** Generate a list of networks covering @a this range.
+     *
+     * @return A network generator.
+     *
+     * The returned object can be used as an iterator, or as a container to iterating over
+     * the unique minimal set of networks that cover @a this range.
+     *
+     * @code
+     * void (IP6Range const& range) {
+     *   for ( auto const& net : range ) {
+     *     net.addr(); // network address.
+     *     net.mask(); // network mask;
+     *   }
+     * }
+     * @endcode
+     */
+    NetSource networks() const;
+  };
+
+  /** Network generator class.
+   * This generates networks from a range and acts as both a forward iterator and a container.
    *
-   * @param family IP address family.
-   * @return @c true if this is @a family, @c false if not.
+   * @see IP6Range::networks
    */
-  bool is(sa_family_t family) const;
+  class IP6Range::NetSource
+  {
+    using self_type = NetSource; ///< Self reference type.
+  public:
+    using range_type = IP6Range; ///< Import base range type.
 
-  /// @return Reference to the viewed IPv4 range.
-  IP4Range const& ip4() const;
+    /// Construct from @a range.
+    explicit NetSource(range_type const &range);
 
-  /// @return Reference to the viewd IPv6 range.
-  IP6Range const& ip6() const;
+    /// Copy constructor.
+    NetSource(self_type const &that) = default;
 
-  /// @{
-  /// Forwarding methods.
+    /// This class acts as a container and an iterator.
+    using iterator = self_type;
+    /// All iteration is constant so no distinction between iterators.
+    using const_iterator = iterator;
 
-  /// @return The minimum address in the range.
-  IPAddr min() const;
+    iterator begin() const; ///< First network.
+    iterator end() const;   ///< Past last network.
 
-  /// @return The maximum value in the range.
-  IPAddr max() const;
+    /// @return @c true if there are valid networks, @c false if not.
+    bool empty() const;
 
-  /// Equality.
-  bool operator == (self_type const& that) const;
+    /// @return The current network.
+    IP6Net operator*() const;
 
-  /// Inequality.
-  bool operator != (self_type const& that) const;
+    /// Access @a this as if it were an @c IP6Net.
+    self_type *operator->();
 
-  /** Generate a list of networks covering @a this range.
-   *
-   * @return A network generator.
+    /// @return The current network address.
+    IP6Addr const &addr() const;
+
+    /// Iterator support.
+    /// @return The current network mask.
+    IPMask mask() const;
+
+    /// Move to next network.
+    self_type &operator++();
+
+    /// Move to next network.
+    self_type operator++(int);
+
+    /// Equality.
+    bool operator==(self_type const &that) const;
+
+    /// Inequality.
+    bool operator!=(self_type const &that) const;
+
+  protected:
+    IP6Range _range;              ///< Remaining range.
+    IPMask _mask{IP6Addr::WIDTH}; ///< Current CIDR value.
+
+    void search_wider();
+
+    void search_narrower();
+
+    bool is_valid(IPMask const &mask);
+  };
+
+  class IPRangeView; // Forward declare.
+
+  /** Range of IP addresses.
+   * Although this can hold IPv4 or IPv6, any specific instance is one or the other, this can never contain
+   * a range of different address families.
+   */
+  class IPRange
+  {
+    using self_type = IPRange;
+
+  public:
+    /// Default constructor - construct invalid range.
+    IPRange() = default;
+
+    /** Construct an inclusive range.
+     *
+     * @param min Minimum range value.
+     * @param max Maximum range value.
+     */
+    IPRange(IPAddr const &min, IPAddr const &max);
+
+    /** Construct an inclusive range.
+     *
+     * @param min Minimum range value.
+     * @param max Maximum range value.
+     */
+    IPRange(IP4Addr const &min, IP4Addr const &max);
+
+    /** Construct an inclusive range.
+     *
+     * @param min Minimum range value.
+     * @param max Maximum range value.
+     */
+    IPRange(IP6Addr const &min, IP6Addr const &max);
+
+    /** Construct a singleton range.
+     *
+     * @param addr Address of range.
+     */
+    IPRange(IPAddr const &addr) : IPRange(addr, addr) {}
+
+    /** Construct a singleton range.
+     *
+     * @param addr Address of range.
+     */
+    IPRange(IP4Addr addr) : IPRange(addr, addr) {}
+
+    /** Construct a singleton range.
+     *
+     * @param addr Address of range.
+     */
+    IPRange(IP6Addr const &addr) : IPRange(addr, addr) {}
+
+    /// Construct from an IPv4 @a range.
+    IPRange(IP4Range const &range);
+
+    /// Construct from an IPv6 @a range.
+    IPRange(IP6Range const &range);
+
+    /// Construct from view.
+    IPRange(IPRangeView const &view);
+
+    /** Construct from a string format.
+     *
+     * @param text Text form of range.
+     *
+     * The string can be a single address, two addresses separated by a dash '-' or a CIDR network.
+     */
+    IPRange(string_view const &text);
+
+    /** Update with an IPv4 range.
+     *
+     * @param min Minimum value.
+     * @param max Maximum value.
+     * @return @a this.
+     */
+    self_type &assign(IP4Addr const &min, IP4Addr const &max);
+
+    /** Update with an IPv6 range.
+     *
+     * @param min Minimum address.
+     * @param max Maximum address.
+     * @return @a this
+     */
+    self_type &assign(IP6Addr const &min, IP6Addr const &max);
+
+    /// Assign from view.
+    self_type &operator=(IPRangeView const &rv);
+
+    /// Equality
+    bool operator==(self_type const &that) const;
+    /// Inequality
+    bool operator!=(self_type const &that) const;
+
+    /// @return @c true if this is an IPv4 range, @c false if not.
+    bool is_ip4() const;
+
+    /// @return @c true if this is an IPv6 range, @c false if not.
+    bool is_ip6() const;
+
+    /** Check if @a this range is the IP address @a family.
+     *
+     * @param family IP address family.
+     * @return @c true if this is @a family, @c false if not.
+     */
+    bool is(sa_family_t family) const;
+
+    /** Load the range from @a text.
+     *
+     * @param text Range specifier in text format.
+     * @return @c true if @a text was successfully parsed, @c false if not.
+     *
+     * A successful parse means @a this was loaded with the specified range. If not the range is
+     * marked as invalid.
+     */
+    bool load(std::string_view const &text);
+
+    /// @return The minimum address in the range.
+    IPAddr min() const;
+
+    /// @return The maximum address in the range.
+    IPAddr max() const;
+
+    /// @return @c true if there are no addresses in the range.
+    bool empty() const;
+
+    /// Make the range empty / invalid.
+    self_type &clear();
+
+    /// @return The IPv4 range.
+    IP4Range const &
+    ip4() const
+    {
+      return _range._ip4;
+    }
+
+    /// @return The IPv6 range.
+    IP6Range const &
+    ip6() const
+    {
+      return _range._ip6;
+    }
+
+    /// @return The range family.
+    sa_family_t
+    family() const
+    {
+      return _family;
+    }
+
+    /** Compute the mask for @a this as a network.
+     *
+     * @return If @a this is a network, the mask for that network. Otherwise an invalid mask.
+     *
+     * @see IPMask::is_valid
+     */
+    IPMask network_mask() const;
+
+    /// Container for remaining range for network generation.
+    class NetSource;
+
+    /** Generate a list of networks covering @a this range.
+     *
+     * @return A network generator.
+     *
+     * The returned object can be used as an iterator, or as a container to iterating over
+     * the unique minimal set of networks that cover @a this range.
+     *
+     * @code
+     * void (IPRange const& range) {
+     *   for ( auto const& net : range ) {
+     *     net.addr(); // network address.
+     *     net.mask(); // network mask;
+     *   }
+     * }
+     * @endcode
+     */
+    NetSource networks() const;
+
+  protected:
+    /** Range container.
+     *
+     * @internal
+     *
+     * This was a @c std::variant at one point, but the complexity got in the way because
+     * - These objects have no state, need no destruction.
+     * - Construction was problematic because @c variant requires construction, then access,
+     *   whereas this needs access to construct (e.g. via the @c load method).
+     */
+    union {
+      std::monostate _nil; ///< Make constructor easier to implement.
+      IP4Range _ip4;       ///< IPv4 range.
+      IP6Range _ip6;       ///< IPv6 range.
+    } _range{std::monostate{}};
+
+    /// Family of @a _range.
+    sa_family_t _family{AF_UNSPEC};
+  };
+
+  /** Network generator class.
+   * This generates networks from a range and acts as both a forward iterator and a container.
    *
    * @see IPRange::networks
    */
-  IPRange::NetSource networks() const { return IPRange::NetSource(*this); }
+  class IPRange::NetSource
+  {
+    using self_type = NetSource; ///< Self reference type.
+  public:
+    using range_type = IPRange; ///< Import base range type.
 
-  /// @}
+    /// Construct from @a range.
+    explicit NetSource(range_type const &range);
 
-protected:
-  storage_type _raw = { std::monostate() }; ///< Storage for the view pointer.
-  sa_family_t _family = AF_UNSPEC; ///< Range address family.
-};
+    /// Construct from view.
+    explicit NetSource(IPRangeView const &rv);
 
-/// An IPv4 network.
-class IP4Net {
-  using self_type = IP4Net; ///< Self reference type.
-public:
-  IP4Net()                      = default; ///< Construct invalid network.
-  IP4Net(self_type const &that) = default; ///< Copy constructor.
+    /// Copy constructor.
+    NetSource(self_type const &that) = default;
 
-  /** Construct from @a addr and @a mask.
+    /// This class acts as a container and an iterator.
+    using iterator = self_type;
+    /// All iteration is constant so no distinction between iterators.
+    using const_iterator = iterator;
+
+    iterator begin() const; ///< First network.
+    iterator end() const;   ///< Past last network.
+
+    /// @return The current network.
+    IPNet operator*() const;
+
+    /// Access @a this as if it were an @c IP6Net.
+    self_type *operator->();
+
+    /// Iterator support.
+    /// @return The current network address.
+    IPAddr addr() const;
+
+    /// Iterator support.
+    /// @return The current network mask.
+    IPMask mask() const;
+
+    /// Move to next network.
+    self_type &operator++();
+
+    /// Move to next network.
+    self_type operator++(int);
+
+    /// Equality.
+    bool operator==(self_type const &that) const;
+
+    /// Inequality.
+    bool operator!=(self_type const &that) const;
+
+  protected:
+    union {
+      std::monostate _nil;      ///< Default value, no addresses.
+      IP4Range::NetSource _ip4; ///< IPv4 addresses.
+      IP6Range::NetSource _ip6; ///< IPv6 addresses.
+    };
+
+    sa_family_t _family = AF_UNSPEC; ///< Mark for union content.
+  };
+
+  /** View of a range.
    *
-   * @param addr An address in the network.
-   * @param mask The mask for the network.
+   * The point of this is @c IPRange is really a union on top of @c IP4Range and @c IP6Range therefore
+   * using it requires copying. A view enable using an IPv4 or IPv6 range as a generic range without
+   * the copy. This is useful in situations where performance is critical.
    *
-   * The network is based on the mask, and the resulting network address is chosen such that the
-   * network will contain @a addr. For a given @a addr and @a mask there is only one network
-   * that satisifies these criteria.
+   * Used primarily for iterator implementation where the ranges are stored in family specific ranges
+   * in the container. The iterator can use this to provide access as an @c IPRange without a copying
+   * every iteration.
+   *
+   * @note An earlier implementation used references and updated those to achieve this same effect but
+   * that appeared to confusion the optimizer and odd effects would happen at higher optimization levels
+   * (in particular, iterators would appear to not actually increment even thought the increment code
+   * was invoked).
    */
-  IP4Net(IP4Addr addr, IPMask mask);
+  class IPRangeView
+  {
+    using self_type = IPRangeView;
+    friend IPRange;
+    /// Storage for the view pointer - union because only one can be valid.
+    union storage_type {
+      std::monostate _nil; ///< No data present.
+      IP4Range const *_4;  ///< IPv4 range.
+      IP6Range const *_6;  ///< IPv6 range.
+      void const *_void;   ///< Used only for fast copy in construction and assignment.
 
-  IP4Net(swoc::TextView text) { this->load(text); }
+      // These constructors are needed to make the default construction / assignent methods work.
+      // Otherwise the compiler thinks the union isn't initialized.
+      storage_type() = default;
+      storage_type(std::monostate) {}
+      storage_type(storage_type const &that) : _void(that._void) {}
+    };
 
-  /** Parse network as @a text.
+  public:
+    /// Default constructor - invalid view.
+    IPRangeView() = default;
+
+    /// Compare to a range.
+    bool operator==(IPRange const &r) const;
+
+    /// @return @c true if there is no valid view to a range.
+    bool valid() const;
+
+    // @return @c true if the range is empty (invalid views are empty)
+    bool empty() const;
+
+    /// Reset to invalid view.
+    self_type &clear();
+
+    /// Update the view.
+    self_type &assign(IP4Range const &r);
+
+    /// Update the view.
+    self_type &assign(IP6Range const &r);
+
+    /// @return @c true if this is an IPv4 range.
+    bool is_ip4() const;
+
+    /// @return @c true if this is an IPv6 range.
+    bool is_ip6() const;
+
+    /** Check if @a this range is the IP address @a family.
+     *
+     * @param family IP address family.
+     * @return @c true if this is @a family, @c false if not.
+     */
+    bool is(sa_family_t family) const;
+
+    /// @return Reference to the viewed IPv4 range.
+    IP4Range const &ip4() const;
+
+    /// @return Reference to the viewd IPv6 range.
+    IP6Range const &ip6() const;
+
+    /// @{
+    /// Forwarding methods.
+
+    /// @return The minimum address in the range.
+    IPAddr min() const;
+
+    /// @return The maximum value in the range.
+    IPAddr max() const;
+
+    /// Equality.
+    bool operator==(self_type const &that) const;
+
+    /// Inequality.
+    bool operator!=(self_type const &that) const;
+
+    /** Generate a list of networks covering @a this range.
+     *
+     * @return A network generator.
+     *
+     * @see IPRange::networks
+     */
+    IPRange::NetSource
+    networks() const
+    {
+      return IPRange::NetSource(*this);
+    }
+
+    /// @}
+
+  protected:
+    storage_type _raw   = {std::monostate()}; ///< Storage for the view pointer.
+    sa_family_t _family = AF_UNSPEC;          ///< Range address family.
+  };
+
+  /// An IPv4 network.
+  class IP4Net
+  {
+    using self_type = IP4Net; ///< Self reference type.
+  public:
+    IP4Net()                      = default; ///< Construct invalid network.
+    IP4Net(self_type const &that) = default; ///< Copy constructor.
+
+    /** Construct from @a addr and @a mask.
+     *
+     * @param addr An address in the network.
+     * @param mask The mask for the network.
+     *
+     * The network is based on the mask, and the resulting network address is chosen such that the
+     * network will contain @a addr. For a given @a addr and @a mask there is only one network
+     * that satisifies these criteria.
+     */
+    IP4Net(IP4Addr addr, IPMask mask);
+
+    IP4Net(swoc::TextView text) { this->load(text); }
+
+    /** Parse network as @a text.
+     *
+     * @param text String describing the network in CIDR format.
+     * @return @c true if a valid string, @c false if not.
+     */
+    bool load(swoc::TextView text);
+
+    /// @return @c true if the network contains no addresses (is invalid).
+    bool empty() const;
+
+    /// @return Network address - smallest address in the network.
+    IP4Addr min() const;
+
+    /// @return The largest address in the network.
+    IP4Addr max() const;
+
+    /// @return The mask for the network.
+    IPMask const &mask() const;
+
+    /// @return A range that exactly covers the network.
+    IP4Range as_range() const;
+
+    /** Assign an @a addr and @a mask to @a this.
+     *
+     * @param addr Network addres.
+     * @param mask Network mask.
+     * @return @a this.
+     */
+    self_type &assign(IP4Addr const &addr, IPMask const &mask);
+
+    /// Reset network to invalid state.
+    self_type &
+    clear()
+    {
+      _mask.clear();
+      return *this;
+    }
+
+    /// Equality.
+    bool operator==(self_type const &that) const;
+
+    /// Inequality
+    bool operator!=(self_type const &that) const;
+
+  protected:
+    IP4Addr _addr; ///< Network address (also lower_node).
+    IPMask _mask;  ///< Network mask.
+  };
+
+  /// IPv6 network.
+  class IP6Net
+  {
+    using self_type = IP6Net; ///< Self reference type.
+  public:
+    IP6Net()                      = default; ///< Construct invalid network.
+    IP6Net(self_type const &that) = default; ///< Copy constructor.
+
+    /** Construct from @a addr and @a mask.
+     *
+     * @param addr An address in the network.
+     * @param mask The mask for the network.
+     *
+     * The network is based on the mask, and the resulting network address is chosen such that the
+     * network will contain @a addr. For a given @a addr and @a mask there is only one network
+     * that satisifies these criteria.
+     */
+    IP6Net(IP6Addr addr, IPMask mask);
+
+    /** Construct from text.
+     *
+     * @param text Network description.
+     *
+     * The format must be "addr/mask" where "addr" is a valid address and mask is either a single
+     * number for the mask width (CIDR) or a mask in address notation.
+     */
+    IP6Net(TextView text) { this->load(text); }
+
+    /** Parse network as @a text.
+     *
+     * @param text String describing the network in CIDR format.
+     * @return @c true if a valid string, @c false if not.
+     */
+    bool load(swoc::TextView text);
+
+    /// @return @c true if the network contains no addresses (is invalid).
+    bool empty() const;
+
+    /// @return Network address - smallest address in the network.
+    IP6Addr min() const;
+
+    /// @return Largest address in the network.
+    IP6Addr max() const;
+
+    /// @return The mask for the network.
+    IPMask const &mask() const;
+
+    /// @return A range that exactly covers the network.
+    IP6Range as_range() const;
+
+    /** Assign an @a addr and @a mask to @a this.
+     *
+     * @param addr Network addres.
+     * @param mask Network mask.
+     * @return @a this.
+     */
+    self_type &assign(IP6Addr const &addr, IPMask const &mask);
+
+    /// Reset network to invalid state.
+    self_type &
+    clear()
+    {
+      _mask.clear();
+      return *this;
+    }
+
+    /// Equality.
+    bool operator==(self_type const &that) const;
+
+    /// Inequality
+    bool operator!=(self_type const &that) const;
+
+  protected:
+    IP6Addr _addr; ///< Network address (also lower_node).
+    IPMask _mask;  ///< Network mask.
+  };
+
+  /** Representation of an IP address network.
    *
-   * @param text String describing the network in CIDR format.
-   * @return @c true if a valid string, @c false if not.
    */
-  bool load(swoc::TextView text);
+  class IPNet
+  {
+    using self_type = IPNet; ///< Self reference type.
+  public:
+    IPNet()                      = default; ///< Construct invalid network.
+    IPNet(self_type const &that) = default; ///< Copy constructor.
 
-  /// @return @c true if the network contains no addresses (is invalid).
-  bool empty() const;
+    /** Construct from @a addr and @a mask.
+     *
+     * @param addr An address in the network.
+     * @param mask The mask for the network.
+     *
+     * The network is based on the mask, and the resulting network address is chosen such that the
+     * network will contain @a addr. For a given @a addr and @a mask there is only one network
+     * that satisifies these criteria.
+     */
+    IPNet(IPAddr const &addr, IPMask const &mask);
 
-  /// @return Network address - smallest address in the network.
-  IP4Addr min() const;
+    /** Construct from text.
+     *
+     * @param text Network description.
+     *
+     * The format must be "addr/mask" where "addr" is a valid address and mask is either a single
+     * number for the mask width (CIDR) or a mask in address notation.
+     */
+    IPNet(TextView text);
 
-  /// @return The largest address in the network.
-  IP4Addr max() const;
+    /** Parse network as @a text.
+     *
+     * @param text String describing the network in CIDR format.
+     * @return @c true if a valid string, @c false if not.
+     */
+    bool load(swoc::TextView text);
 
-  /// @return The mask for the network.
-  IPMask const &mask() const;
+    /// @return @c true if the network contains no addresses (is invalid).
+    bool empty() const;
 
-  /// @return A range that exactly covers the network.
-  IP4Range as_range() const;
+    /// @return Network address - smallest address in the network.
+    IPAddr min() const;
 
-  /** Assign an @a addr and @a mask to @a this.
+    /// @return Largest address in the network.
+    IPAddr max() const;
+
+    /// @return The number of bits in the mask.
+    IPMask::raw_type width() const;
+
+    /// @return The mask for the network.
+    IPMask const &mask() const;
+
+    /// @return A range that exactly covers the network.
+    IPRange as_range() const;
+
+    /// @return @c true if network is IPv4.
+    bool
+    is_ip4() const
+    {
+      return _addr.is_ip4();
+    }
+
+    /// @return @c true if network is IPv6.
+    bool
+    is_ip6() const
+    {
+      return _addr.is_ip6();
+    }
+
+    /// Address family of network.
+    sa_family_t
+    family() const
+    {
+      return _addr.family();
+    }
+
+    /// @return The network as explicitly IPv4.
+    IP4Net ip4() const;
+
+    /// @return The network as explicitly IPv6.
+    IP6Net ip6() const;
+
+    /** Assign an @a addr and @a mask to @a this.
+     *
+     * @param addr Network addres.
+     * @param mask Network mask.
+     * @return @a this.
+     */
+    self_type &assign(IPAddr const &addr, IPMask const &mask);
+
+    /// Reset network to invalid state.
+    self_type &clear();
+
+    /// Equality.
+    bool operator==(self_type const &that) const;
+
+    /// Inequality
+    bool operator!=(self_type const &that) const;
+
+  protected:
+    IPAddr _addr; ///< Address and family.
+    IPMask _mask; ///< Network mask.
+  };
+
+  // --------------------------------------------------------------------------
+  namespace detail
+  {
+    /** Value type for @c IPSpace constant iterator.
+     *
+     * @tparam PAYLOAD User data type to be stored.
+     *
+     * @internal Exported because inner classes in template classes cannot be used in partial
+     * specialization which is required for tuple support.
+     *
+     * @internal The value type must be split in two to provide @c const consistency. The structured
+     * bidingin types are determined only by the type of the value, therefore if the structured binding
+     * should vary in whether the payload binding is @c const then there must be two types. I tested using
+     * @c const in the typle type templates but the binding always used the @c const variant regardless of
+     * the @const state of the payload instance.
+     *
+     * @note The @c assign methods are used to update iterators.
+     *
+     * @see IPSpace
+     */
+    template <typename PAYLOAD> struct ip_space_const_value_type {
+      using self_type = ip_space_const_value_type;
+
+      IPRangeView _rv;             ///< View to the current range.
+      PAYLOAD *_payload = nullptr; ///< Payload for @a _range.
+
+      ip_space_const_value_type() = default;
+
+      /// Reset to default constructed state.
+      self_type &clear();
+
+      /** Update the internal state.
+       *
+       * @param r Range.
+       * @param payload Payload.
+       * @return @a this.
+       */
+      self_type &assign(IP4Range const &r, PAYLOAD &payload);
+
+      /** Update the internal state.
+       *
+       * @param r Range.
+       * @param payload Payload.
+       * @return @a this.
+       */
+      self_type &assign(IP6Range const &r, PAYLOAD &payload);
+
+      /** Update from another instance.
+       *
+       * @param that Other instance.
+       * @return @a this.
+       */
+      self_type &assign(self_type const &that);
+
+      /// Support assignemnt to @c std::tie.
+      std::tuple<IPRangeView, PAYLOAD &>
+      tuple() const
+      {
+        return {_rv, *_payload};
+      }
+
+      /// Equality against an equivalent tuple.
+      bool operator==(std::tuple<swoc::IPRange, PAYLOAD> const &t) const;
+
+      /// @return The address range.
+      IPRange
+      range() const
+      {
+        return _rv;
+      }
+
+      /// @return The range view.
+      IPRangeView
+      range_view() const
+      {
+        return _rv;
+      }
+
+      /// @return A reference to the payload (user content).
+      PAYLOAD const &
+      payload() const
+      {
+        return *_payload;
+      }
+    };
+
+    /** Value type for @c IPSpace.
+     *
+     * @tparam PAYLOAD User data type to be stored.
+     *
+     * @internal Exported because inner classes in template classes cannot be used in partial
+     * specialization which is required for tuple support. This should be removed next API incompatible
+     * change release because tuple access is being deprecated.
+     *
+     * @note The @c assign methods are used to update iterators.
+     *
+     * @see IPSpace
+     */
+    template <typename PAYLOAD> struct ip_space_value_type : ip_space_const_value_type<PAYLOAD> {
+      using self_type  = ip_space_value_type;
+      using super_type = ip_space_const_value_type<PAYLOAD>;
+
+      /// @return A reference to the payload (user content).
+      PAYLOAD &
+      payload()
+      {
+        return *super_type::_payload;
+      }
+    };
+
+    template <typename PAYLOAD>
+    auto
+    ip_space_const_value_type<PAYLOAD>::clear() -> self_type &
+    {
+      _rv.clear();
+      _payload = nullptr;
+      return *this;
+    }
+
+    template <typename PAYLOAD>
+    auto
+    ip_space_const_value_type<PAYLOAD>::assign(IP4Range const &r, PAYLOAD &payload) -> self_type &
+    {
+      _rv.assign(r);
+      _payload = &payload;
+      return *this;
+    }
+
+    template <typename PAYLOAD>
+    auto
+    ip_space_const_value_type<PAYLOAD>::assign(IP6Range const &r, PAYLOAD &payload) -> self_type &
+    {
+      _rv.assign(r);
+      _payload = &payload;
+      return *this;
+    }
+
+    template <typename PAYLOAD>
+    auto
+    ip_space_const_value_type<PAYLOAD>::assign(ip_space_const_value_type::self_type const &that) -> self_type &
+    {
+      _rv      = that._rv;
+      _payload = that._payload;
+      return *this;
+    }
+
+    template <typename PAYLOAD>
+    bool
+    ip_space_const_value_type<PAYLOAD>::operator==(std::tuple<swoc::IPRange, PAYLOAD> const &t) const
+    {
+      return _rv == std::get<0>(t) && std::get<1>(t) == *_payload;
+    }
+
+  } // namespace detail
+
+  /** Coloring of IP address space.
    *
-   * @param addr Network addres.
-   * @param mask Network mask.
-   * @return @a this.
+   * @tparam PAYLOAD The color class.
+   *
+   * This is a class to do fast coloring and lookup of the IP address space. It is range oriented and
+   * performs well for ranges, much less well for singletons. Conceptually every IP address is a key
+   * in the space and can have a color / payload of type @c PAYLOAD.
+   *
+   * @c PAYLOAD must have the properties
+   *
+   * - Cheap to copy.
+   * - Comparable via the equality and inequality operators.
    */
-  self_type &assign(IP4Addr const &addr, IPMask const &mask);
+  template <typename PAYLOAD> class IPSpace
+  {
+    using self_type = IPSpace;
+    using IP4Space  = DiscreteSpace<IP4Addr, PAYLOAD>;
+    using IP6Space  = DiscreteSpace<IP6Addr, PAYLOAD>;
 
-  /// Reset network to invalid state.
-  self_type & clear() {  _mask.clear(); return *this;  }
+  public:
+    using payload_t = PAYLOAD; ///< Export payload type.
+    /// Iterator value, a range and payload.
+    using value_type = detail::ip_space_value_type<PAYLOAD>;
 
-  /// Equality.
-  bool operator==(self_type const &that) const;
+    /// Construct an empty space.
+    IPSpace() = default;
 
-  /// Inequality
-  bool operator!=(self_type const &that) const;
+    /** Mark the range @a r with @a payload.
+     *
+     * @param range Range to mark.
+     * @param payload Payload to assign.
+     * @return @a this
+     *
+     * All addresses in @a r are set to have the @a payload.
+     */
+    self_type &mark(IPRange const &range, PAYLOAD const &payload);
 
-protected:
-  IP4Addr _addr; ///< Network address (also lower_node).
-  IPMask _mask;  ///< Network mask.
-};
+    /** Fill the @a range with @a payload.
+     *
+     * @param range Destination range.
+     * @param payload Payload for range.
+     * @return this
+     *
+     * Addresses in @a range are set to have @a payload if the address does not already have a payload.
+     */
+    self_type &fill(IPRange const &range, PAYLOAD const &payload);
 
-/// IPv6 network.
-class IP6Net {
-  using self_type = IP6Net; ///< Self reference type.
-public:
-  IP6Net()                      = default; ///< Construct invalid network.
-  IP6Net(self_type const &that) = default; ///< Copy constructor.
+    /** Erase addresses in @a range.
+     *
+     * @param range Address range.
+     * @return @a this
+     */
+    self_type &erase(IPRange const &range);
 
-  /** Construct from @a addr and @a mask.
+    /** Blend @a color in to the @a range.
+     *
+     * @tparam F Blending functor type (deduced).
+     * @tparam U Data to blend in to payloads.
+     * @param range Target range.
+     * @param color Data to blend in to existing payloads in @a range.
+     * @param blender Blending functor.
+     * @return @a this
+     *
+     * @a blender is required to have the signature <tt>void(PAYLOAD& lhs , U CONST&rhs)</tt>. It must
+     * act as a compound assignment operator, blending @a rhs into @a lhs. That is, if the result of
+     * blending @a rhs in to @a lhs is defined as "lhs @ rhs" for the binary operator "@", then @a
+     * blender computes "lhs @= rhs".
+     *
+     * Every address in @a range is assigned a payload. If the address does not already have a color,
+     * it is assigned the default constructed @c PAYLOAD blended with @a color. If the address has a
+     * @c PAYLOAD @a p, @a p is updated by invoking <tt>blender(p, color)</tt>, with the expectation
+     * that @a p will be updated in place.
+     */
+    template <typename F, typename U = PAYLOAD> self_type &blend(IPRange const &range, U const &color, F &&blender);
+
+    template <typename F, typename U = PAYLOAD> self_type &blend(IP4Range const &range, U const &color, F &&blender);
+
+    template <typename F, typename U = PAYLOAD> self_type &blend(IP6Range const &range, U const &color, F &&blender);
+
+    /// @return The number of distinct ranges.
+    size_t count() const;
+
+    /// @return The number of IPv4 ranges.
+    size_t count_ip4() const;
+
+    /// @return The number of IPv6 ranges.
+    size_t count_ip6() const;
+
+    /** Number of rnages for a specific address family.
+     *
+     * @param f Address family.
+     * @return The number of ranges of @a family.
+     */
+    size_t count(sa_family_t f) const;
+
+    /// @return @c true if there are no ranges in the space, @c false otherwise.
+    bool empty() const;
+
+    /// Remove all ranges.
+    void clear();
+
+    /** Constant iterator.
+     * The value type is a tuple of the IP address range and the @a PAYLOAD. Both are constant.
+     *
+     * @internal The non-const iterator is a subclass of this, in order to share implementation. This
+     * also makes it easy to convert from iterator to const iterator, which is desirable.
+     *
+     * @internal The return type is quite tricky because the value type of the nested containers is
+     * not the same as the value type for this container. It's not even a composite - @c IPRange is
+     * not an alias for either of the family specific range types. Therefore the iterator itself must
+     * contain a synthesized instance of the value type, which creates scoping and update problems.
+     * The approach here is to update the synthetic value when the iterator is modified and returning
+     * it by value for the dereference operator because a return by reference means  code like
+     * @code
+     *   auto && [ r , p ] = *(space.find(addr));
+     * @endcode
+     * can fail due to the iterator going out of scope after the statement is finished making @a r
+     * and @a p dangling references. If the return is by value the compiler takes care of it.
+     */
+    class const_iterator
+    {
+      using self_type = const_iterator; ///< Self reference type.
+      friend class IPSpace;
+
+    public:
+      using value_type = detail::ip_space_const_value_type<PAYLOAD>; /// Import for API compliance.
+      // STL algorithm compliance.
+      using iterator_category = std::bidirectional_iterator_tag;
+      using pointer           = value_type const *;
+      using reference         = value_type const &;
+      using difference_type   = int;
+
+      /// Default constructor.
+      const_iterator() = default;
+
+      /// Copy constructor.
+      const_iterator(self_type const &that) = default;
+
+      /// Assignment.
+      self_type &operator=(self_type const &that);
+
+      /// Pre-increment.
+      /// Move to the next element in the list.
+      /// @return The iterator.
+      self_type &operator++();
+
+      /// Pre-decrement.
+      /// Move to the previous element in the list.
+      /// @return The iterator.
+      self_type &operator--();
+
+      /// Post-increment.
+      /// Move to the next element in the list.
+      /// @return The iterator value before the increment.
+      self_type operator++(int);
+
+      /// Post-decrement.
+      /// Move to the previous element in the list.
+      /// @return The iterator value before the decrement.
+      self_type operator--(int);
+
+      /// Dereference.
+      /// @return A reference to the referent.
+      reference operator*() const;
+
+      /// Dereference.
+      /// @return A pointer to the referent.
+      pointer operator->() const;
+
+      /// Equality
+      bool operator==(self_type const &that) const;
+
+      /// Inequality
+      bool operator!=(self_type const &that) const;
+
+    protected:
+      // These are stored non-const to make implementing @c iterator easier. The containing class provides the
+      // required @c const protection. Internally a tuple of iterators is stored for forward iteration. If
+      // the primary (ipv4) iterator is at the end, then use the secondary (ipv6) iterator. The reverse
+      // is done for reverse iteration. This depends on the extra support @c IntrusiveDList iterators
+      // provide.
+      typename IP4Space::iterator _iter_4; ///< IPv4 sub-space iterator.
+      typename IP6Space::iterator _iter_6; ///< IPv6 sub-space iterator.
+      /// Current value.
+      value_type _value;
+
+      /** Internal constructor.
+       *
+       * @param iter4 Starting place for IPv4 subspace.
+       * @param iter6 Starting place for IPv6 subspace.
+       *
+       * In practice, at most one iterator should be "internal", the other should be the beginning or end.
+       */
+      const_iterator(typename IP4Space::const_iterator const &iter4, typename IP6Space::const_iterator const &iter6);
+
+      // These are required because the actual range type for the subspaces is @c DiscreteRange<T>
+      // and returning that type without a cast creates a temporary which causes some nasty side effects.
+
+      /// @return Properly type cast range from iterator.
+      IP4Range const &
+      r4()
+      {
+        return static_cast<IP4Range const &>(_iter_4->range());
+      }
+      /// @return Properly type cast range from iterator.
+      IP6Range const &
+      r6()
+      {
+        return static_cast<IP6Range const &>(_iter_6->range());
+      }
+    };
+
+    /** Iterator.
+     * The value type is a tuple of the IP address range and the @a PAYLOAD. The range is constant
+     * and the @a PAYLOAD is a reference. This can be used to update the @a PAYLOAD for this range.
+     *
+     * @note Range merges are not triggered by modifications of the @a PAYLOAD via an iterator.
+     */
+    class iterator : public const_iterator
+    {
+      using self_type  = iterator;
+      using super_type = const_iterator;
+
+      friend class IPSpace;
+
+    protected:
+      using super_type::super_type; /// Inherit supertype constructors.
+      /// Protected constructor to convert const to non-const.
+      /// @note This makes for much less code duplication in iterator relevant methods.
+      iterator(const_iterator const &that) : const_iterator(that) {}
+
+    public:
+      /// Value type of iteration.
+      using value_type = detail::ip_space_value_type<PAYLOAD>;
+      using pointer    = value_type *;
+      using reference  = value_type &;
+
+      /// Default constructor.
+      iterator() = default;
+
+      /// Copy constructor.
+      iterator(self_type const &that) = default;
+
+      /// Assignment.
+      self_type &operator=(self_type const &that);
+
+      /// Pre-increment.
+      /// Move to the next element in the list.
+      /// @return The iterator.
+      self_type &operator++();
+
+      /// Pre-decrement.
+      /// Move to the previous element in the list.
+      /// @return The iterator.
+      self_type &operator--();
+
+      /// Post-increment.
+      /// Move to the next element in the list.
+      /// @return The iterator value before the increment.
+      self_type operator++(int);
+
+      /// Post-decrement.
+      /// Move to the previous element in the list.
+      /// @return The iterator value before the decrement.
+      self_type operator--(int);
+
+      /// Dereference.
+      /// @return A reference to the referent.
+      reference operator*() const;
+
+      /// Dereference.
+      /// @return A pointer to the referent.
+      pointer operator->() const;
+
+    protected:
+      // Retrieve the value and convert from the super (const) type value to the value for iterator.
+      value_type &value() const;
+    };
+
+    /** Find the payload for an @a addr.
+     *
+     * @param addr Address to find.
+     * @return Iterator for the range containing @a addr.
+     */
+    iterator find(IPAddr const &addr);
+
+    /** Find the payload for an @a addr.
+     *
+     * @param addr Address to find.
+     * @return Iterator for the range containing @a addr.
+     */
+    const_iterator find(IPAddr const &addr) const;
+
+    /** Find the payload for an @a addr.
+     *
+     * @param addr Address to find.
+     * @return An iterator which is valid if @a addr was found, @c end if not.
+     */
+    iterator find(IP4Addr const &addr);
+
+    /** Find the payload for an @a addr.
+     *
+     * @param addr Address to find.
+     * @return An iterator which is valid if @a addr was found, @c end if not.
+     */
+    const_iterator find(IP4Addr const &addr) const;
+
+    /** Find the payload for an @a addr.
+     *
+     * @param addr Address to find.
+     * @return An iterator which is valid if @a addr was found, @c end if not.
+     */
+    iterator find(IP6Addr const &addr);
+
+    /** Find the payload for an @a addr.
+     *
+     * @param addr Address to find.
+     * @return An iterator which is valid if @a addr was found, @c end if not.
+     */
+    const_iterator find(IP6Addr const &addr) const;
+
+    /// @return An iterator to the first element.
+    iterator begin();
+
+    /// @return A constant iterator to the first element.
+    const_iterator begin() const;
+
+    /// @return An iterator past the last element.
+    iterator end();
+
+    /// @return A constant iterator past the last element.
+    const_iterator end() const;
+
+    /// @return Iterator to the first IPv4 address.
+    iterator begin_ip4();
+    /// @return Iterator to the first IPv4 address.
+    const_iterator begin_ip4() const;
+
+    /// @return Iterator past the last IPv4 address.
+    iterator end_ip4();
+    /// @return Iterator past the last IPv4 address.
+    const_iterator end_ip4() const;
+
+    /// @return Iterator at the first IPv6 address.
+    iterator begin_ip6();
+    /// @return Iterator at the first IPv6 address.
+    const_iterator begin_ip6() const;
+    /// @return Iterator past the last IPv6 address.
+    iterator end_ip6();
+    /// @return Iterator past the last IPv6 address.
+    const_iterator end_ip6() const;
+
+    /// @return Iterator to the first address of @a family.
+    const_iterator begin(sa_family_t family) const;
+
+    /// @return Iterator past the last address of @a family.
+    const_iterator end(sa_family_t family) const;
+
+    /** Sequnce of ranges that intersect @a r.
+     *
+     * @param r Search range.
+     * @return Iterator pair covering ranges that intersect @a r.
+     */
+    std::pair<iterator, iterator>
+    intersection(IP4Range const &r)
+    {
+      auto &&[begin, end] = _ip4.intersection(r);
+      return {this->iterator_at(begin), this->iterator_at(end)};
+    }
+
+    /** Sequnce of ranges that intersect @a r.
+     *
+     * @param r Search range.
+     * @return Iterator pair covering ranges that intersect @a r.
+     */
+    std::pair<iterator, iterator>
+    intersection(IP6Range const &r)
+    {
+      auto &&[begin, end] = _ip6.intersection(r);
+      return {this->iterator_at(begin), this->iterator_at(end)};
+    }
+
+    /** Sequnce of ranges that intersect @a r.
+     *
+     * @param r Search range.
+     * @return Iterator pair covering ranges that intersect @a r.
+     */
+    std::pair<iterator, iterator>
+    intersection(IPRange const &r)
+    {
+      if (r.is_ip4()) {
+        return this->intersection(r.ip4());
+      } else if (r.is_ip6()) {
+        return this->intersection(r.ip6());
+      }
+      return {this->end(), this->end()};
+    }
+
+  protected:
+    IP4Space _ip4; ///< Sub-space containing IPv4 ranges.
+    IP6Space _ip6; ///< sub-space containing IPv6 ranges.
+
+    iterator
+    iterator_at(typename IP4Space::const_iterator const &spot)
+    {
+      return iterator(spot, _ip6.begin());
+    }
+    iterator
+    iterator_at(typename IP6Space::const_iterator const &spot)
+    {
+      return iterator(_ip4.end(), spot);
+    }
+
+    friend class IPRangeSet;
+  };
+
+  /** An IPSpace that contains only addresses.
    *
-   * @param addr An address in the network.
-   * @param mask The mask for the network.
+   * This is to @c IPSpace as @c std::set is to @c std::map. The @c value_type is removed from the API
+   * and only the keys are visible. This suits use cases where the goal is to track the presence of
+   * addresses without any additional data.
    *
-   * The network is based on the mask, and the resulting network address is chosen such that the
-   * network will contain @a addr. For a given @a addr and @a mask there is only one network
-   * that satisifies these criteria.
+   * @note Because there is only one value stored, there is no difference between @c mark and @c fill.
    */
-  IP6Net(IP6Addr addr, IPMask mask);
+  class IPRangeSet
+  {
+    using self_type = IPRangeSet;
 
-  /** Construct from text.
-   *
-   * @param text Network description.
-   *
-   * The format must be "addr/mask" where "addr" is a valid address and mask is either a single
-   * number for the mask width (CIDR) or a mask in address notation.
+    /// Empty struct to use for payload.
+    /// This declares the struct and defines the singleton instance used.
+    /// @internal For some reason @c std::monostate didn't work, but I don't remember why.
+    static inline constexpr struct Mark {
+      using self_type = Mark;
+      /// @internal @c IPSpace requires equality / inequality operators.
+      /// These make all instance equal to each other.
+      bool operator==(self_type const &that);
+      bool operator!=(self_type const &that);
+    } MARK{};
+
+    /// Range set type.
+    using Space = swoc::IPSpace<Mark>;
+
+  public:
+    /// Default construct empty set.
+    IPRangeSet() = default;
+
+    /** Add addresses to the set.
+     *
+     * @param r Range of addresses to add.
+     * @return @a this
+     *
+     * Identical to @c fill.
+     */
+    self_type &mark(swoc::IPRange const &r);
+
+    /** Add addresses to the set.
+     *
+     * @param r Range of addresses to add.
+     * @return @a this
+     *
+     * Identical to @c mark.
+     */
+    self_type &fill(swoc::IPRange const &r);
+
+    /// @return @c true if @a addr is in the set.
+    bool contains(swoc::IPAddr const &addr) const;
+
+    /// @return Number of ranges in the set.
+    size_t count() const;
+
+    bool empty() const;
+
+    /// Remove all addresses in the set.
+    void clear();
+
+    /// Bidirectional constant iterator for iteration over ranges.
+    class const_iterator
+    {
+      using self_type  = const_iterator; ///< Self reference type.
+      using super_type = Space::const_iterator;
+      friend class IPRangeSet;
+
+    public:
+      using value_type = IPRangeView;
+      // STL algorithm compliance.
+      using iterator_category = std::bidirectional_iterator_tag;
+      using pointer           = value_type const *;
+      using reference         = value_type const &;
+      using difference_type   = int;
+
+      /// Default constructor.
+      const_iterator() = default;
+
+      /// Copy constructor.
+      const_iterator(self_type const &that) = default;
+
+      /// Assignment.
+      self_type &operator=(self_type const &that) = default;
+
+      /// Pre-increment.
+      /// Move to the next element in the list.
+      /// @return The iterator.
+      self_type &operator++();
+
+      /// Pre-decrement.
+      /// Move to the previous element in the list.
+      /// @return The iterator.
+      self_type &operator--();
+
+      /// Post-increment.
+      /// Move to the next element in the list.
+      /// @return The iterator value before the increment.
+      self_type operator++(int);
+
+      /// Post-decrement.
+      /// Move to the previous element in the list.
+      /// @return The iterator value before the decrement.
+      self_type operator--(int);
+
+      /// Dereference.
+      /// @return A reference to the referent.
+      reference operator*() const;
+
+      /// Dereference.
+      /// @return A pointer to the referent.
+      pointer operator->() const;
+
+      /// Equality
+      bool operator==(self_type const &that) const;
+
+      /// Inequality
+      bool operator!=(self_type const &that) const;
+
+    protected:
+      const_iterator(super_type const &spot) : _iter(spot) {}
+
+      super_type _iter; ///< Underlying iterator.
+      IPRange _r;       ///< Some less temporary storage for dereferences.
+    };
+
+    using iterator = const_iterator;
+
+    /// @return Iterator to first range.
+    const_iterator
+    begin() const
+    {
+      return _addrs.begin();
+    }
+    /// @return Iterator past last range.
+    const_iterator
+    end() const
+    {
+      return _addrs.end();
+    }
+
+  protected:
+    /// The address set.
+    Space _addrs;
+  };
+
+  inline auto
+  IPRangeSet::mark(swoc::IPRange const &r) -> self_type &
+  {
+    _addrs.mark(r, MARK);
+    return *this;
+  }
+
+  inline auto
+  IPRangeSet::fill(swoc::IPRange const &r) -> self_type &
+  {
+    _addrs.mark(r, MARK);
+    return *this;
+  }
+
+  inline bool
+  IPRangeSet::contains(swoc::IPAddr const &addr) const
+  {
+    return _addrs.find(addr) != _addrs.end();
+  }
+
+  inline size_t
+  IPRangeSet::count() const
+  {
+    return _addrs.count();
+  }
+
+  inline bool
+  IPRangeSet::empty() const
+  {
+    return _addrs.empty();
+  }
+
+  inline void
+  IPRangeSet::clear()
+  {
+    _addrs.clear();
+  }
+
+  inline bool
+  IPRangeSet::Mark::operator==(IPRangeSet::Mark::self_type const &)
+  {
+    return true;
+  }
+
+  inline bool
+  IPRangeSet::Mark::operator!=(IPRangeSet::Mark::self_type const &)
+  {
+    return false;
+  }
+
+  template <typename PAYLOAD>
+  IPSpace<PAYLOAD>::const_iterator::const_iterator(typename IP4Space::const_iterator const &iter4,
+                                                   typename IP6Space::const_iterator const &iter6)
+    : _iter_4(static_cast<typename IP4Space::iterator const &>(iter4)),
+      _iter_6(static_cast<typename IP6Space::iterator const &>(iter6))
+  {
+    if (_iter_4.has_next()) {
+      _value.assign(this->r4(), _iter_4->payload());
+    } else if (_iter_6.has_next()) {
+      _value.assign(this->r6(), _iter_6->payload());
+    }
+  }
+
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::const_iterator::operator=(self_type const &that) -> self_type &
+  {
+    _iter_4 = that._iter_4;
+    _iter_6 = that._iter_6;
+    _value.assign(that._value);
+    return *this;
+  }
+
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::const_iterator::operator++() -> self_type &
+  {
+    bool incr_p = false;
+    if (_iter_4.has_next()) {
+      ++_iter_4;
+      incr_p = true;
+      if (_iter_4.has_next()) {
+        _value.assign(this->r4(), _iter_4->payload());
+        return *this;
+      }
+    }
+
+    if (_iter_6.has_next()) {
+      if (incr_p || (++_iter_6).has_next()) {
+        _value.assign(this->r6(), _iter_6->payload());
+        return *this;
+      }
+    }
+    _value.clear();
+    return *this;
+  }
+
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::const_iterator::operator++(int) -> self_type
+  {
+    self_type zret(*this);
+    ++*this;
+    return zret;
+  }
+
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::const_iterator::operator--() -> self_type &
+  {
+    if (_iter_6.has_prev()) {
+      --_iter_6;
+      _value.assign(this->r6(), _iter_6->payload());
+      return *this;
+    }
+    if (_iter_4.has_prev()) {
+      --_iter_4;
+      _value.assign(this->r4(), _iter_4->payload());
+      return *this;
+    }
+    _value.clear();
+    return *this;
+  }
+
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::const_iterator::operator--(int) -> self_type
+  {
+    self_type zret(*this);
+    --*this;
+    return zret;
+  }
+
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::const_iterator::operator*() const -> reference
+  {
+    return _value;
+  }
+
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::const_iterator::operator->() const -> pointer
+  {
+    return &_value;
+  }
+
+  /* Bit of subtlety with equality - although it seems that if @a _iter_4 is valid, it doesn't matter
+   * where @a _iter6 is (because it is really the iterator location that's being checked), it's
+   * necessary to do the @a _iter_4 validity on both iterators to avoid the case of a false positive
+   * where different internal iterators are valid. However, in practice the other (non-active)
+   * iterator won't have an arbitrary value, it will be either @c begin or @c end in step with the
+   * active iterator therefore it's effective and cheaper to just check both values.
    */
-  IP6Net(TextView text) { this->load(text); }
 
-  /** Parse network as @a text.
-   *
-   * @param text String describing the network in CIDR format.
-   * @return @c true if a valid string, @c false if not.
-   */
-  bool load(swoc::TextView text);
+  template <typename PAYLOAD>
+  bool
+  IPSpace<PAYLOAD>::const_iterator::operator==(self_type const &that) const
+  {
+    return _iter_4 == that._iter_4 && _iter_6 == that._iter_6;
+  }
 
-  /// @return @c true if the network contains no addresses (is invalid).
-  bool empty() const;
+  template <typename PAYLOAD>
+  bool
+  IPSpace<PAYLOAD>::const_iterator::operator!=(self_type const &that) const
+  {
+    return _iter_4 != that._iter_4 || _iter_6 != that._iter_6;
+  }
 
-  /// @return Network address - smallest address in the network.
-  IP6Addr min() const;
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::iterator::operator=(self_type const &that) -> self_type &
+  {
+    this->super_type::operator=(that);
+    return *this;
+  }
 
-  /// @return Largest address in the network.
-  IP6Addr max() const;
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::iterator::value() const -> value_type &
+  {
+    return reinterpret_cast<value_type &>(const_cast<self_type *>(this)->_value);
+  }
 
-  /// @return The mask for the network.
-  IPMask const &mask() const;
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::iterator::operator->() const -> pointer
+  {
+    return &(this->value());
+  }
 
-  /// @return A range that exactly covers the network.
-  IP6Range as_range() const;
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::iterator::operator*() const -> reference
+  {
+    return this->value();
+  }
 
-  /** Assign an @a addr and @a mask to @a this.
-   *
-   * @param addr Network addres.
-   * @param mask Network mask.
-   * @return @a this.
-   */
-  self_type &assign(IP6Addr const &addr, IPMask const &mask);
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::iterator::operator++() -> self_type &
+  {
+    this->super_type::operator++();
+    return *this;
+  }
 
-  /// Reset network to invalid state.
-  self_type &
-  clear() {
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::iterator::operator++(int) -> self_type
+  {
+    self_type zret{*this};
+    ++*this;
+    return zret;
+  }
+
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::iterator::operator--() -> self_type &
+  {
+    this->super_type::operator--();
+    return *this;
+  }
+
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::iterator::operator--(int) -> self_type
+  {
+    self_type zret{*this};
+    --*this;
+    return zret;
+  }
+
+  /// ------------------------------------------------------------------------------------
+
+  // +++ IPRange +++
+
+  inline IP4Range::IP4Range(string_view const &text)
+  {
+    this->load(text);
+  }
+
+  inline auto
+  IP4Range::networks() const -> NetSource
+  {
+    return {NetSource{*this}};
+  }
+
+  inline IP6Range::IP6Range(string_view const &text)
+  {
+    this->load(text);
+  }
+
+  inline auto
+  IP6Range::networks() const -> NetSource
+  {
+    return {NetSource{*this}};
+  }
+
+  inline IPRange::IPRange(IP4Range const &range) : _family(AF_INET)
+  {
+    _range._ip4 = range;
+  }
+
+  inline IPRange::IPRange(IP6Range const &range) : _family(AF_INET6)
+  {
+    _range._ip6 = range;
+  }
+
+  inline IPRange::IPRange(IP4Addr const &min, IP4Addr const &max)
+  {
+    this->assign(min, max);
+  }
+
+  inline IPRange::IPRange(IP6Addr const &min, IP6Addr const &max)
+  {
+    this->assign(min, max);
+  }
+
+  inline IPRange::IPRange(string_view const &text)
+  {
+    this->load(text);
+  }
+
+  inline IPRange::IPRange(IPRangeView const &view)
+  {
+    if (AF_INET == view._family) {
+      *this = *view._raw._4;
+    } else if (AF_INET6 == view._family) {
+      *this = *view._raw._6;
+    }
+  }
+
+  inline auto
+  IPRange::assign(IP4Addr const &min, IP4Addr const &max) -> self_type &
+  {
+    _range._ip4.assign(min, max);
+    _family = AF_INET;
+    return *this;
+  }
+
+  inline auto
+  IPRange::assign(IP6Addr const &min, IP6Addr const &max) -> self_type &
+  {
+    _range._ip6.assign(min, max);
+    _family = AF_INET6;
+    return *this;
+  }
+
+  inline auto
+  IPRange::operator=(const IPRangeView &rv) -> self_type &
+  {
+    if (AF_INET == rv._family) {
+      *this = *rv._raw._4;
+    } else if (AF_INET6 == rv._family) {
+      *this = *rv._raw._6;
+    }
+    return *this;
+  }
+
+  inline auto
+  IPRange::clear() -> self_type &
+  {
+    _family = AF_UNSPEC;
+    return *this;
+  }
+
+  inline auto
+  IPRange::networks() const -> NetSource
+  {
+    return {NetSource{*this}};
+  }
+
+  inline bool
+  IPRange::is(sa_family_t family) const
+  {
+    return family == _family;
+  }
+
+  inline bool
+  IPRange::operator!=(const self_type &that) const
+  {
+    return !(*this == that);
+  }
+
+  inline bool
+  IPRange::is_ip4() const
+  {
+    return AF_INET == _family;
+  }
+
+  inline bool
+  IPRange::is_ip6() const
+  {
+    return AF_INET6 == _family;
+  }
+
+  inline auto
+  IPRangeView::clear() -> self_type &
+  {
+    _family = AF_UNSPEC;
+    return *this;
+  }
+
+  inline bool
+  IPRangeView::empty() const
+  {
+    return AF_INET6 == _family ? _raw._6->empty() : AF_INET == _family ? _raw._4->empty() : true;
+  }
+
+  inline bool
+  IPRangeView::is_ip4() const
+  {
+    return AF_INET == _family;
+  }
+
+  inline bool
+  IPRangeView::is_ip6() const
+  {
+    return AF_INET6 == _family;
+  }
+
+  inline bool
+  IPRangeView::is(sa_family_t f) const
+  {
+    return f == _family;
+  }
+
+  inline IP4Range const &
+  IPRangeView::ip4() const
+  {
+    return *_raw._4;
+  }
+
+  inline IP6Range const &
+  IPRangeView::ip6() const
+  {
+    return *_raw._6;
+  }
+
+  inline bool
+  IPRangeView::valid() const
+  {
+    return AF_INET == _family || AF_INET6 == _family;
+  }
+
+  inline auto
+  IPRangeView::assign(IP4Range const &r) -> self_type &
+  {
+    _family = r.family();
+    _raw._4 = &r;
+    return *this;
+  }
+
+  inline auto
+  IPRangeView::assign(IP6Range const &r) -> self_type &
+  {
+    _family = r.family();
+    _raw._6 = &r;
+    return *this;
+  }
+
+  inline bool
+  IPRangeView::operator!=(IPRangeView::self_type const &that) const
+  {
+    return !(*this == that);
+  }
+
+  inline IPAddr
+  IPRangeView::min() const
+  {
+    return AF_INET == _family ? _raw._4->min() : AF_INET6 == _family ? _raw._6->min() : IPAddr::INVALID;
+  }
+
+  inline IPAddr
+  IPRangeView::max() const
+  {
+    return AF_INET == _family ? _raw._4->max() : AF_INET6 == _family ? _raw._6->max() : IPAddr::INVALID;
+  }
+
+  // +++ IPNet +++
+
+  inline IP4Net::IP4Net(swoc::IP4Addr addr, swoc::IPMask mask) : _addr(addr & mask), _mask(mask) {}
+
+  inline IPMask const &
+  IP4Net::mask() const
+  {
+    return _mask;
+  }
+
+  inline bool
+  IP4Net::empty() const
+  {
+    return !_mask.is_valid();
+  }
+
+  inline IP4Addr
+  IP4Net::min() const
+  {
+    return _addr;
+  }
+
+  inline IP4Addr
+  IP4Net::max() const
+  {
+    return _addr | _mask;
+  }
+
+  inline IP4Range
+  IP4Net::as_range() const
+  {
+    return {this->min(), this->max()};
+  }
+
+  inline bool
+  IP4Net::operator==(self_type const &that) const
+  {
+    return _mask == that._mask && _addr == that._addr;
+  }
+
+  inline bool
+  IP4Net::operator!=(self_type const &that) const
+  {
+    return _mask != that._mask || _addr != that._addr;
+  }
+
+  inline IP4Net::self_type &
+  IP4Net::assign(IP4Addr const &addr, IPMask const &mask)
+  {
+    _addr = addr & mask;
+    _mask = mask;
+    return *this;
+  }
+
+  inline IP6Net::IP6Net(swoc::IP6Addr addr, swoc::IPMask mask) : _addr(addr & mask), _mask(mask) {}
+
+  inline IPMask const &
+  IP6Net::mask() const
+  {
+    return _mask;
+  }
+
+  inline bool
+  IP6Net::empty() const
+  {
+    return !_mask.is_valid();
+  }
+
+  inline IP6Addr
+  IP6Net::min() const
+  {
+    return _addr;
+  }
+
+  inline IP6Addr
+  IP6Net::max() const
+  {
+    return _addr | _mask;
+  }
+
+  inline IP6Range
+  IP6Net::as_range() const
+  {
+    return {this->min(), this->max()};
+  }
+
+  inline bool
+  IP6Net::operator==(self_type const &that) const
+  {
+    return _mask == that._mask && _addr == that._addr;
+  }
+
+  inline bool
+  IP6Net::operator!=(self_type const &that) const
+  {
+    return _mask != that._mask || _addr != that._addr;
+  }
+
+  inline IP6Net::self_type &
+  IP6Net::assign(IP6Addr const &addr, IPMask const &mask)
+  {
+    _addr = addr & mask;
+    _mask = mask;
+    return *this;
+  }
+
+  inline IPNet::IPNet(IPAddr const &addr, IPMask const &mask) : _addr(addr & mask), _mask(mask) {}
+
+  inline IPNet::IPNet(TextView text)
+  {
+    this->load(text);
+  }
+
+  inline bool
+  IPNet::empty() const
+  {
+    return !_mask.is_valid();
+  }
+
+  inline IPAddr
+  IPNet::min() const
+  {
+    return _addr;
+  }
+
+  inline IPAddr
+  IPNet::max() const
+  {
+    return _addr | _mask;
+  }
+
+  inline IPMask::raw_type
+  IPNet::width() const
+  {
+    return _mask.width();
+  }
+
+  inline IPMask const &
+  IPNet::mask() const
+  {
+    return _mask;
+  }
+
+  inline IPRange
+  IPNet::as_range() const
+  {
+    return {this->min(), this->max()};
+  }
+
+  inline IPNet::self_type &
+  IPNet::assign(IPAddr const &addr, IPMask const &mask)
+  {
+    _addr = addr & mask;
+    _mask = mask;
+    return *this;
+  }
+
+  inline bool
+  IPNet::operator==(IPNet::self_type const &that) const
+  {
+    return _mask == that._mask && _addr == that._addr;
+  }
+
+  inline bool
+  IPNet::operator!=(IPNet::self_type const &that) const
+  {
+    return _mask != that._mask || _addr != that._addr;
+  }
+
+  inline bool
+  operator==(IPNet const &lhs, IP4Net const &rhs)
+  {
+    return lhs.is_ip4() && lhs.ip4() == rhs;
+  }
+
+  inline bool
+  operator==(IP4Net const &lhs, IPNet const &rhs)
+  {
+    return rhs.is_ip4() && rhs.ip4() == lhs;
+  }
+
+  inline bool
+  operator==(IPNet const &lhs, IP6Net const &rhs)
+  {
+    return lhs.is_ip6() && lhs.ip6() == rhs;
+  }
+
+  inline bool
+  operator==(IP6Net const &lhs, IPNet const &rhs)
+  {
+    return rhs.is_ip6() && rhs.ip6() == lhs;
+  }
+
+  inline IP4Net
+  IPNet::ip4() const
+  {
+    return IP4Net{_addr.ip4(), _mask};
+  }
+
+  inline IP6Net
+  IPNet::ip6() const
+  {
+    return IP6Net{_addr.ip6(), _mask};
+  }
+
+  inline auto
+  IPNet::clear() -> self_type &
+  {
     _mask.clear();
     return *this;
   }
 
-  /// Equality.
-  bool operator==(self_type const &that) const;
-
-  /// Inequality
-  bool operator!=(self_type const &that) const;
-
-protected:
-  IP6Addr _addr; ///< Network address (also lower_node).
-  IPMask _mask;  ///< Network mask.
-};
-
-/** Representation of an IP address network.
- *
- */
-class IPNet {
-  using self_type = IPNet; ///< Self reference type.
-public:
-  IPNet()                      = default; ///< Construct invalid network.
-  IPNet(self_type const &that) = default; ///< Copy constructor.
-
-  /** Construct from @a addr and @a mask.
-   *
-   * @param addr An address in the network.
-   * @param mask The mask for the network.
-   *
-   * The network is based on the mask, and the resulting network address is chosen such that the
-   * network will contain @a addr. For a given @a addr and @a mask there is only one network
-   * that satisifies these criteria.
-   */
-  IPNet(IPAddr const &addr, IPMask const &mask);
-
-  /** Construct from text.
-   *
-   * @param text Network description.
-   *
-   * The format must be "addr/mask" where "addr" is a valid address and mask is either a single
-   * number for the mask width (CIDR) or a mask in address notation.
-   */
-  IPNet(TextView text);
-
-  /** Parse network as @a text.
-   *
-   * @param text String describing the network in CIDR format.
-   * @return @c true if a valid string, @c false if not.
-   */
-  bool load(swoc::TextView text);
-
-  /// @return @c true if the network contains no addresses (is invalid).
-  bool empty() const;
-
-  /// @return Network address - smallest address in the network.
-  IPAddr min() const;
-
-  /// @return Largest address in the network.
-  IPAddr max() const;
-
-  /// @return The number of bits in the mask.
-  IPMask::raw_type width() const;
-
-  /// @return The mask for the network.
-  IPMask const &mask() const;
-
-  /// @return A range that exactly covers the network.
-  IPRange as_range() const;
-
-  /// @return @c true if network is IPv4.
-  bool is_ip4() const { return _addr.is_ip4(); }
-
-  /// @return @c true if network is IPv6.
-  bool is_ip6() const { return _addr.is_ip6(); }
-
-  /// Address family of network.
-  sa_family_t family() const { return _addr.family(); }
-
-  /// @return The network as explicitly IPv4.
-  IP4Net ip4() const;
-
-  /// @return The network as explicitly IPv6.
-  IP6Net ip6() const;
-
-  /** Assign an @a addr and @a mask to @a this.
-   *
-   * @param addr Network addres.
-   * @param mask Network mask.
-   * @return @a this.
-   */
-  self_type &assign(IPAddr const &addr, IPMask const &mask);
-
-  /// Reset network to invalid state.
-  self_type & clear();
-
-  /// Equality.
-  bool operator==(self_type const &that) const;
-
-  /// Inequality
-  bool operator!=(self_type const &that) const;
-
-protected:
-  IPAddr _addr; ///< Address and family.
-  IPMask _mask; ///< Network mask.
-};
-
-// --------------------------------------------------------------------------
-namespace detail {
-/** Value type for @c IPSpace constant iterator.
- *
- * @tparam PAYLOAD User data type to be stored.
- *
- * @internal Exported because inner classes in template classes cannot be used in partial
- * specialization which is required for tuple support.
- *
- * @internal The value type must be split in two to provide @c const consistency. The structured
- * bidingin types are determined only by the type of the value, therefore if the structured binding
- * should vary in whether the payload binding is @c const then there must be two types. I tested using
- * @c const in the typle type templates but the binding always used the @c const variant regardless of
- * the @const state of the payload instance.
- *
- * @note The @c assign methods are used to update iterators.
- *
- * @see IPSpace
- */
-template < typename PAYLOAD > struct ip_space_const_value_type {
-  using self_type = ip_space_const_value_type;
-
-  IPRangeView _rv; ///< View to the current range.
-  PAYLOAD * _payload = nullptr; ///< Payload for @a _range.
-
-  ip_space_const_value_type() = default;
-
-  /// Reset to default constructed state.
-  self_type & clear();
-
-  /** Update the internal state.
-   *
-   * @param r Range.
-   * @param payload Payload.
-   * @return @a this.
-   */
-  self_type & assign(IP4Range const& r, PAYLOAD & payload);
-
-  /** Update the internal state.
-   *
-   * @param r Range.
-   * @param payload Payload.
-   * @return @a this.
-   */
-  self_type & assign(IP6Range const& r, PAYLOAD & payload);
-
-  /** Update from another instance.
-   *
-   * @param that Other instance.
-   * @return @a this.
-   */
-  self_type & assign(self_type const& that);
-
-  /// Support assignemnt to @c std::tie.
-  std::tuple<IPRangeView, PAYLOAD &> tuple() const { return { _rv, *_payload }; }
-
-  /// Equality against an equivalent tuple.
-  bool operator == (std::tuple<swoc::IPRange, PAYLOAD> const& t) const;
-
-  /// @return The address range.
-  IPRange range() const { return _rv; }
-
-  /// @return The range view.
-  IPRangeView range_view() const { return _rv; }
-
-  /// @return A reference to the payload (user content).
-  PAYLOAD const & payload() const { return *_payload; }
-};
-
-/** Value type for @c IPSpace.
- *
- * @tparam PAYLOAD User data type to be stored.
- *
- * @internal Exported because inner classes in template classes cannot be used in partial
- * specialization which is required for tuple support. This should be removed next API incompatible
- * change release because tuple access is being deprecated.
- *
- * @note The @c assign methods are used to update iterators.
- *
- * @see IPSpace
- */
-template < typename PAYLOAD > struct ip_space_value_type : ip_space_const_value_type<PAYLOAD> {
-  using self_type = ip_space_value_type;
-  using super_type = ip_space_const_value_type<PAYLOAD>;
-
-  /// @return A reference to the payload (user content).
-  PAYLOAD & payload() { return *super_type::_payload; }
-
-};
-
-template <typename PAYLOAD>
-auto
-ip_space_const_value_type<PAYLOAD>::clear() -> self_type & {
-  _rv.clear();
-  _payload = nullptr;
-  return *this;
-}
-
-template <typename PAYLOAD>
-auto
-ip_space_const_value_type<PAYLOAD>::assign(IP4Range const &r, PAYLOAD &payload) -> self_type &{
-  _rv.assign(r);
-  _payload = &payload;
-  return *this;
-}
-
-template <typename PAYLOAD>
-auto
-ip_space_const_value_type<PAYLOAD>::assign(IP6Range const &r, PAYLOAD &payload) -> self_type & {
-  _rv.assign(r);
-  _payload = &payload;
-  return *this;
-}
-
-template <typename PAYLOAD>
-auto
-ip_space_const_value_type<PAYLOAD>::assign(ip_space_const_value_type::self_type const &that) -> self_type & {
-  _rv = that._rv;
-  _payload = that._payload;
-  return *this;
-}
-
-template <typename PAYLOAD>
-bool
-ip_space_const_value_type<PAYLOAD>::operator==(std::tuple<swoc::IPRange, PAYLOAD> const &t) const {
-  return _rv == std::get<0>(t) && std::get<1>(t) == *_payload;
-}
-
-} // namespace detail
-
-/** Coloring of IP address space.
- *
- * @tparam PAYLOAD The color class.
- *
- * This is a class to do fast coloring and lookup of the IP address space. It is range oriented and
- * performs well for ranges, much less well for singletons. Conceptually every IP address is a key
- * in the space and can have a color / payload of type @c PAYLOAD.
- *
- * @c PAYLOAD must have the properties
- *
- * - Cheap to copy.
- * - Comparable via the equality and inequality operators.
- */
-template <typename PAYLOAD> class IPSpace {
-  using self_type = IPSpace;
-  using IP4Space  = DiscreteSpace<IP4Addr, PAYLOAD>;
-  using IP6Space  = DiscreteSpace<IP6Addr, PAYLOAD>;
-
-public:
-  using payload_t  = PAYLOAD; ///< Export payload type.
-  /// Iterator value, a range and payload.
-  using value_type = detail::ip_space_value_type<PAYLOAD>;
-
-  /// Construct an empty space.
-  IPSpace() = default;
-
-  /** Mark the range @a r with @a payload.
-   *
-   * @param range Range to mark.
-   * @param payload Payload to assign.
-   * @return @a this
-   *
-   * All addresses in @a r are set to have the @a payload.
-   */
-  self_type &mark(IPRange const &range, PAYLOAD const &payload);
-
-  /** Fill the @a range with @a payload.
-   *
-   * @param range Destination range.
-   * @param payload Payload for range.
-   * @return this
-   *
-   * Addresses in @a range are set to have @a payload if the address does not already have a payload.
-   */
-  self_type &fill(IPRange const &range, PAYLOAD const &payload);
-
-  /** Erase addresses in @a range.
-   *
-   * @param range Address range.
-   * @return @a this
-   */
-  self_type &erase(IPRange const &range);
-
-  /** Blend @a color in to the @a range.
-   *
-   * @tparam F Blending functor type (deduced).
-   * @tparam U Data to blend in to payloads.
-   * @param range Target range.
-   * @param color Data to blend in to existing payloads in @a range.
-   * @param blender Blending functor.
-   * @return @a this
-   *
-   * @a blender is required to have the signature <tt>void(PAYLOAD& lhs , U CONST&rhs)</tt>. It must
-   * act as a compound assignment operator, blending @a rhs into @a lhs. That is, if the result of
-   * blending @a rhs in to @a lhs is defined as "lhs @ rhs" for the binary operator "@", then @a
-   * blender computes "lhs @= rhs".
-   *
-   * Every address in @a range is assigned a payload. If the address does not already have a color,
-   * it is assigned the default constructed @c PAYLOAD blended with @a color. If the address has a
-   * @c PAYLOAD @a p, @a p is updated by invoking <tt>blender(p, color)</tt>, with the expectation
-   * that @a p will be updated in place.
-   */
-  template <typename F, typename U = PAYLOAD> self_type &blend(IPRange const &range, U const &color, F &&blender);
-
-  template <typename F, typename U = PAYLOAD>
-    self_type & blend(IP4Range const &range, U const &color, F &&blender);
-
-  template <typename F, typename U = PAYLOAD>
-    self_type & blend(IP6Range const &range, U const &color, F &&blender);
-
-  /// @return The number of distinct ranges.
-  size_t count() const;
-
-  /// @return The number of IPv4 ranges.
-  size_t count_ip4() const;
-
-  /// @return The number of IPv6 ranges.
-  size_t count_ip6() const;
-
-  /** Number of rnages for a specific address family.
-   *
-   * @param f Address family.
-   * @return The number of ranges of @a family.
-   */
-  size_t count(sa_family_t f) const;
-
-  /// @return @c true if there are no ranges in the space, @c false otherwise.
-  bool empty() const;
-
-  /// Remove all ranges.
-  void clear();
-
-  /** Constant iterator.
-   * The value type is a tuple of the IP address range and the @a PAYLOAD. Both are constant.
-   *
-   * @internal The non-const iterator is a subclass of this, in order to share implementation. This
-   * also makes it easy to convert from iterator to const iterator, which is desirable.
-   *
-   * @internal The return type is quite tricky because the value type of the nested containers is
-   * not the same as the value type for this container. It's not even a composite - @c IPRange is
-   * not an alias for either of the family specific range types. Therefore the iterator itself must
-   * contain a synthesized instance of the value type, which creates scoping and update problems.
-   * The approach here is to update the synthetic value when the iterator is modified and returning
-   * it by value for the dereference operator because a return by reference means  code like
-   * @code
-   *   auto && [ r , p ] = *(space.find(addr));
-   * @endcode
-   * can fail due to the iterator going out of scope after the statement is finished making @a r
-   * and @a p dangling references. If the return is by value the compiler takes care of it.
-   */
-  class const_iterator {
-    using self_type = const_iterator; ///< Self reference type.
-    friend class IPSpace;
-
-  public:
-    using value_type = detail::ip_space_const_value_type<PAYLOAD>; /// Import for API compliance.
-    // STL algorithm compliance.
-    using iterator_category = std::bidirectional_iterator_tag;
-    using pointer           = value_type const *;
-    using reference         = value_type const &;
-    using difference_type   = int;
-
-    /// Default constructor.
-    const_iterator() = default;
-
-    /// Copy constructor.
-    const_iterator(self_type const &that) = default;
-
-    /// Assignment.
-    self_type &operator=(self_type const &that);
-
-    /// Pre-increment.
-    /// Move to the next element in the list.
-    /// @return The iterator.
-    self_type &operator++();
-
-    /// Pre-decrement.
-    /// Move to the previous element in the list.
-    /// @return The iterator.
-    self_type &operator--();
-
-    /// Post-increment.
-    /// Move to the next element in the list.
-    /// @return The iterator value before the increment.
-    self_type operator++(int);
-
-    /// Post-decrement.
-    /// Move to the previous element in the list.
-    /// @return The iterator value before the decrement.
-    self_type operator--(int);
-
-    /// Dereference.
-    /// @return A reference to the referent.
-    reference operator*() const;
-
-    /// Dereference.
-    /// @return A pointer to the referent.
-    pointer operator->() const;
-
-    /// Equality
-    bool operator==(self_type const &that) const;
-
-    /// Inequality
-    bool operator!=(self_type const &that) const;
-
-  protected:
-    // These are stored non-const to make implementing @c iterator easier. The containing class provides the
-    // required @c const protection. Internally a tuple of iterators is stored for forward iteration. If
-    // the primary (ipv4) iterator is at the end, then use the secondary (ipv6) iterator. The reverse
-    // is done for reverse iteration. This depends on the extra support @c IntrusiveDList iterators
-    // provide.
-    typename IP4Space::iterator _iter_4; ///< IPv4 sub-space iterator.
-    typename IP6Space::iterator _iter_6; ///< IPv6 sub-space iterator.
-    /// Current value.
-    value_type _value;
-
-    /** Internal constructor.
-     *
-     * @param iter4 Starting place for IPv4 subspace.
-     * @param iter6 Starting place for IPv6 subspace.
-     *
-     * In practice, at most one iterator should be "internal", the other should be the beginning or end.
-     */
-    const_iterator(typename IP4Space::const_iterator const &iter4, typename IP6Space::const_iterator const &iter6);
-
-    // These are required because the actual range type for the subspaces is @c DiscreteRange<T>
-    // and returning that type without a cast creates a temporary which causes some nasty side effects.
-
-    /// @return Properly type cast range from iterator.
-    IP4Range const& r4() { return static_cast<IP4Range const&>(_iter_4->range()); }
-    /// @return Properly type cast range from iterator.
-    IP6Range const& r6() { return static_cast<IP6Range const&>(_iter_6->range()); }
-  };
-
-  /** Iterator.
-   * The value type is a tuple of the IP address range and the @a PAYLOAD. The range is constant
-   * and the @a PAYLOAD is a reference. This can be used to update the @a PAYLOAD for this range.
-   *
-   * @note Range merges are not triggered by modifications of the @a PAYLOAD via an iterator.
-   */
-  class iterator : public const_iterator {
-    using self_type  = iterator;
-    using super_type = const_iterator;
-
-    friend class IPSpace;
-
-  protected:
-    using super_type::super_type; /// Inherit supertype constructors.
-    /// Protected constructor to convert const to non-const.
-    /// @note This makes for much less code duplication in iterator relevant methods.
-    iterator(const_iterator const& that) : const_iterator(that) {}
-  public:
-    /// Value type of iteration.
-    using value_type = detail::ip_space_value_type<PAYLOAD>;
-    using pointer    = value_type *;
-    using reference  = value_type &;
-
-    /// Default constructor.
-    iterator() = default;
-
-    /// Copy constructor.
-    iterator(self_type const &that) = default;
-
-    /// Assignment.
-    self_type &operator=(self_type const &that);
-
-    /// Pre-increment.
-    /// Move to the next element in the list.
-    /// @return The iterator.
-    self_type &operator++();
-
-    /// Pre-decrement.
-    /// Move to the previous element in the list.
-    /// @return The iterator.
-    self_type &operator--();
-
-    /// Post-increment.
-    /// Move to the next element in the list.
-    /// @return The iterator value before the increment.
-    self_type operator++(int);
-
-    /// Post-decrement.
-    /// Move to the previous element in the list.
-    /// @return The iterator value before the decrement.
-    self_type operator--(int);
-
-    /// Dereference.
-    /// @return A reference to the referent.
-    reference operator*() const;
-
-    /// Dereference.
-    /// @return A pointer to the referent.
-    pointer operator->() const;
-
-  protected:
-    // Retrieve the value and convert from the super (const) type value to the value for iterator.
-    value_type & value() const;
-  };
-
-  /** Find the payload for an @a addr.
-   *
-   * @param addr Address to find.
-   * @return Iterator for the range containing @a addr.
-   */
-  iterator find(IPAddr const &addr);
-
-  /** Find the payload for an @a addr.
-   *
-   * @param addr Address to find.
-   * @return Iterator for the range containing @a addr.
-   */
-  const_iterator find(IPAddr const &addr) const;
-
-  /** Find the payload for an @a addr.
-   *
-   * @param addr Address to find.
-   * @return An iterator which is valid if @a addr was found, @c end if not.
-   */
-  iterator find(IP4Addr const &addr);
-
-  /** Find the payload for an @a addr.
-   *
-   * @param addr Address to find.
-   * @return An iterator which is valid if @a addr was found, @c end if not.
-   */
-  const_iterator find(IP4Addr const &addr) const;
-
-  /** Find the payload for an @a addr.
-   *
-   * @param addr Address to find.
-   * @return An iterator which is valid if @a addr was found, @c end if not.
-   */
-  iterator find(IP6Addr const &addr);
-
-  /** Find the payload for an @a addr.
-   *
-   * @param addr Address to find.
-   * @return An iterator which is valid if @a addr was found, @c end if not.
-   */
-  const_iterator find(IP6Addr const &addr) const;
-
-  /// @return An iterator to the first element.
-  iterator begin();
-
-  /// @return A constant iterator to the first element.
-  const_iterator begin() const;
-
-  /// @return An iterator past the last element.
-  iterator end();
-
-  /// @return A constant iterator past the last element.
-  const_iterator end() const;
-
-  /// @return Iterator to the first IPv4 address.
-  iterator begin_ip4();
-  /// @return Iterator to the first IPv4 address.
-  const_iterator begin_ip4() const;
-
-  /// @return Iterator past the last IPv4 address.
-  iterator end_ip4();
-  /// @return Iterator past the last IPv4 address.
-  const_iterator end_ip4() const;
-
-  /// @return Iterator at the first IPv6 address.
-  iterator begin_ip6();
-  /// @return Iterator at the first IPv6 address.
-  const_iterator begin_ip6() const;
-  /// @return Iterator past the last IPv6 address.
-  iterator end_ip6();
-  /// @return Iterator past the last IPv6 address.
-  const_iterator end_ip6() const;
-
-  /// @return Iterator to the first address of @a family.
-  const_iterator begin(sa_family_t family) const;
-
-  /// @return Iterator past the last address of @a family.
-  const_iterator end(sa_family_t family) const;
-
-  /** Sequnce of ranges that intersect @a r.
-   *
-   * @param r Search range.
-   * @return Iterator pair covering ranges that intersect @a r.
-   */
-  std::pair<iterator, iterator> intersection(IP4Range const& r) {
-    auto && [ begin, end ] = _ip4.intersection(r);
-    return { this->iterator_at(begin), this->iterator_at(end) };
+  // +++ Range -> Network classes +++
+
+  inline bool
+  IP4Range::NetSource::is_valid(swoc::IP4Addr mask) const
+  {
+    return ((mask._addr & _range._min._addr) == _range._min._addr) && ((_range._min._addr | ~mask._addr) <= _range._max._addr);
   }
 
-  /** Sequnce of ranges that intersect @a r.
-   *
-   * @param r Search range.
-   * @return Iterator pair covering ranges that intersect @a r.
-   */
-  std::pair<iterator, iterator> intersection(IP6Range const& r) {
-    auto && [ begin, end ] = _ip6.intersection(r);
-    return { this->iterator_at(begin), this->iterator_at(end) };
+  inline IP4Net
+  IP4Range::NetSource::operator*() const
+  {
+    return IP4Net{_range.min(), IPMask{_cidr}};
   }
 
-  /** Sequnce of ranges that intersect @a r.
-   *
-   * @param r Search range.
-   * @return Iterator pair covering ranges that intersect @a r.
-   */
-  std::pair<iterator, iterator> intersection(IPRange const& r) {
-    if (r.is_ip4()) {
-      return this->intersection(r.ip4());
-    } else if (r.is_ip6()) {
-      return this->intersection(r.ip6());
-    }
-    return { this->end(), this->end() };
-  }
-
-protected:
-  IP4Space _ip4; ///< Sub-space containing IPv4 ranges.
-  IP6Space _ip6; ///< sub-space containing IPv6 ranges.
-
-  iterator iterator_at(typename IP4Space::const_iterator const& spot) {
-    return iterator(spot, _ip6.begin());
-  }
-  iterator iterator_at(typename IP6Space::const_iterator const& spot) {
-    return iterator(_ip4.end(), spot);
-  }
-
-  friend class IPRangeSet;
-};
-
-/** An IPSpace that contains only addresses.
- *
- * This is to @c IPSpace as @c std::set is to @c std::map. The @c value_type is removed from the API
- * and only the keys are visible. This suits use cases where the goal is to track the presence of
- * addresses without any additional data.
- *
- * @note Because there is only one value stored, there is no difference between @c mark and @c fill.
- */
-class IPRangeSet
-{
-  using self_type = IPRangeSet;
-
-  /// Empty struct to use for payload.
-  /// This declares the struct and defines the singleton instance used.
-  /// @internal For some reason @c std::monostate didn't work, but I don't remember why.
-  static inline constexpr struct Mark {
-    using self_type = Mark;
-    /// @internal @c IPSpace requires equality / inequality operators.
-    /// These make all instance equal to each other.
-    bool operator==(self_type const &that);
-    bool operator!=(self_type const &that);
-  } MARK{};
-
-  /// Range set type.
-  using Space = swoc::IPSpace<Mark>;
-
-public:
-  /// Default construct empty set.
-  IPRangeSet() = default;
-
-  /** Add addresses to the set.
-   *
-   * @param r Range of addresses to add.
-   * @return @a this
-   *
-   * Identical to @c fill.
-   */
-  self_type &mark(swoc::IPRange const &r);
-
-  /** Add addresses to the set.
-   *
-   * @param r Range of addresses to add.
-   * @return @a this
-   *
-   * Identical to @c mark.
-   */
-  self_type &fill(swoc::IPRange const &r);
-
-  /// @return @c true if @a addr is in the set.
-  bool contains(swoc::IPAddr const &addr) const;
-
-  /// @return Number of ranges in the set.
-  size_t count() const;
-
-  bool empty() const;
-
-  /// Remove all addresses in the set.
-  void clear();
-
-  /// Bidirectional constant iterator for iteration over ranges.
-  class const_iterator {
-    using self_type = const_iterator; ///< Self reference type.
-    using super_type = Space::const_iterator;
-    friend class IPRangeSet;
-
-  public:
-    using value_type = IPRangeView;
-    // STL algorithm compliance.
-    using iterator_category = std::bidirectional_iterator_tag;
-    using pointer           = value_type const *;
-    using reference         = value_type const &;
-    using difference_type   = int;
-
-    /// Default constructor.
-    const_iterator() = default;
-
-    /// Copy constructor.
-    const_iterator(self_type const &that) = default;
-
-    /// Assignment.
-    self_type &operator=(self_type const &that) = default;
-
-    /// Pre-increment.
-    /// Move to the next element in the list.
-    /// @return The iterator.
-    self_type &operator++();
-
-    /// Pre-decrement.
-    /// Move to the previous element in the list.
-    /// @return The iterator.
-    self_type &operator--();
-
-    /// Post-increment.
-    /// Move to the next element in the list.
-    /// @return The iterator value before the increment.
-    self_type operator++(int);
-
-    /// Post-decrement.
-    /// Move to the previous element in the list.
-    /// @return The iterator value before the decrement.
-    self_type operator--(int);
-
-    /// Dereference.
-    /// @return A reference to the referent.
-    reference operator*() const;
-
-    /// Dereference.
-    /// @return A pointer to the referent.
-    pointer operator->() const;
-
-    /// Equality
-    bool operator==(self_type const &that) const;
-
-    /// Inequality
-    bool operator!=(self_type const &that) const;
-
-  protected:
-    const_iterator(super_type const& spot) : _iter(spot) {}
-
-    super_type _iter; ///< Underlying iterator.
-    IPRange _r; ///< Some less temporary storage for dereferences.
-  };
-
-  using iterator = const_iterator;
-
-  /// @return Iterator to first range.
-  const_iterator begin() const { return _addrs.begin(); }
-  /// @return Iterator past last range.
-  const_iterator end() const { return _addrs.end(); }
-
-protected:
-  /// The address set.
-  Space _addrs;
-};
-
-inline auto
-IPRangeSet::mark(swoc::IPRange const &r) -> self_type &
-{
-  _addrs.mark(r, MARK);
-  return *this;
-}
-
-inline auto
-IPRangeSet::fill(swoc::IPRange const &r) -> self_type &
-{
-  _addrs.mark(r, MARK);
-  return *this;
-}
-
-inline bool
-IPRangeSet::contains(swoc::IPAddr const &addr) const
-{
-  return _addrs.find(addr) != _addrs.end();
-}
-
-inline size_t
-IPRangeSet::count() const
-{
-  return _addrs.count();
-}
-
-inline bool
-IPRangeSet::empty() const {
-  return _addrs.empty();
-}
-
-inline void
-IPRangeSet::clear()
-{
-  _addrs.clear();
-}
-
-inline bool
-IPRangeSet::Mark::operator==(IPRangeSet::Mark::self_type const &)
-{
-  return true;
-}
-
-inline bool
-IPRangeSet::Mark::operator!=(IPRangeSet::Mark::self_type const &)
-{
-  return false;
-}
-
-template <typename PAYLOAD>
-IPSpace<PAYLOAD>::const_iterator::const_iterator(typename IP4Space::const_iterator const &iter4, typename IP6Space::const_iterator const &iter6)
-: _iter_4(static_cast<typename IP4Space::iterator const&>(iter4)), _iter_6(static_cast<typename IP6Space::iterator const&>(iter6)) {
-  if (_iter_4.has_next()) {
-    _value.assign(this->r4(), _iter_4->payload());
-  } else if (_iter_6.has_next()) {
-    _value.assign(this->r6(), _iter_6->payload());
-  }
-}
-
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::const_iterator::operator=(self_type const &that) -> self_type & {
-  _iter_4 = that._iter_4;
-  _iter_6 = that._iter_6;
-  _value.assign(that._value);
-  return *this;
-}
-
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::const_iterator::operator++() -> self_type & {
-  bool incr_p = false;
-  if (_iter_4.has_next()) {
-    ++_iter_4;
-    incr_p = true;
-    if (_iter_4.has_next()) {
-      _value.assign(this->r4(), _iter_4->payload());
-      return *this;
-    }
-  }
-
-  if (_iter_6.has_next()) {
-    if (incr_p || (++_iter_6).has_next()) {
-      _value.assign(this->r6(), _iter_6->payload());
-      return *this;
-    }
-  }
-  _value.clear();
-  return *this;
-}
-
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::const_iterator::operator++(int) -> self_type {
-  self_type zret(*this);
-  ++*this;
-  return zret;
-}
-
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::const_iterator::operator--() -> self_type & {
-  if (_iter_6.has_prev()) {
-    --_iter_6;
-    _value.assign(this->r6(), _iter_6->payload());
+  inline IP4Range::NetSource::iterator
+  IP4Range::NetSource::begin() const
+  {
     return *this;
   }
-  if (_iter_4.has_prev()) {
-    --_iter_4;
-    _value.assign(this->r4(), _iter_4->payload());
+
+  inline IP4Range::NetSource::iterator
+  IP4Range::NetSource::end()
+  {
+    return self_type{range_type{}};
+  }
+
+  inline bool
+  IP4Range::NetSource::empty() const
+  {
+    return _range.empty();
+  }
+
+  inline IPMask
+  IP4Range::NetSource::mask() const
+  {
+    return IPMask{_cidr};
+  }
+
+  inline auto
+  IP4Range::NetSource::operator->() -> self_type *
+  {
+    return this;
+  }
+
+  inline IP4Addr const &
+  IP4Range::NetSource::addr() const
+  {
+    return _range.min();
+  }
+
+  inline bool
+  IP4Range::NetSource::operator==(IP4Range::NetSource::self_type const &that) const
+  {
+    return ((_cidr == that._cidr) && (_range == that._range)) || (_range.empty() && that._range.empty());
+  }
+
+  inline bool
+  IP4Range::NetSource::operator!=(IP4Range::NetSource::self_type const &that) const
+  {
+    return !(*this == that);
+  }
+
+  inline auto
+  IP6Range::NetSource::begin() const -> iterator
+  {
     return *this;
   }
-  _value.clear();
-  return *this;
-}
 
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::const_iterator::operator--(int) -> self_type {
-  self_type zret(*this);
-  --*this;
-  return zret;
-}
-
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::const_iterator::operator*() const -> reference {
-  return _value;
-}
-
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::const_iterator::operator->() const -> pointer {
-  return &_value;
-}
-
-/* Bit of subtlety with equality - although it seems that if @a _iter_4 is valid, it doesn't matter
- * where @a _iter6 is (because it is really the iterator location that's being checked), it's
- * necessary to do the @a _iter_4 validity on both iterators to avoid the case of a false positive
- * where different internal iterators are valid. However, in practice the other (non-active)
- * iterator won't have an arbitrary value, it will be either @c begin or @c end in step with the
- * active iterator therefore it's effective and cheaper to just check both values.
- */
-
-template <typename PAYLOAD>
-bool
-IPSpace<PAYLOAD>::const_iterator::operator==(self_type const &that) const {
-  return _iter_4 == that._iter_4 && _iter_6 == that._iter_6;
-}
-
-template <typename PAYLOAD>
-bool
-IPSpace<PAYLOAD>::const_iterator::operator!=(self_type const &that) const {
-  return _iter_4 != that._iter_4 || _iter_6 != that._iter_6;
-}
-
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::iterator::operator=(self_type const &that) -> self_type & {
-  this->super_type::operator=(that);
-  return *this;
-}
-
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::iterator::value() const -> value_type & {
-  return reinterpret_cast<value_type&>(const_cast<self_type*>(this)->_value);
-}
-
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::iterator::operator->() const -> pointer {
-  return &(this->value());
-}
-
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::iterator::operator*() const -> reference {
-  return this->value();
-}
-
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::iterator::operator++() -> self_type & {
-  this->super_type::operator++();
-  return *this;
-}
-
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::iterator::operator++(int) -> self_type {
-  self_type zret{*this};
-  ++*this;
-  return zret;
-}
-
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::iterator::operator--() -> self_type & {
-  this->super_type::operator--();
-  return *this;
-}
-
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::iterator::operator--(int) -> self_type {
-  self_type zret{*this};
-  --*this;
-  return zret;
-}
-
-/// ------------------------------------------------------------------------------------
-
-// +++ IPRange +++
-
-inline IP4Range::IP4Range(string_view const &text) {
-  this->load(text);
-}
-
-inline auto
-IP4Range::networks() const -> NetSource {
-  return {NetSource{*this}};
-}
-
-inline IP6Range::IP6Range(string_view const &text) {
-  this->load(text);
-}
-
-inline auto
-IP6Range::networks() const -> NetSource {
-  return {NetSource{*this}};
-}
-
-inline IPRange::IPRange(IP4Range const &range) : _family(AF_INET) {
-  _range._ip4 = range;
-}
-
-inline IPRange::IPRange(IP6Range const &range) : _family(AF_INET6) {
-  _range._ip6 = range;
-}
-
-inline IPRange::IPRange(IP4Addr const &min, IP4Addr const &max) {
-  this->assign(min, max);
-}
-
-inline IPRange::IPRange(IP6Addr const &min, IP6Addr const &max) {
-  this->assign(min, max);
-}
-
-inline IPRange::IPRange(string_view const &text) {
-  this->load(text);
-}
-
-inline IPRange::IPRange(IPRangeView const& view) {
-  if (AF_INET == view._family) {
-    *this = *view._raw._4;
-  } else if (AF_INET6 == view._family) {
-    *this = *view._raw._6;
+  inline auto
+  IP6Range::NetSource::end() const -> iterator
+  {
+    return self_type{range_type{}};
   }
-}
 
-inline auto
-IPRange::assign(IP4Addr const &min, IP4Addr const &max) -> self_type & {
-  _range._ip4.assign(min, max);
-  _family = AF_INET;
-  return *this;
-}
-
-inline auto
-IPRange::assign(IP6Addr const &min, IP6Addr const &max) -> self_type & {
-  _range._ip6.assign(min, max);
-  _family = AF_INET6;
-  return *this;
-}
-
-inline auto
-IPRange::operator=(const IPRangeView &rv) -> self_type & {
-  if (AF_INET == rv._family) {
-    *this = *rv._raw._4;
-  } else if (AF_INET6 == rv._family) {
-    *this = *rv._raw._6;
+  inline bool
+  IP6Range::NetSource::empty() const
+  {
+    return _range.empty();
   }
-  return *this;
-}
 
-inline auto
-IPRange::clear() -> self_type & {
-  _family = AF_UNSPEC;
-  return *this;
-}
-
-inline auto
-IPRange::networks() const -> NetSource {
-  return {NetSource{*this}};
-}
-
-inline bool
-IPRange::is(sa_family_t family) const {
-  return family == _family;
-}
-
-inline bool
-IPRange::operator!=(const self_type &that) const {
-  return ! (*this == that);
-}
-
-inline bool
-IPRange::is_ip4() const {
-  return AF_INET == _family;
-}
-
-inline bool IPRange::is_ip6() const {
-  return AF_INET6 == _family;
-}
-
-inline auto
-IPRangeView::clear() -> self_type & {
-  _family = AF_UNSPEC;
-  return *this;
-}
-
-inline bool
-IPRangeView::empty() const {
-  return AF_INET6 == _family ? _raw._6->empty()
-         : AF_INET == _family ? _raw._4->empty()
-                               : true;
-}
-
-inline bool IPRangeView::is_ip4() const { return AF_INET == _family; }
-
-inline bool IPRangeView::is_ip6() const { return AF_INET6 == _family; }
-
-inline bool IPRangeView::is(sa_family_t f) const { return f == _family; }
-
-inline IP4Range const & IPRangeView::ip4() const { return *_raw._4; }
-
-inline IP6Range const & IPRangeView::ip6() const { return *_raw._6; }
-
-inline bool
-IPRangeView::valid() const { return AF_INET == _family || AF_INET6 == _family; }
-
-inline auto
-IPRangeView::assign(IP4Range const &r) -> self_type & {
-  _family = r.family();
-  _raw._4 = &r;
-  return *this;
-}
-
-inline auto
-IPRangeView::assign(IP6Range const &r) -> self_type & {
-  _family = r.family();
-  _raw._6 = &r;
-  return *this;
-}
-
-inline bool
-IPRangeView::operator!=(IPRangeView::self_type const &that) const {
-  return ! (*this == that);
-}
-
-inline IPAddr
-IPRangeView::min() const {
-  return AF_INET == _family ? _raw._4->min() : AF_INET6 == _family ? _raw._6->min() : IPAddr::INVALID;
-}
-
-inline IPAddr
-IPRangeView::max() const {
-  return AF_INET == _family ? _raw._4->max() : AF_INET6 == _family ? _raw._6->max() : IPAddr::INVALID;
-}
-
-// +++ IPNet +++
-
-inline IP4Net::IP4Net(swoc::IP4Addr addr, swoc::IPMask mask) : _addr(addr & mask), _mask(mask) {}
-
-inline IPMask const &
-IP4Net::mask() const {
-  return _mask;
-}
-
-inline bool
-IP4Net::empty() const {
-  return ! _mask.is_valid();
-}
-
-inline IP4Addr
-IP4Net::min() const {
-  return _addr;
-}
-
-inline IP4Addr
-IP4Net::max() const {
-  return _addr | _mask;
-}
-
-inline IP4Range
-IP4Net::as_range() const {
-  return {this->min(), this->max()};
-}
-
-inline bool
-IP4Net::operator==(self_type const &that) const {
-  return _mask == that._mask && _addr == that._addr;
-}
-
-inline bool
-IP4Net::operator!=(self_type const &that) const {
-  return _mask != that._mask || _addr != that._addr;
-}
-
-inline IP4Net::self_type &
-IP4Net::assign(IP4Addr const &addr, IPMask const &mask) {
-  _addr = addr & mask;
-  _mask = mask;
-  return *this;
-}
-
-inline IP6Net::IP6Net(swoc::IP6Addr addr, swoc::IPMask mask) : _addr(addr & mask), _mask(mask) {}
-
-inline IPMask const &
-IP6Net::mask() const {
-  return _mask;
-}
-
-inline bool
-IP6Net::empty() const {
-  return ! _mask.is_valid();
-}
-
-inline IP6Addr
-IP6Net::min() const {
-  return _addr;
-}
-
-inline IP6Addr
-IP6Net::max() const {
-  return _addr | _mask;
-}
-
-inline IP6Range
-IP6Net::as_range() const {
-  return {this->min(), this->max()};
-}
-
-inline bool
-IP6Net::operator==(self_type const &that) const {
-  return _mask == that._mask && _addr == that._addr;
-}
-
-inline bool
-IP6Net::operator!=(self_type const &that) const {
-  return _mask != that._mask || _addr != that._addr;
-}
-
-inline IP6Net::self_type &
-IP6Net::assign(IP6Addr const &addr, IPMask const &mask) {
-  _addr = addr & mask;
-  _mask = mask;
-  return *this;
-}
-
-inline IPNet::IPNet(IPAddr const &addr, IPMask const &mask) : _addr(addr & mask), _mask(mask) {}
-
-inline IPNet::IPNet(TextView text) {
-  this->load(text);
-}
-
-inline bool
-IPNet::empty() const {
-  return ! _mask.is_valid();
-}
-
-inline IPAddr
-IPNet::min() const {
-  return _addr;
-}
-
-inline IPAddr
-IPNet::max() const {
-  return _addr | _mask;
-}
-
-inline IPMask::raw_type
-IPNet::width() const {
-  return _mask.width();
-}
-
-inline IPMask const &
-IPNet::mask() const {
-  return _mask;
-}
-
-inline IPRange
-IPNet::as_range() const {
-  return {this->min(), this->max()};
-}
-
-inline IPNet::self_type &
-IPNet::assign(IPAddr const &addr, IPMask const &mask) {
-  _addr = addr & mask;
-  _mask = mask;
-  return *this;
-}
-
-inline bool
-IPNet::operator==(IPNet::self_type const &that) const {
-  return _mask == that._mask && _addr == that._addr;
-}
-
-inline bool
-IPNet::operator!=(IPNet::self_type const &that) const {
-  return _mask != that._mask || _addr != that._addr;
-}
-
-inline bool
-operator==(IPNet const &lhs, IP4Net const &rhs) {
-  return lhs.is_ip4() && lhs.ip4() == rhs;
-}
-
-inline bool
-operator==(IP4Net const &lhs, IPNet const &rhs) {
-  return rhs.is_ip4() && rhs.ip4() == lhs;
-}
-
-inline bool
-operator==(IPNet const &lhs, IP6Net const &rhs) {
-  return lhs.is_ip6() && lhs.ip6() == rhs;
-}
-
-inline bool
-operator==(IP6Net const &lhs, IPNet const &rhs) {
-  return rhs.is_ip6() && rhs.ip6() == lhs;
-}
-
-inline IP4Net
-IPNet::ip4() const {
-  return IP4Net{_addr.ip4(), _mask};
-}
-
-inline IP6Net
-IPNet::ip6() const {
-  return IP6Net{_addr.ip6(), _mask};
-}
-
-inline auto
-IPNet::clear() -> self_type & {
-  _mask.clear();
-  return *this;
-}
-
-// +++ Range -> Network classes +++
-
-inline bool
-IP4Range::NetSource::is_valid(swoc::IP4Addr mask) const {
-  return ((mask._addr & _range._min._addr) == _range._min._addr) && ((_range._min._addr | ~mask._addr) <= _range._max._addr);
-}
-
-inline IP4Net
-IP4Range::NetSource::operator*() const {
-  return IP4Net{_range.min(), IPMask{_cidr}};
-}
-
-inline IP4Range::NetSource::iterator
-IP4Range::NetSource::begin() const {
-  return *this;
-}
-
-inline IP4Range::NetSource::iterator
-IP4Range::NetSource::end() {
-  return self_type{range_type{}};
-}
-
-inline bool
-IP4Range::NetSource::empty() const {
-  return _range.empty();
-}
-
-inline IPMask
-IP4Range::NetSource::mask() const {
-  return IPMask{_cidr};
-}
-
-inline auto
-IP4Range::NetSource::operator->() -> self_type * {
-  return this;
-}
-
-inline IP4Addr const &
-IP4Range::NetSource::addr() const {
-  return _range.min();
-}
-
-inline bool
-IP4Range::NetSource::operator==(IP4Range::NetSource::self_type const &that) const {
-  return ((_cidr == that._cidr) && (_range == that._range)) || (_range.empty() && that._range.empty());
-}
-
-inline bool
-IP4Range::NetSource::operator!=(IP4Range::NetSource::self_type const &that) const {
-  return !(*this == that);
-}
-
-inline auto
-IP6Range::NetSource::begin() const -> iterator {
-  return *this;
-}
-
-inline auto
-IP6Range::NetSource::end() const -> iterator {
-  return self_type{range_type{}};
-}
-
-inline bool
-IP6Range::NetSource::empty() const {
-  return _range.empty();
-}
-
-inline IP6Net
-IP6Range::NetSource::operator*() const {
-  return IP6Net{_range.min(), _mask};
-}
-
-inline auto
-IP6Range::NetSource::operator->() -> self_type * {
-  return this;
-}
-
-inline bool
-IP6Range::NetSource::is_valid(IPMask const &mask) {
-  return ((_range.min() & mask) == _range.min()) && ((_range.min() | mask) <= _range.max());
-}
-
-inline bool
-IP6Range::NetSource::operator==(IP6Range::NetSource::self_type const &that) const {
-  return ((_mask == that._mask) && (_range == that._range)) || (_range.empty() && that._range.empty());
-}
-
-inline bool
-IP6Range::NetSource::operator!=(IP6Range::NetSource::self_type const &that) const {
-  return !(*this == that);
-}
-
-inline IP6Addr const &
-IP6Range::NetSource::addr() const {
-  return _range.min();
-}
-
-inline IPMask
-IP6Range::NetSource::mask() const {
-  return _mask;
-}
-
-inline IPRange::NetSource::NetSource(IPRange::NetSource::range_type const &range) {
-  if (range.is_ip4()) {
-    new (&_ip4) decltype(_ip4)(range.ip4());
-    _family = AF_INET;
-  } else if (range.is_ip6()) {
-    new (&_ip6) decltype(_ip6)(range.ip6());
-    _family = AF_INET6;
+  inline IP6Net
+  IP6Range::NetSource::operator*() const
+  {
+    return IP6Net{_range.min(), _mask};
   }
-}
 
-inline IPRange::NetSource::NetSource(IPRangeView const &rv) {
-  if (rv.is_ip4()) {
-    new (&_ip4) decltype(_ip4)(rv.ip4());
-    _family = AF_INET;
-  } else if (rv.is_ip6()) {
-    new (&_ip6) decltype(_ip6)(rv.ip6());
-    _family = AF_INET6;
+  inline auto
+  IP6Range::NetSource::operator->() -> self_type *
+  {
+    return this;
   }
-}
 
-inline auto
-IPRange::NetSource::begin() const -> iterator {
-  return *this;
-}
-
-inline auto
-IPRange::NetSource::end() const -> iterator {
-  return AF_INET == _family ? self_type{IP4Range{}} : AF_INET6 == _family ? self_type{IP6Range{}} : self_type{IPRange{}};
-}
-
-inline IPAddr
-IPRange::NetSource::addr() const {
-  if (AF_INET == _family) {
-    return _ip4.addr();
-  } else if (AF_INET6 == _family) {
-    return _ip6.addr();
+  inline bool
+  IP6Range::NetSource::is_valid(IPMask const &mask)
+  {
+    return ((_range.min() & mask) == _range.min()) && ((_range.min() | mask) <= _range.max());
   }
-  return {};
-}
 
-inline IPMask
-IPRange::NetSource::mask() const {
-  if (AF_INET == _family) {
-    return _ip4.mask();
-  } else if (AF_INET6 == _family) {
-    return _ip6.mask();
+  inline bool
+  IP6Range::NetSource::operator==(IP6Range::NetSource::self_type const &that) const
+  {
+    return ((_mask == that._mask) && (_range == that._range)) || (_range.empty() && that._range.empty());
   }
-  return {};
-}
 
-inline IPNet
-IPRange::NetSource::operator*() const {
-  return {this->addr(), this->mask()};
-}
-
-inline auto
-IPRange::NetSource::operator++() -> self_type & {
-  if (AF_INET == _family) {
-    ++_ip4;
-  } else if (AF_INET6 == _family) {
-    ++_ip6;
+  inline bool
+  IP6Range::NetSource::operator!=(IP6Range::NetSource::self_type const &that) const
+  {
+    return !(*this == that);
   }
-  return *this;
-}
 
-inline auto
-IPRange::NetSource::operator->() -> self_type * {
-  return this;
-}
+  inline IP6Addr const &
+  IP6Range::NetSource::addr() const
+  {
+    return _range.min();
+  }
 
-inline bool
-IPRange::NetSource::operator==(self_type const &that) const {
-  if (_family != that._family) {
+  inline IPMask
+  IP6Range::NetSource::mask() const
+  {
+    return _mask;
+  }
+
+  inline IPRange::NetSource::NetSource(IPRange::NetSource::range_type const &range)
+  {
+    if (range.is_ip4()) {
+      new (&_ip4) decltype(_ip4)(range.ip4());
+      _family = AF_INET;
+    } else if (range.is_ip6()) {
+      new (&_ip6) decltype(_ip6)(range.ip6());
+      _family = AF_INET6;
+    }
+  }
+
+  inline IPRange::NetSource::NetSource(IPRangeView const &rv)
+  {
+    if (rv.is_ip4()) {
+      new (&_ip4) decltype(_ip4)(rv.ip4());
+      _family = AF_INET;
+    } else if (rv.is_ip6()) {
+      new (&_ip6) decltype(_ip6)(rv.ip6());
+      _family = AF_INET6;
+    }
+  }
+
+  inline auto
+  IPRange::NetSource::begin() const -> iterator
+  {
+    return *this;
+  }
+
+  inline auto
+  IPRange::NetSource::end() const -> iterator
+  {
+    return AF_INET == _family ? self_type{IP4Range{}} : AF_INET6 == _family ? self_type{IP6Range{}} : self_type{IPRange{}};
+  }
+
+  inline IPAddr
+  IPRange::NetSource::addr() const
+  {
+    if (AF_INET == _family) {
+      return _ip4.addr();
+    } else if (AF_INET6 == _family) {
+      return _ip6.addr();
+    }
+    return {};
+  }
+
+  inline IPMask
+  IPRange::NetSource::mask() const
+  {
+    if (AF_INET == _family) {
+      return _ip4.mask();
+    } else if (AF_INET6 == _family) {
+      return _ip6.mask();
+    }
+    return {};
+  }
+
+  inline IPNet
+  IPRange::NetSource::operator*() const
+  {
+    return {this->addr(), this->mask()};
+  }
+
+  inline auto
+  IPRange::NetSource::operator++() -> self_type &
+  {
+    if (AF_INET == _family) {
+      ++_ip4;
+    } else if (AF_INET6 == _family) {
+      ++_ip6;
+    }
+    return *this;
+  }
+
+  inline auto
+  IPRange::NetSource::operator->() -> self_type *
+  {
+    return this;
+  }
+
+  inline bool
+  IPRange::NetSource::operator==(self_type const &that) const
+  {
+    if (_family != that._family) {
+      return false;
+    }
+    if (AF_INET == _family) {
+      return _ip4 == that._ip4;
+    } else if (AF_INET6 == _family) {
+      return _ip6 == that._ip6;
+    } else if (AF_UNSPEC == _family) {
+      return true;
+    }
     return false;
   }
-  if (AF_INET == _family) {
-    return _ip4 == that._ip4;
-  } else if (AF_INET6 == _family) {
-    return _ip6 == that._ip6;
-  } else if (AF_UNSPEC == _family) {
-    return true;
+
+  inline bool
+  IPRange::NetSource::operator!=(self_type const &that) const
+  {
+    return !(*this == that);
   }
-  return false;
-}
 
-inline bool
-IPRange::NetSource::operator!=(self_type const &that) const {
-  return !(*this == that);
-}
+  // --- IPSpace
 
-// --- IPSpace
-
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::mark(IPRange const &range, PAYLOAD const &payload) -> self_type & {
-  if (range.is(AF_INET)) {
-    _ip4.mark(range.ip4(), payload);
-  } else if (range.is(AF_INET6)) {
-    _ip6.mark(range.ip6(), payload);
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::mark(IPRange const &range, PAYLOAD const &payload) -> self_type &
+  {
+    if (range.is(AF_INET)) {
+      _ip4.mark(range.ip4(), payload);
+    } else if (range.is(AF_INET6)) {
+      _ip6.mark(range.ip6(), payload);
+    }
+    return *this;
   }
-  return *this;
-}
 
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::fill(IPRange const &range, PAYLOAD const &payload) -> self_type & {
-  if (range.is(AF_INET6)) {
-    _ip6.fill(range.ip6(), payload);
-  } else if (range.is(AF_INET)) {
-    _ip4.fill(range.ip4(), payload);
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::fill(IPRange const &range, PAYLOAD const &payload) -> self_type &
+  {
+    if (range.is(AF_INET6)) {
+      _ip6.fill(range.ip6(), payload);
+    } else if (range.is(AF_INET)) {
+      _ip4.fill(range.ip4(), payload);
+    }
+    return *this;
   }
-  return *this;
-}
 
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::erase(IPRange const &range) -> self_type & {
-  if (range.is(AF_INET)) {
-    _ip4.erase(range.ip4());
-  } else if (range.is(AF_INET6)) {
-    _ip6.erase(range.ip6());
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::erase(IPRange const &range) -> self_type &
+  {
+    if (range.is(AF_INET)) {
+      _ip4.erase(range.ip4());
+    } else if (range.is(AF_INET6)) {
+      _ip6.erase(range.ip6());
+    }
+    return *this;
   }
-  return *this;
-}
 
-template <typename PAYLOAD>
-template <typename F, typename U>
-auto
-IPSpace<PAYLOAD>::blend(IPRange const &range, U const &color, F &&blender) -> self_type & {
-  if (range.is(AF_INET)) {
-    _ip4.blend(range.ip4(), color, blender);
-  } else if (range.is(AF_INET6)) {
-    _ip6.blend(range.ip6(), color, blender);
+  template <typename PAYLOAD>
+  template <typename F, typename U>
+  auto
+  IPSpace<PAYLOAD>::blend(IPRange const &range, U const &color, F &&blender) -> self_type &
+  {
+    if (range.is(AF_INET)) {
+      _ip4.blend(range.ip4(), color, blender);
+    } else if (range.is(AF_INET6)) {
+      _ip6.blend(range.ip6(), color, blender);
+    }
+    return *this;
   }
-  return *this;
-}
 
-template <typename PAYLOAD>
-template <typename F, typename U>
-auto
-IPSpace<PAYLOAD>::blend(IP4Range const &range, U const &color, F &&blender) -> self_type & {
-  _ip4.blend(range, color, std::forward<F>(blender));
-  return *this;
-}
-
-template <typename PAYLOAD>
-template <typename F, typename U>
-auto
-IPSpace<PAYLOAD>::blend(IP6Range const &range, U const &color, F &&blender) -> self_type & {
-  _ip6.blend(range, color, std::forward<F>(blender));
-  return *this;
-}
-
-template <typename PAYLOAD>
-void
-IPSpace<PAYLOAD>::clear() {
-  _ip4.clear();
-  _ip6.clear();
-}
-
-template <typename PAYLOAD>
-auto IPSpace<PAYLOAD>::begin() -> iterator { return iterator{_ip4.begin(), _ip6.begin()}; }
-
-template <typename PAYLOAD>
-auto IPSpace<PAYLOAD>::begin() const -> const_iterator { return const_cast<self_type *>(this)->begin(); }
-
-template <typename PAYLOAD>
-auto IPSpace<PAYLOAD>::end() -> iterator { return iterator{_ip4.end(), _ip6.end()}; }
-
-template <typename PAYLOAD>
-auto IPSpace<PAYLOAD>::end() const -> const_iterator { return const_cast<self_type *>(this)->end(); }
-
-template <typename PAYLOAD>
-auto IPSpace<PAYLOAD>::begin_ip4() -> iterator { return this->begin(); }
-
-template <typename PAYLOAD>
-auto IPSpace<PAYLOAD>::begin_ip4() const -> const_iterator { return this->begin(); }
-
-template <typename PAYLOAD>
-auto IPSpace<PAYLOAD>::end_ip4() -> iterator { return { _ip4.end(), _ip6.begin() }; }
-
-template <typename PAYLOAD>
-auto IPSpace<PAYLOAD>::end_ip4() const -> const_iterator { return const_cast<self_type*>(this)->end_ip4(); }
-
-template <typename PAYLOAD>
-auto IPSpace<PAYLOAD>::begin_ip6() -> iterator {
-  return { _ip4.end(), _ip6.begin() };
-}
-
-template <typename PAYLOAD>
-auto IPSpace<PAYLOAD>::begin_ip6() const -> const_iterator {
-  return const_cast<self_type*>(this)->begin_ip6();
-}
-
-template <typename PAYLOAD>
-auto IPSpace<PAYLOAD>::end_ip6() -> iterator { return this->end(); }
-
-template <typename PAYLOAD>
-auto IPSpace<PAYLOAD>::end_ip6() const -> const_iterator { return this->end(); }
-
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::find(IPAddr const &addr) -> iterator {
-  if (addr.is_ip4()) {
-    return this->find(addr.ip4());
-  } else if (addr.is_ip6()) {
-    return this->find(addr.ip6());
+  template <typename PAYLOAD>
+  template <typename F, typename U>
+  auto
+  IPSpace<PAYLOAD>::blend(IP4Range const &range, U const &color, F &&blender) -> self_type &
+  {
+    _ip4.blend(range, color, std::forward<F>(blender));
+    return *this;
   }
-  return this->end();
-}
 
-template <typename PAYLOAD>
-auto IPSpace<PAYLOAD>::find(IPAddr const &addr) const -> const_iterator {
-  if (addr.is_ip4()) {
-    return this->find(addr.ip4());
-  } else if (addr.is_ip6()) {
-    return this->find(addr.ip6());
+  template <typename PAYLOAD>
+  template <typename F, typename U>
+  auto
+  IPSpace<PAYLOAD>::blend(IP6Range const &range, U const &color, F &&blender) -> self_type &
+  {
+    _ip6.blend(range, color, std::forward<F>(blender));
+    return *this;
   }
-  return this->end();
-}
 
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::find(IP4Addr const &addr) -> iterator {
-  if ( auto spot = _ip4.find(addr) ; spot != _ip4.end()) {
-    return { spot, _ip6.begin() };
+  template <typename PAYLOAD>
+  void
+  IPSpace<PAYLOAD>::clear()
+  {
+    _ip4.clear();
+    _ip6.clear();
   }
-  return this->end();
-}
 
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::find(IP4Addr const &addr) const -> const_iterator {
-  if ( auto spot = _ip4.find(addr) ; spot != _ip4.end()) {
-    return { spot, _ip6.begin() };
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::begin() -> iterator
+  {
+    return iterator{_ip4.begin(), _ip6.begin()};
   }
-  return this->end();
-}
 
-template <typename PAYLOAD>
-auto IPSpace<PAYLOAD>::find(IP6Addr const &addr) -> iterator { return {_ip4.end(), _ip6.find(addr)}; }
-
-template <typename PAYLOAD>
-auto IPSpace<PAYLOAD>::find(IP6Addr const &addr) const -> const_iterator { return const_iterator{_ip4.end(), _ip6.find(addr)}; }
-
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::begin(sa_family_t family) const -> const_iterator {
-  if (AF_INET == family) {
-    return this->begin_ip4();
-  } else if (AF_INET6 == family) {
-    return this->begin_ip6();
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::begin() const -> const_iterator
+  {
+    return const_cast<self_type *>(this)->begin();
   }
-  return this->end();
-}
 
-template <typename PAYLOAD>
-auto
-IPSpace<PAYLOAD>::end(sa_family_t family) const -> const_iterator {
-  if (AF_INET == family) {
-    return this->end_ip4();
-  } else if (AF_INET6 == family) {
-    return this->end_ip6();
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::end() -> iterator
+  {
+    return iterator{_ip4.end(), _ip6.end()};
   }
-  return this->end();
-}
 
-template <typename PAYLOAD>
-size_t
-IPSpace<PAYLOAD>::count_ip4() const {
-  return _ip4.count();
-}
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::end() const -> const_iterator
+  {
+    return const_cast<self_type *>(this)->end();
+  }
 
-template <typename PAYLOAD>
-size_t
-IPSpace<PAYLOAD>::count_ip6() const {
-  return _ip6.count();
-}
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::begin_ip4() -> iterator
+  {
+    return this->begin();
+  }
 
-template <typename PAYLOAD>
-size_t
-IPSpace<PAYLOAD>::count() const {
-  return _ip4.count() + _ip6.count();
-}
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::begin_ip4() const -> const_iterator
+  {
+    return this->begin();
+  }
 
-template <typename PAYLOAD>
-size_t
-IPSpace<PAYLOAD>::count(sa_family_t f) const {
-  return IP4Addr::AF_value == f ? _ip4.count() : IP6Addr::AF_value == f ? _ip6.count() : 0;
-}
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::end_ip4() -> iterator
+  {
+    return {_ip4.end(), _ip6.begin()};
+  }
 
-template <typename PAYLOAD>
-bool
-IPSpace<PAYLOAD>::empty() const {
-  return _ip4.empty() && _ip6.empty();
-}
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::end_ip4() const -> const_iterator
+  {
+    return const_cast<self_type *>(this)->end_ip4();
+  }
 
-inline auto
-IPRangeSet::const_iterator::operator++() -> self_type & {
-  ++_iter;
-  return *this;
-}
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::begin_ip6() -> iterator
+  {
+    return {_ip4.end(), _ip6.begin()};
+  }
 
-inline auto
-IPRangeSet::const_iterator::operator--() -> self_type & {
-  --_iter;
-  return *this;
-}
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::begin_ip6() const -> const_iterator
+  {
+    return const_cast<self_type *>(this)->begin_ip6();
+  }
 
-inline auto
-IPRangeSet::const_iterator::operator++(int) -> self_type {
-  self_type zret{*this};
-  ++_iter;
-  return zret;
-}
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::end_ip6() -> iterator
+  {
+    return this->end();
+  }
 
-inline auto
-IPRangeSet::const_iterator::operator--(int) -> self_type {
-  self_type zret{*this};
-  --_iter;
-  return zret;
-}
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::end_ip6() const -> const_iterator
+  {
+    return this->end();
+  }
 
-inline auto
-IPRangeSet::const_iterator::operator*() const -> reference {
-  return _iter->_rv;
-}
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::find(IPAddr const &addr) -> iterator
+  {
+    if (addr.is_ip4()) {
+      return this->find(addr.ip4());
+    } else if (addr.is_ip6()) {
+      return this->find(addr.ip6());
+    }
+    return this->end();
+  }
 
-inline auto
-IPRangeSet::const_iterator::operator->() const -> pointer {
-  return &(_iter->_rv);
-}
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::find(IPAddr const &addr) const -> const_iterator
+  {
+    if (addr.is_ip4()) {
+      return this->find(addr.ip4());
+    } else if (addr.is_ip6()) {
+      return this->find(addr.ip6());
+    }
+    return this->end();
+  }
 
-inline bool
-IPRangeSet::const_iterator::operator==(IPRangeSet::const_iterator::self_type const &that) const {
-  return _iter == that._iter;
-}
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::find(IP4Addr const &addr) -> iterator
+  {
+    if (auto spot = _ip4.find(addr); spot != _ip4.end()) {
+      return {spot, _ip6.begin()};
+    }
+    return this->end();
+  }
 
-inline bool
-IPRangeSet::const_iterator::operator!=(IPRangeSet::const_iterator::self_type const &that) const {
-  return _iter != that._iter;
-}
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::find(IP4Addr const &addr) const -> const_iterator
+  {
+    if (auto spot = _ip4.find(addr); spot != _ip4.end()) {
+      return {spot, _ip6.begin()};
+    }
+    return this->end();
+  }
 
-}} // namespace swoc::SWOC_VERSION_NS
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::find(IP6Addr const &addr) -> iterator
+  {
+    return {_ip4.end(), _ip6.find(addr)};
+  }
+
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::find(IP6Addr const &addr) const -> const_iterator
+  {
+    return const_iterator{_ip4.end(), _ip6.find(addr)};
+  }
+
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::begin(sa_family_t family) const -> const_iterator
+  {
+    if (AF_INET == family) {
+      return this->begin_ip4();
+    } else if (AF_INET6 == family) {
+      return this->begin_ip6();
+    }
+    return this->end();
+  }
+
+  template <typename PAYLOAD>
+  auto
+  IPSpace<PAYLOAD>::end(sa_family_t family) const -> const_iterator
+  {
+    if (AF_INET == family) {
+      return this->end_ip4();
+    } else if (AF_INET6 == family) {
+      return this->end_ip6();
+    }
+    return this->end();
+  }
+
+  template <typename PAYLOAD>
+  size_t
+  IPSpace<PAYLOAD>::count_ip4() const
+  {
+    return _ip4.count();
+  }
+
+  template <typename PAYLOAD>
+  size_t
+  IPSpace<PAYLOAD>::count_ip6() const
+  {
+    return _ip6.count();
+  }
+
+  template <typename PAYLOAD>
+  size_t
+  IPSpace<PAYLOAD>::count() const
+  {
+    return _ip4.count() + _ip6.count();
+  }
+
+  template <typename PAYLOAD>
+  size_t
+  IPSpace<PAYLOAD>::count(sa_family_t f) const
+  {
+    return IP4Addr::AF_value == f ? _ip4.count() : IP6Addr::AF_value == f ? _ip6.count() : 0;
+  }
+
+  template <typename PAYLOAD>
+  bool
+  IPSpace<PAYLOAD>::empty() const
+  {
+    return _ip4.empty() && _ip6.empty();
+  }
+
+  inline auto
+  IPRangeSet::const_iterator::operator++() -> self_type &
+  {
+    ++_iter;
+    return *this;
+  }
+
+  inline auto
+  IPRangeSet::const_iterator::operator--() -> self_type &
+  {
+    --_iter;
+    return *this;
+  }
+
+  inline auto
+  IPRangeSet::const_iterator::operator++(int) -> self_type
+  {
+    self_type zret{*this};
+    ++_iter;
+    return zret;
+  }
+
+  inline auto
+  IPRangeSet::const_iterator::operator--(int) -> self_type
+  {
+    self_type zret{*this};
+    --_iter;
+    return zret;
+  }
+
+  inline auto
+  IPRangeSet::const_iterator::operator*() const -> reference
+  {
+    return _iter->_rv;
+  }
+
+  inline auto
+  IPRangeSet::const_iterator::operator->() const -> pointer
+  {
+    return &(_iter->_rv);
+  }
+
+  inline bool
+  IPRangeSet::const_iterator::operator==(IPRangeSet::const_iterator::self_type const &that) const
+  {
+    return _iter == that._iter;
+  }
+
+  inline bool
+  IPRangeSet::const_iterator::operator!=(IPRangeSet::const_iterator::self_type const &that) const
+  {
+    return _iter != that._iter;
+  }
+
+} // namespace SWOC_VERSION_NS
+} // namespace swoc
 
 /// @cond NOT_DOCUMENTED
-namespace std {
+namespace std
+{
 
 // -- Tuple support for IP4Net --
-template <> class tuple_size<swoc::IP4Net> : public std::integral_constant<size_t, 2> {};
+template <> class tuple_size<swoc::IP4Net> : public std::integral_constant<size_t, 2>
+{
+};
 
-template <size_t IDX> class tuple_element<IDX, swoc::IP4Net> { static_assert("swoc::IP4Net tuple index out of range"); };
+template <size_t IDX> class tuple_element<IDX, swoc::IP4Net>
+{
+  static_assert("swoc::IP4Net tuple index out of range");
+};
 
-template <> class tuple_element<0, swoc::IP4Net> {
+template <> class tuple_element<0, swoc::IP4Net>
+{
 public:
   using type = swoc::IP4Addr;
 };
 
-template <> class tuple_element<1, swoc::IP4Net> {
+template <> class tuple_element<1, swoc::IP4Net>
+{
 public:
   using type = swoc::IPMask;
 };
 
 // -- Tuple support for IP6Net --
-template <> class tuple_size<swoc::IP6Net> : public std::integral_constant<size_t, 2> {};
+template <> class tuple_size<swoc::IP6Net> : public std::integral_constant<size_t, 2>
+{
+};
 
-template <size_t IDX> class tuple_element<IDX, swoc::IP6Net> { static_assert("swoc::IP6Net tuple index out of range"); };
+template <size_t IDX> class tuple_element<IDX, swoc::IP6Net>
+{
+  static_assert("swoc::IP6Net tuple index out of range");
+};
 
-template <> class tuple_element<0, swoc::IP6Net> {
+template <> class tuple_element<0, swoc::IP6Net>
+{
 public:
   using type = swoc::IP6Addr;
 };
 
-template <> class tuple_element<1, swoc::IP6Net> {
+template <> class tuple_element<1, swoc::IP6Net>
+{
 public:
   using type = swoc::IPMask;
 };
 
 // -- Tuple support for IPNet --
-template <> class tuple_size<swoc::IPNet> : public std::integral_constant<size_t, 2> {};
+template <> class tuple_size<swoc::IPNet> : public std::integral_constant<size_t, 2>
+{
+};
 
-template <size_t IDX> class tuple_element<IDX, swoc::IPNet> { static_assert("swoc::IPNet tuple index out of range"); };
+template <size_t IDX> class tuple_element<IDX, swoc::IPNet>
+{
+  static_assert("swoc::IPNet tuple index out of range");
+};
 
-template <> class tuple_element<0, swoc::IPNet> {
+template <> class tuple_element<0, swoc::IPNet>
+{
 public:
   using type = swoc::IPAddr;
 };
 
-template <> class tuple_element<1, swoc::IPNet> {
+template <> class tuple_element<1, swoc::IPNet>
+{
 public:
   using type = swoc::IPMask;
 };
 
 } // namespace std
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
 
-template <size_t IDX>
-typename std::tuple_element<IDX, IP4Net>::type
-get(swoc::IP4Net const &net) {
-  if constexpr (IDX == 0) {
-    return net.min();
-  } else if constexpr (IDX == 1) {
-    return net.mask();
+  template <size_t IDX>
+  typename std::tuple_element<IDX, IP4Net>::type
+  get(swoc::IP4Net const &net)
+  {
+    if constexpr (IDX == 0) {
+      return net.min();
+    } else if constexpr (IDX == 1) {
+      return net.mask();
+    }
   }
-}
 
-template <size_t IDX>
-typename std::tuple_element<IDX, IP6Net>::type
-get(swoc::IP6Net const &net) {
-  if constexpr (IDX == 0) {
-    return net.min();
-  } else if constexpr (IDX == 1) {
-    return net.mask();
+  template <size_t IDX>
+  typename std::tuple_element<IDX, IP6Net>::type
+  get(swoc::IP6Net const &net)
+  {
+    if constexpr (IDX == 0) {
+      return net.min();
+    } else if constexpr (IDX == 1) {
+      return net.mask();
+    }
   }
-}
 
-template <size_t IDX>
-typename std::tuple_element<IDX, IPNet>::type
-get(swoc::IPNet const &net) {
-  if constexpr (IDX == 0) {
-    return net.min();
-  } else if constexpr (IDX == 1) {
-    return net.mask();
+  template <size_t IDX>
+  typename std::tuple_element<IDX, IPNet>::type
+  get(swoc::IPNet const &net)
+  {
+    if constexpr (IDX == 0) {
+      return net.min();
+    } else if constexpr (IDX == 1) {
+      return net.mask();
+    }
   }
-}
-/// @endcond
+  /// @endcond
 
-}} // namespace swoc::SWOC_VERSION_NS
+} // namespace SWOC_VERSION_NS
+} // namespace swoc
 
 // Tuple support for IPSpace values.
 /// @cond NOT_DOCUMENTED
 
-namespace std {
+namespace std
+{
 
-template <typename P> class tuple_size<swoc::detail::ip_space_value_type<P>> : public integral_constant<size_t, 2> {};
-template <typename P> class tuple_size<swoc::detail::ip_space_const_value_type<P>> : public integral_constant<size_t, 2> {};
-
-template <size_t IDX, typename P> class tuple_element<IDX, swoc::detail::ip_space_value_type<P>> {
-  static_assert("swoc::IPSpace::value_type tuple index out of range");
+template <typename P> class tuple_size<swoc::detail::ip_space_value_type<P>> : public integral_constant<size_t, 2>
+{
 };
-template <size_t IDX, typename P> class tuple_element<IDX, swoc::detail::ip_space_const_value_type<P>> {
-  static_assert("swoc::IPSpace::value_type tuple index out of range");
+template <typename P> class tuple_size<swoc::detail::ip_space_const_value_type<P>> : public integral_constant<size_t, 2>
+{
 };
 
-template <typename P> class tuple_element<0, swoc::detail::ip_space_value_type<P>> {
+template <size_t IDX, typename P> class tuple_element<IDX, swoc::detail::ip_space_value_type<P>>
+{
+  static_assert("swoc::IPSpace::value_type tuple index out of range");
+};
+template <size_t IDX, typename P> class tuple_element<IDX, swoc::detail::ip_space_const_value_type<P>>
+{
+  static_assert("swoc::IPSpace::value_type tuple index out of range");
+};
+
+template <typename P> class tuple_element<0, swoc::detail::ip_space_value_type<P>>
+{
 public:
   using type = swoc::IPRangeView const &;
 };
 
-template <typename P> class tuple_element<1, swoc::detail::ip_space_value_type<P>> {
+template <typename P> class tuple_element<1, swoc::detail::ip_space_value_type<P>>
+{
 public:
   using type = P &;
 };
 
-template <typename P> class tuple_element<0, swoc::detail::ip_space_const_value_type<P>> {
+template <typename P> class tuple_element<0, swoc::detail::ip_space_const_value_type<P>>
+{
 public:
   using type = swoc::IPRangeView const &;
 };
 
-template <typename P> class tuple_element<1, swoc::detail::ip_space_const_value_type<P>> {
+template <typename P> class tuple_element<1, swoc::detail::ip_space_const_value_type<P>>
+{
 public:
   using type = P const &;
 };
 
 } // namespace std
 
-namespace swoc { inline namespace SWOC_VERSION_NS { namespace detail {
-template <size_t IDX, typename P>
-auto
-get(ip_space_const_value_type<P> const& p) -> typename std::tuple_element<IDX, ip_space_const_value_type<P>>::type {
-  if constexpr (IDX == 0) {
-    return p._rv;
-  } else if constexpr (IDX == 1) {
-    return *(p._payload);
-  }
-}
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  namespace detail
+  {
+    template <size_t IDX, typename P>
+    auto
+    get(ip_space_const_value_type<P> const &p) -> typename std::tuple_element<IDX, ip_space_const_value_type<P>>::type
+    {
+      if constexpr (IDX == 0) {
+        return p._rv;
+      } else if constexpr (IDX == 1) {
+        return *(p._payload);
+      }
+    }
 
-template <size_t IDX, typename P>
-auto
-get(ip_space_value_type<P> const& p) -> typename std::tuple_element<IDX, ip_space_value_type<P>>::type {
-  if constexpr (IDX == 0) {
-    return p._rv;
-  } else if constexpr (IDX == 1) {
-    return *(p._payload);
-  }
-}
-}}} // namespace swoc::detail
+    template <size_t IDX, typename P>
+    auto
+    get(ip_space_value_type<P> const &p) -> typename std::tuple_element<IDX, ip_space_value_type<P>>::type
+    {
+      if constexpr (IDX == 0) {
+        return p._rv;
+      } else if constexpr (IDX == 1) {
+        return *(p._payload);
+      }
+    }
+  } // namespace detail
+} // namespace SWOC_VERSION_NS
+} // namespace swoc
 
 // Support unqualified @c get because ADL doesn't seem to work.
 using swoc::detail::get;
 // Support @c std::get
-namespace std { using swoc::detail::get; }
+namespace std
+{
+using swoc::detail::get;
+}
 
 /// @endcond

--- a/code/include/swoc/IPSrv.h
+++ b/code/include/swoc/IPSrv.h
@@ -12,669 +12,925 @@
 #include "swoc/swoc_version.h"
 #include "swoc/IPAddr.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
 
-class IPSrv;
+  class IPSrv;
 
-/// An IPv4 address and host_order_port, modeled on an SRV type for DNS.
-class IP4Srv {
-private:
-  using self_type = IP4Srv;
+  /// An IPv4 address and host_order_port, modeled on an SRV type for DNS.
+  class IP4Srv
+  {
+  private:
+    using self_type = IP4Srv;
 
-public:
-  constexpr IP4Srv() = default; ///< Default constructor.
+  public:
+    constexpr IP4Srv() = default; ///< Default constructor.
 
-  /** Construct from address and host_order_port.
-   *
-   * @param addr The address.
-   * @param port The port in host order, defaults to 0.
-   */
-  explicit IP4Srv(IP4Addr addr, in_port_t port = 0);
+    /** Construct from address and host_order_port.
+     *
+     * @param addr The address.
+     * @param port The port in host order, defaults to 0.
+     */
+    explicit IP4Srv(IP4Addr addr, in_port_t port = 0);
 
-  /** Construct from generic.
-   *
-   * @param that The generic SRV.
-   *
-   * If @a that is not IPv4 the result is a default constructed instance.
-   */
-  explicit IP4Srv(IPSrv const& that);
+    /** Construct from generic.
+     *
+     * @param that The generic SRV.
+     *
+     * If @a that is not IPv4 the result is a default constructed instance.
+     */
+    explicit IP4Srv(IPSrv const &that);
 
-  /** Construct from socket address.
-   *
-   * @param sa Socket address.
-   */
-  IP4Srv(sockaddr_in const * s) : _addr(s), _port(ntohs(s->sin_port)) {}
+    /** Construct from socket address.
+     *
+     * @param sa Socket address.
+     */
+    IP4Srv(sockaddr_in const *s) : _addr(s), _port(ntohs(s->sin_port)) {}
 
-  /** Construct from a string.
-   *
-   * @param text Input text.
-   *
-   * If the port is not present it is set to zero.
-   */
-  explicit IP4Srv(swoc::TextView text);
+    /** Construct from a string.
+     *
+     * @param text Input text.
+     *
+     * If the port is not present it is set to zero.
+     */
+    explicit IP4Srv(swoc::TextView text);
 
-  /// Implicit conversion to an address.
-  constexpr operator IP4Addr const& () const;
+    /// Implicit conversion to an address.
+    constexpr operator IP4Addr const &() const;
 
-  /// @return The address.
-  constexpr IP4Addr const& addr() const;
+    /// @return The address.
+    constexpr IP4Addr const &addr() const;
 
-  /// @return The host_order_port in host order.
-  in_port_t host_order_port() const;
+    /// @return The host_order_port in host order.
+    in_port_t host_order_port() const;
 
-  /// @return The host_order_port in network order.
-  in_port_t network_order_port() const;
+    /// @return The host_order_port in network order.
+    in_port_t network_order_port() const;
 
-  /// The protocol family.
-  /// @return @c AF_INET
-  /// @note Useful primarily for template classes.
-  static constexpr sa_family_t family();
+    /// The protocol family.
+    /// @return @c AF_INET
+    /// @note Useful primarily for template classes.
+    static constexpr sa_family_t family();
 
-  bool operator == (self_type that) const;
-  bool operator != (self_type that) const;
+    bool operator==(self_type that) const;
+    bool operator!=(self_type that) const;
 
-  bool operator < (self_type that) const;
-  bool operator <= (self_type const& that) const;
-  bool operator > (self_type const& that) const;
-  bool operator >= (self_type const& that) const;
+    bool operator<(self_type that) const;
+    bool operator<=(self_type const &that) const;
+    bool operator>(self_type const &that) const;
+    bool operator>=(self_type const &that) const;
 
-  /** Load from a string.
-   *
-   * @param text Input string.
-   * @return @c true if @a text in a valid format, @c false if not.
-   */
-  bool load(swoc::TextView text);
+    /** Load from a string.
+     *
+     * @param text Input string.
+     * @return @c true if @a text in a valid format, @c false if not.
+     */
+    bool load(swoc::TextView text);
 
-  /** Change the address.
-   *
-   * @param addr Address to assign.
-   * @return @a this
-   */
-  self_type & assign(IP4Addr const& addr);
+    /** Change the address.
+     *
+     * @param addr Address to assign.
+     * @return @a this
+     */
+    self_type &assign(IP4Addr const &addr);
 
-  /** Change the host_order_port.
-   *
-   * @param port Port to assign.
-   * @return @a this.
-   */
-  self_type & assign(in_port_t port);
+    /** Change the host_order_port.
+     *
+     * @param port Port to assign.
+     * @return @a this.
+     */
+    self_type &assign(in_port_t port);
 
-  /** Change the address and port.
-   *
-   * @param addr Address to assign.
-   * @param port Port to assign.
-   * @return @a this
-   */
-  self_type & assign(IP4Addr const& addr, in_port_t port);
+    /** Change the address and port.
+     *
+     * @param addr Address to assign.
+     * @param port Port to assign.
+     * @return @a this
+     */
+    self_type &assign(IP4Addr const &addr, in_port_t port);
 
-  /** Change the address and port.
-   *
-   * @param s A socket address.
-   * @return @a this
-   */
-  self_type & assign(sockaddr_in const * s);
+    /** Change the address and port.
+     *
+     * @param s A socket address.
+     * @return @a this
+     */
+    self_type &assign(sockaddr_in const *s);
 
-protected:
-  IP4Addr _addr; ///< Address.
-  in_port_t _port = 0; ///< Port.
-};
+  protected:
+    IP4Addr _addr;       ///< Address.
+    in_port_t _port = 0; ///< Port.
+  };
 
-/// An IPv6 address and host_order_port, modeled on an SRV type for DNS.
-class IP6Srv {
-private:
-  using self_type = IP6Srv;
+  /// An IPv6 address and host_order_port, modeled on an SRV type for DNS.
+  class IP6Srv
+  {
+  private:
+    using self_type = IP6Srv;
 
-public:
-  IP6Srv() = default; ///< Default constructor.
+  public:
+    IP6Srv() = default; ///< Default constructor.
 
-  /** Construct from address and host_order_port.
-   *
-   * @param addr The address.
-   * @param port The port in host order, defaults to 0.
-   */
-  explicit IP6Srv(IP6Addr addr, in_port_t port = 0);
+    /** Construct from address and host_order_port.
+     *
+     * @param addr The address.
+     * @param port The port in host order, defaults to 0.
+     */
+    explicit IP6Srv(IP6Addr addr, in_port_t port = 0);
 
-  /** Construct from generic.
-   *
-   * @param that The generic SRV.
-   *
-   * If @a that is not IPv6 the result is a default constructed instance.
-   */
-  explicit IP6Srv(IPSrv const& that);
+    /** Construct from generic.
+     *
+     * @param that The generic SRV.
+     *
+     * If @a that is not IPv6 the result is a default constructed instance.
+     */
+    explicit IP6Srv(IPSrv const &that);
 
-  /** Construct from a socket address.
-   *
-   * @param s Socket address.
-   */
-  explicit IP6Srv(sockaddr_in6 const * s);
+    /** Construct from a socket address.
+     *
+     * @param s Socket address.
+     */
+    explicit IP6Srv(sockaddr_in6 const *s);
 
-  /** Construct from a string.
-   *
-   * @param text Input text.
-   *
-   * If the port is not present it is set to zero.
-   */
-  explicit IP6Srv(swoc::TextView text);
+    /** Construct from a string.
+     *
+     * @param text Input text.
+     *
+     * If the port is not present it is set to zero.
+     */
+    explicit IP6Srv(swoc::TextView text);
 
-  /** Load from a string.
-   *
-   * @param text Input string.
-   * @return @c true if @a text in a valid format, @c false if not.
-   */
-  bool load(swoc::TextView text);
+    /** Load from a string.
+     *
+     * @param text Input string.
+     * @return @c true if @a text in a valid format, @c false if not.
+     */
+    bool load(swoc::TextView text);
 
-  /// Implicit conversion to address.
-  constexpr operator IP6Addr const& () const;
+    /// Implicit conversion to address.
+    constexpr operator IP6Addr const &() const;
 
-  /// @return The address.
-  constexpr IP6Addr const& addr() const;
-  /// @return The port in host order.
-  in_port_t host_order_port() const;
-  /// @return The port in network order.
-  in_port_t network_order_port() const;
-
-  /// The protocol family.
-  /// @return @c AF_INET6
-  /// @note Useful primarily for template classes.
-  static constexpr sa_family_t family();
-
-  bool operator == (self_type that) const;
-  bool operator != (self_type that) const;
-
-  bool operator < (self_type that) const;
-  bool operator <= (self_type const& that) const;
-  bool operator > (self_type const& that) const;
-  bool operator >= (self_type const& that) const;
-
-  /** Change the address.
-   *
-   * @param addr Address to assign.
-   * @return @a this
-   */
-  self_type & assign(IP6Addr const& addr);
-
-  /** Change the host_order_port.
-   *
-   * @param port Port to assign.
-   * @return @a this.
-   */
-  self_type & assign(in_port_t port);
-
-  /** Change the address and host_order_port.
-   *
-   * @param addr Address to assign.
-   * @param port Port to assign.
-   * @return @a this
-   */
-  self_type & assign(IP6Addr const& addr, in_port_t port);
-
-  /** Change the address and port.
-   *
-   * @param s A socket address.
-   * @return @a this
-   */
-  self_type & assign(sockaddr_in6 const * s);
-
-protected:
-  IP6Addr _addr; ///< Address.
-  in_port_t _port = 0; ///< Port.
-};
-
-/// An IP address and host_order_port, modeled on an SRV type for DNS.
-class IPSrv {
-private:
-  using self_type = IPSrv;
-
-public:
-  IPSrv() = default; ///< Default constructor.
-  explicit IPSrv(IP4Addr addr, in_port_t port = 0) : _srv(IP4Srv{addr, port}), _family(addr.family()) {}
-  explicit IPSrv(IP6Addr addr, in_port_t port = 0) : _srv(IP6Srv{addr, port}), _family(addr.family()) {}
-  explicit IPSrv(IPAddr addr, in_port_t port = 0);
-  explicit IPSrv(sockaddr const * sa);
-  explicit IPSrv(sockaddr_in const * s);
-  explicit IPSrv(sockaddr_in6 const * s);
-  explicit IPSrv(IPEndpoint const& ep);
-
-  /** Construct from a string.
-   *
-   * @param text Input text.
-   *
-   * If the port is not present it is set to zero.
-   */
-  explicit IPSrv(swoc::TextView text);
-
-  /** Load from a string.
-   *
-   * @param text Input string.
-   * @return @c true if @a text in a valid format, @c false if not.
-   */
-  bool load(swoc::TextView text);
-
-  /// @return The address.
-  IPAddr addr() const;
-  /// @return The host_order_port in host order..
-  constexpr in_port_t host_order_port() const;
-  /// @return The host_order_port in network order.
-  in_port_t network_order_port() const;
-  /// @return The protocol of the current value.
-  constexpr sa_family_t family() const;
-
-  /// @return @c true if the data is IPv4, @c false if not.
-  bool is_ip4() const;
-  /// @return @c true if hte data is IPv6, @c false if not.
-  bool is_ip6() const;
-
-  /// @return The IPv4 data.
-  IP4Srv const& ip4() const { return _srv._ip4; }
-  /// @return The IPv6 data.
-  IP6Srv const& ip6() const { return _srv._ip6; }
-
-  /** Change the address.
-   *
-   * @param addr Address to assign.
-   * @return @a this
-   */
-  self_type & assign(IP4Addr const& addr);
-
-  /** Change the address.
-   *
-   * @param addr Address to assign.
-   * @return @a this
-   */
-  self_type & assign(IP6Addr const& addr);
-
-  /** Change the address.
-   *
-   * @param addr Address to assign.
-   * @return @a this
-   *
-   * If @a addr isn't valid then no assignment is made.
-   */
-  self_type & assign(IPAddr const& addr);
-
-  /** Change the host_order_port.
-   *
-   * @param port Port in host order.
-   * @return @a this.
-   */
-  self_type & assign(in_port_t port);
-
-  /** Change the address and port.
-   *
-   * @param addr Address to assign.
-   * @param port Port to assign.
-   * @return @a this
-   */
-  self_type & assign(IP4Addr const& addr, in_port_t port);
-
-  /** Change the address and port.
-   *
-   * @param addr Address to assign.
-   * @param port Port to assign.
-   * @return @a this
-   */
-  self_type & assign(IP6Addr const& addr, in_port_t port);
-
-  /** Change the address and port.
-   *
-   * @param sa Socket address.
-   * @return @a this
-   */
-  self_type & assign(sockaddr const * sa);
-
-  /** Change the address and port.
-   *
-   * @param s Socket address.
-   * @return @a this
-   */
-  self_type & assign(sockaddr_in const * s);
-
-  /** Change the address and port.
-   *
-   * @param s Socket address.
-   * @return @a this
-   */
-  self_type & assign(sockaddr_in6 const * s);
-
-  /** Change the address and host_order_port.
-   *
-   * @param addr Address to assign.
-   * @param port Port to assign.
-   * @return @a this
-   *
-   * If @a addr isn't valid then no assignment is made.
-   */
-  self_type & assign(IPAddr const& addr, in_port_t port);
-
-  self_type & operator = (self_type const& that) = default;
-  self_type & operator = (IP4Srv const& that);
-  self_type & operator = (IP6Srv const& that);
-  self_type & operator = (sockaddr const * sa) { return this->assign(sa); }
-  self_type & operator = (sockaddr_in const * s) { return this->assign(s); }
-  self_type & operator = (sockaddr_in6 const * s) { return this->assign(s); }
-
-protected:
-  /// Family specialized data.
-  union data {
-    IP4Srv _ip4;            ///< IPv4 address (host)
-    IP6Srv _ip6;            ///< IPv6 address (host)
-
-    data() {}; // enable default construction.
-
-    /// Construct from IPv4 data.
-    explicit data(IP4Srv const &srv) : _ip4(srv) {}
-    explicit data(sockaddr_in const * s) : _ip4(s) {}
-
-    /// Construct from IPv6 data.
-    explicit data(IP6Srv const &srv) : _ip6(srv) {}
-    explicit data(sockaddr_in6 const * s) : _ip6(s) {}
-
-    /// @return A generic address.
-    IPAddr addr(sa_family_t f) const;
-
+    /// @return The address.
+    constexpr IP6Addr const &addr() const;
     /// @return The port in host order.
-    constexpr in_port_t port(sa_family_t f) const;
-  } _srv;
-
-  sa_family_t _family = AF_UNSPEC; ///< Protocol family.
-
-};
-
-// --- Implementation
-
-inline IP4Srv::IP4Srv(IP4Addr addr, in_port_t port) : _addr(addr), _port(port) {}
-inline IP4Srv::IP4Srv(IPSrv const &that) : IP4Srv(that.is_ip4() ? that.ip4() : self_type{}) {}
-
-inline auto IP4Srv::assign(IP4Addr const &addr) -> self_type & { _addr = addr; return *this; }
-inline auto IP4Srv::assign(in_port_t port) -> self_type & { _port = port; return *this; }
-inline auto IP4Srv::assign(IP4Addr const &addr, in_port_t port) -> self_type & { _addr = addr; _port = port; return *this;}
-inline auto IP4Srv::assign(sockaddr_in const * s) -> self_type & { _addr = s; _port = ntohs(s->sin_port); return *this; }
-inline constexpr IP4Srv::operator IP4Addr const &() const { return _addr; }
-inline constexpr IP4Addr const & IP4Srv::addr() const { return _addr; }
-inline in_port_t IP4Srv::host_order_port() const { return _port; }
-inline in_port_t IP4Srv::network_order_port() const { return htons(_port); }
-inline constexpr sa_family_t IP4Srv::family() { return AF_INET; }
-
-inline bool IP4Srv::operator==(IP4Srv::self_type that) const { return _addr == that._addr && _port == that._port; }
-inline bool IP4Srv::operator!=(IP4Srv::self_type that) const { return _addr != that._addr || _port != that._port; }
-inline bool IP4Srv::operator< (IP4Srv::self_type that) const { return _addr < that._addr || (_addr == that._addr && _port < that._port); }
-inline bool IP4Srv::operator<=(IP4Srv::self_type const &that) const { return _addr < that._addr || (_addr == that._addr && _port <= that._port); }
-inline bool IP4Srv::operator> (IP4Srv::self_type const &that) const { return that < *this; }
-inline bool IP4Srv::operator>=(IP4Srv::self_type const &that) const { return that <= *this; }
-
-/// --- IPv6
-
-inline IP6Srv::IP6Srv(IP6Addr addr, in_port_t port) : _addr(addr), _port(port) {}
-inline IP6Srv::IP6Srv(IPSrv const &that) : IP6Srv(that.is_ip6() ? that.ip6() : self_type{}) {}
-inline IP6Srv::IP6Srv(const sockaddr_in6 *s) : _addr(s->sin6_addr), _port(ntohs(s->sin6_port)) {}
-
-inline constexpr IP6Srv::operator IP6Addr const &() const { return _addr; }
-inline constexpr IP6Addr const & IP6Srv::addr() const { return _addr; }
-inline in_port_t IP6Srv::host_order_port() const { return _port; }
-inline in_port_t IP6Srv::network_order_port() const { return htons(_port); }
-inline constexpr sa_family_t IP6Srv::family() { return AF_INET6; }
-
-inline bool IP6Srv::operator==(IP6Srv::self_type that) const { return _addr == that._addr && _port == that._port; }
-inline bool IP6Srv::operator!=(IP6Srv::self_type that) const { return _port != that._port || _addr != that._addr; }
-inline bool IP6Srv::operator< (IP6Srv::self_type that) const { return _addr < that._addr || (_addr == that._addr && _port < that._port); }
-inline bool IP6Srv::operator<=(IP6Srv::self_type const &that) const { return _addr < that._addr || (_addr == that._addr && _port <= that._port); }
-inline bool IP6Srv::operator> (IP6Srv::self_type const &that) const { return that < *this; }
-inline bool IP6Srv::operator>=(IP6Srv::self_type const &that) const { return that <= *this; }
-
-inline auto
-IP6Srv::assign(in_port_t port) -> self_type & { _port = port; return *this; }
-
-inline auto
-IP6Srv::assign(IP6Addr const &addr) -> self_type & { _addr = addr; return *this; }
-
-inline auto
-IP6Srv::assign(IP6Addr const &addr, in_port_t port) -> self_type & {
-  _addr = addr;
-  _port = port;
-  return *this;
-}
-
-inline auto
-IP6Srv::assign(sockaddr_in6 const *s) -> self_type & {
-  _addr = s;
-  _port = ntohs(s->sin6_port);
-  return *this;
-}
-
-// --- Generic SRV
-
-inline IPSrv::IPSrv(const sockaddr_in *s) : _srv(s), _family(AF_INET) {}
-inline IPSrv::IPSrv(const sockaddr_in6 *s) : _srv(s), _family(AF_INET6) {}
-inline IPSrv::IPSrv(const sockaddr *sa) { this->assign(sa); }
-
-inline IPAddr IPSrv::addr() const { return _srv.addr(_family); }
-inline constexpr sa_family_t IPSrv::family() const { return _family; }
-inline bool IPSrv::is_ip4() const { return _family == AF_INET; }
-inline bool IPSrv::is_ip6() const { return _family == AF_INET6; }
-
-inline auto
-IPSrv::assign(IP6Addr const &addr) -> self_type & {
-  _srv._ip6.assign(addr, this->host_order_port());
-  _family = addr.family();
-  return *this;
-}
-
-inline auto
-IPSrv::assign(IP4Addr const &addr, in_port_t port) -> self_type & {
-  _srv._ip4.assign(addr, port);
-  _family = addr.family();
-  return *this;
-}
-
-inline auto
-IPSrv::assign(IP6Addr const &addr, in_port_t port) -> self_type & {
-  _srv._ip6.assign(addr, port);
-  _family = addr.family();
-  return *this;
-}
-
-inline auto
-IPSrv::assign(IP4Addr const &addr) -> self_type & {
-  _srv._ip4.assign(addr, this->host_order_port());
-  _family = addr.family();
-  return *this;
-}
-
-inline auto
-IPSrv::assign(in_port_t port) -> self_type & {
-  if (this->is_ip4()) { _srv._ip4.assign(port); }
-  else if (this->is_ip6()) { _srv._ip6.assign(port); }
-  return *this;
-}
-
-inline auto
-IPSrv::assign(IPAddr const &addr) -> self_type & {
-  if (addr.is_ip4()) { this->assign(addr.ip4()); }
-  else if (addr.is_ip6()) { this->assign(addr.ip6());}
-  return *this;
-}
-
-inline auto
-IPSrv::assign(IPAddr const &addr, in_port_t port) -> self_type & {
-  if (addr.is_ip4()) { this->assign(addr.ip4(), port); _family = addr.family(); }
-  else if (addr.is_ip6()) { this->assign(addr.ip6(), port); _family = addr.family(); }
-  return *this;
-}
-
-inline auto
-IPSrv::operator=(IP4Srv const &that) -> self_type & {
-  _family = that.family();
-  _srv._ip4 = that;
-  return *this;
-}
-
-inline auto
-IPSrv::operator=(IP6Srv const &that) -> self_type & {
-  _family = that.family();
-  _srv._ip6 = that;
-  return *this;
-}
-
-inline auto
-IPSrv::assign(sockaddr_in const * s) -> self_type & {
-  _family = _srv._ip4.family();
-  _srv._ip4.assign(s);
-  return *this;
-}
-
-inline auto
-IPSrv::assign(sockaddr_in6 const * s) -> self_type & {
-  _family = _srv._ip6.family();
-  _srv._ip6.assign(s);
-  return *this;
-}
-
-inline constexpr in_port_t
-IPSrv::host_order_port() const { return _srv.port(_family); }
-
-inline in_port_t
-IPSrv::network_order_port() const { return ntohs(_srv.port(_family)); }
-
-inline IPAddr
-IPSrv::data::addr(sa_family_t f) const {
-  return (f == AF_INET) ? _ip4.addr() : (f == AF_INET6) ? _ip6.addr() : IPAddr::INVALID;
-}
-
-constexpr inline in_port_t
-IPSrv::data::port(sa_family_t f) const {
-  return (f == AF_INET) ? _ip4.host_order_port() : (f == AF_INET6) ? _ip6.host_order_port() : 0;
-}
-// --- Independent comparisons.
-
-inline bool operator == (IPSrv const& lhs, IP4Srv const& rhs) {
-  return lhs.is_ip4() && lhs.ip4() == rhs;
-}
-
-inline bool operator == (IP4Srv const& lhs, IPSrv const& rhs) {
-  return rhs.is_ip4() && rhs.ip4() == lhs;
-}
-
-inline bool operator != (IPSrv const& lhs, IP4Srv const& rhs) {
-  return ! lhs.is_ip4() || lhs.ip4() != rhs;
-}
-
-inline bool operator != (IP4Srv const& lhs, IPSrv const& rhs) {
-  return ! rhs.is_ip4() || rhs.ip4() != lhs;
-}
-
-inline bool operator <  (IPSrv const& lhs, IP4Srv const& rhs) {
-  return lhs.is_ip4() && lhs.ip4() < rhs;
-}
-
-inline bool operator <  (IP4Srv const& lhs, IPSrv const& rhs) {
-  return rhs.is_ip4() && lhs < rhs.ip4();
-}
-
-inline bool operator <= (IPSrv const& lhs, IP4Srv const& rhs) {
-  return lhs.is_ip4() && lhs.ip4() <= rhs;
-}
-
-inline bool operator <= (IP4Srv const& lhs, IPSrv const& rhs) {
-  return rhs.is_ip4() && lhs <= rhs.ip4();
-}
-
-inline bool operator >  (IPSrv const& lhs, IP4Srv const& rhs) {
-  return lhs.is_ip4() && lhs.ip4() > rhs;
-}
-
-inline bool operator >  (IP4Srv const& lhs, IPSrv const& rhs) {
-  return rhs.is_ip4() && lhs > rhs.ip4();
-}
-
-inline bool operator >= (IPSrv const& lhs, IP4Srv const& rhs) {
-  return lhs.is_ip4() && lhs.ip4() >= rhs;
-}
-
-inline bool operator >= (IP4Srv const& lhs, IPSrv const& rhs) {
-  return rhs.is_ip4() && lhs >= rhs.ip4();
-}
-
-
-inline bool operator == (IPSrv const& lhs, IP6Srv const& rhs) {
-  return lhs.is_ip6() && lhs.ip6() == rhs;
-}
-
-inline bool operator == (IP6Srv const& lhs, IPSrv const& rhs) {
-  return rhs.is_ip6() && rhs.ip6() == lhs;
-}
-
-inline bool operator != (IPSrv const& lhs, IP6Srv const& rhs) {
-  return ! lhs.is_ip6() || lhs.ip6() != rhs;
-}
-
-inline bool operator != (IP6Srv const& lhs, IPSrv const& rhs) {
-  return ! rhs.is_ip6() || rhs.ip6() != lhs;
-}
-
-inline bool operator <  (IPSrv const& lhs, IP6Srv const& rhs) {
-  return lhs.is_ip6() && lhs.ip6() < rhs;
-}
-
-inline bool operator <  (IP6Srv const& lhs, IPSrv const& rhs) {
-  return rhs.is_ip6() && lhs < rhs.ip6();
-}
-
-inline bool operator <= (IPSrv const& lhs, IP6Srv const& rhs) {
-  return lhs.is_ip6() && lhs.ip6() <= rhs;
-}
-
-inline bool operator <= (IP6Srv const& lhs, IPSrv const& rhs) {
-  return rhs.is_ip6() && lhs <= rhs.ip6();
-}
-
-inline bool operator >  (IPSrv const& lhs, IP6Srv const& rhs) {
-  return lhs.is_ip6() && lhs.ip6() > rhs;
-}
-
-inline bool operator >  (IP6Srv const& lhs, IPSrv const& rhs) {
-  return rhs.is_ip6() && lhs > rhs.ip6();
-}
-
-inline bool operator >= (IPSrv const& lhs, IP6Srv const& rhs) {
-  return lhs.is_ip6() && lhs.ip6() >= rhs;
-}
-
-inline bool operator >= (IP6Srv const& lhs, IPSrv const& rhs) {
-  return rhs.is_ip6() && lhs >= rhs.ip6();
-}
-
-// --- Cross address equality
-
-inline bool operator == (IPSrv const& lhs, IP4Addr const& rhs) {
-  return lhs.is_ip4() && lhs.ip4() == rhs;
-}
-
-inline bool operator == (IP4Addr const& lhs, IPSrv const& rhs) {
-  return rhs.is_ip4() && lhs == rhs.ip4();
-}
-
-inline bool operator != (IPSrv const& lhs, IP4Addr const& rhs) {
-  return ! lhs.is_ip4() || lhs.ip4() != rhs;
-}
-
-inline bool operator != (IP4Addr const& lhs, IPSrv const& rhs) {
-  return ! rhs.is_ip4() || lhs != rhs.ip4();
-}
-
-inline bool operator == (IPSrv const& lhs, IP6Addr const& rhs) {
-  return lhs.is_ip6() && lhs.ip6() == rhs;
-}
-
-inline bool operator == (IP6Addr const& lhs, IPSrv const& rhs) {
-  return rhs.is_ip6() && lhs == rhs.ip6();
-}
-
-inline bool operator != (IPSrv const& lhs, IP6Addr const& rhs) {
-  return ! lhs.is_ip6() || lhs.ip6() != rhs;
-}
-
-inline bool operator != (IP6Addr const& lhs, IPSrv const& rhs) {
-  return ! rhs.is_ip6() || lhs != rhs.ip6();
-}
-
-}} // namespace swoc::SWOC_VERSION_NS
+    in_port_t host_order_port() const;
+    /// @return The port in network order.
+    in_port_t network_order_port() const;
+
+    /// The protocol family.
+    /// @return @c AF_INET6
+    /// @note Useful primarily for template classes.
+    static constexpr sa_family_t family();
+
+    bool operator==(self_type that) const;
+    bool operator!=(self_type that) const;
+
+    bool operator<(self_type that) const;
+    bool operator<=(self_type const &that) const;
+    bool operator>(self_type const &that) const;
+    bool operator>=(self_type const &that) const;
+
+    /** Change the address.
+     *
+     * @param addr Address to assign.
+     * @return @a this
+     */
+    self_type &assign(IP6Addr const &addr);
+
+    /** Change the host_order_port.
+     *
+     * @param port Port to assign.
+     * @return @a this.
+     */
+    self_type &assign(in_port_t port);
+
+    /** Change the address and host_order_port.
+     *
+     * @param addr Address to assign.
+     * @param port Port to assign.
+     * @return @a this
+     */
+    self_type &assign(IP6Addr const &addr, in_port_t port);
+
+    /** Change the address and port.
+     *
+     * @param s A socket address.
+     * @return @a this
+     */
+    self_type &assign(sockaddr_in6 const *s);
+
+  protected:
+    IP6Addr _addr;       ///< Address.
+    in_port_t _port = 0; ///< Port.
+  };
+
+  /// An IP address and host_order_port, modeled on an SRV type for DNS.
+  class IPSrv
+  {
+  private:
+    using self_type = IPSrv;
+
+  public:
+    IPSrv() = default; ///< Default constructor.
+    explicit IPSrv(IP4Addr addr, in_port_t port = 0) : _srv(IP4Srv{addr, port}), _family(addr.family()) {}
+    explicit IPSrv(IP6Addr addr, in_port_t port = 0) : _srv(IP6Srv{addr, port}), _family(addr.family()) {}
+    explicit IPSrv(IPAddr addr, in_port_t port = 0);
+    explicit IPSrv(sockaddr const *sa);
+    explicit IPSrv(sockaddr_in const *s);
+    explicit IPSrv(sockaddr_in6 const *s);
+    explicit IPSrv(IPEndpoint const &ep);
+
+    /** Construct from a string.
+     *
+     * @param text Input text.
+     *
+     * If the port is not present it is set to zero.
+     */
+    explicit IPSrv(swoc::TextView text);
+
+    /** Load from a string.
+     *
+     * @param text Input string.
+     * @return @c true if @a text in a valid format, @c false if not.
+     */
+    bool load(swoc::TextView text);
+
+    /// @return The address.
+    IPAddr addr() const;
+    /// @return The host_order_port in host order..
+    constexpr in_port_t host_order_port() const;
+    /// @return The host_order_port in network order.
+    in_port_t network_order_port() const;
+    /// @return The protocol of the current value.
+    constexpr sa_family_t family() const;
+
+    /// @return @c true if the data is IPv4, @c false if not.
+    bool is_ip4() const;
+    /// @return @c true if hte data is IPv6, @c false if not.
+    bool is_ip6() const;
+
+    /// @return The IPv4 data.
+    IP4Srv const &
+    ip4() const
+    {
+      return _srv._ip4;
+    }
+    /// @return The IPv6 data.
+    IP6Srv const &
+    ip6() const
+    {
+      return _srv._ip6;
+    }
+
+    /** Change the address.
+     *
+     * @param addr Address to assign.
+     * @return @a this
+     */
+    self_type &assign(IP4Addr const &addr);
+
+    /** Change the address.
+     *
+     * @param addr Address to assign.
+     * @return @a this
+     */
+    self_type &assign(IP6Addr const &addr);
+
+    /** Change the address.
+     *
+     * @param addr Address to assign.
+     * @return @a this
+     *
+     * If @a addr isn't valid then no assignment is made.
+     */
+    self_type &assign(IPAddr const &addr);
+
+    /** Change the host_order_port.
+     *
+     * @param port Port in host order.
+     * @return @a this.
+     */
+    self_type &assign(in_port_t port);
+
+    /** Change the address and port.
+     *
+     * @param addr Address to assign.
+     * @param port Port to assign.
+     * @return @a this
+     */
+    self_type &assign(IP4Addr const &addr, in_port_t port);
+
+    /** Change the address and port.
+     *
+     * @param addr Address to assign.
+     * @param port Port to assign.
+     * @return @a this
+     */
+    self_type &assign(IP6Addr const &addr, in_port_t port);
+
+    /** Change the address and port.
+     *
+     * @param sa Socket address.
+     * @return @a this
+     */
+    self_type &assign(sockaddr const *sa);
+
+    /** Change the address and port.
+     *
+     * @param s Socket address.
+     * @return @a this
+     */
+    self_type &assign(sockaddr_in const *s);
+
+    /** Change the address and port.
+     *
+     * @param s Socket address.
+     * @return @a this
+     */
+    self_type &assign(sockaddr_in6 const *s);
+
+    /** Change the address and host_order_port.
+     *
+     * @param addr Address to assign.
+     * @param port Port to assign.
+     * @return @a this
+     *
+     * If @a addr isn't valid then no assignment is made.
+     */
+    self_type &assign(IPAddr const &addr, in_port_t port);
+
+    self_type &operator=(self_type const &that) = default;
+    self_type &operator=(IP4Srv const &that);
+    self_type &operator=(IP6Srv const &that);
+    self_type &
+    operator=(sockaddr const *sa)
+    {
+      return this->assign(sa);
+    }
+    self_type &
+    operator=(sockaddr_in const *s)
+    {
+      return this->assign(s);
+    }
+    self_type &
+    operator=(sockaddr_in6 const *s)
+    {
+      return this->assign(s);
+    }
+
+  protected:
+    /// Family specialized data.
+    union data {
+      IP4Srv _ip4; ///< IPv4 address (host)
+      IP6Srv _ip6; ///< IPv6 address (host)
+
+      data(){}; // enable default construction.
+
+      /// Construct from IPv4 data.
+      explicit data(IP4Srv const &srv) : _ip4(srv) {}
+      explicit data(sockaddr_in const *s) : _ip4(s) {}
+
+      /// Construct from IPv6 data.
+      explicit data(IP6Srv const &srv) : _ip6(srv) {}
+      explicit data(sockaddr_in6 const *s) : _ip6(s) {}
+
+      /// @return A generic address.
+      IPAddr addr(sa_family_t f) const;
+
+      /// @return The port in host order.
+      constexpr in_port_t port(sa_family_t f) const;
+    } _srv;
+
+    sa_family_t _family = AF_UNSPEC; ///< Protocol family.
+  };
+
+  // --- Implementation
+
+  inline IP4Srv::IP4Srv(IP4Addr addr, in_port_t port) : _addr(addr), _port(port) {}
+  inline IP4Srv::IP4Srv(IPSrv const &that) : IP4Srv(that.is_ip4() ? that.ip4() : self_type{}) {}
+
+  inline auto
+  IP4Srv::assign(IP4Addr const &addr) -> self_type &
+  {
+    _addr = addr;
+    return *this;
+  }
+  inline auto
+  IP4Srv::assign(in_port_t port) -> self_type &
+  {
+    _port = port;
+    return *this;
+  }
+  inline auto
+  IP4Srv::assign(IP4Addr const &addr, in_port_t port) -> self_type &
+  {
+    _addr = addr;
+    _port = port;
+    return *this;
+  }
+  inline auto
+  IP4Srv::assign(sockaddr_in const *s) -> self_type &
+  {
+    _addr = s;
+    _port = ntohs(s->sin_port);
+    return *this;
+  }
+  inline constexpr IP4Srv::operator IP4Addr const &() const
+  {
+    return _addr;
+  }
+  inline constexpr IP4Addr const &
+  IP4Srv::addr() const
+  {
+    return _addr;
+  }
+  inline in_port_t
+  IP4Srv::host_order_port() const
+  {
+    return _port;
+  }
+  inline in_port_t
+  IP4Srv::network_order_port() const
+  {
+    return htons(_port);
+  }
+  inline constexpr sa_family_t
+  IP4Srv::family()
+  {
+    return AF_INET;
+  }
+
+  inline bool
+  IP4Srv::operator==(IP4Srv::self_type that) const
+  {
+    return _addr == that._addr && _port == that._port;
+  }
+  inline bool
+  IP4Srv::operator!=(IP4Srv::self_type that) const
+  {
+    return _addr != that._addr || _port != that._port;
+  }
+  inline bool
+  IP4Srv::operator<(IP4Srv::self_type that) const
+  {
+    return _addr < that._addr || (_addr == that._addr && _port < that._port);
+  }
+  inline bool
+  IP4Srv::operator<=(IP4Srv::self_type const &that) const
+  {
+    return _addr < that._addr || (_addr == that._addr && _port <= that._port);
+  }
+  inline bool
+  IP4Srv::operator>(IP4Srv::self_type const &that) const
+  {
+    return that < *this;
+  }
+  inline bool
+  IP4Srv::operator>=(IP4Srv::self_type const &that) const
+  {
+    return that <= *this;
+  }
+
+  /// --- IPv6
+
+  inline IP6Srv::IP6Srv(IP6Addr addr, in_port_t port) : _addr(addr), _port(port) {}
+  inline IP6Srv::IP6Srv(IPSrv const &that) : IP6Srv(that.is_ip6() ? that.ip6() : self_type{}) {}
+  inline IP6Srv::IP6Srv(const sockaddr_in6 *s) : _addr(s->sin6_addr), _port(ntohs(s->sin6_port)) {}
+
+  inline constexpr IP6Srv::operator IP6Addr const &() const
+  {
+    return _addr;
+  }
+  inline constexpr IP6Addr const &
+  IP6Srv::addr() const
+  {
+    return _addr;
+  }
+  inline in_port_t
+  IP6Srv::host_order_port() const
+  {
+    return _port;
+  }
+  inline in_port_t
+  IP6Srv::network_order_port() const
+  {
+    return htons(_port);
+  }
+  inline constexpr sa_family_t
+  IP6Srv::family()
+  {
+    return AF_INET6;
+  }
+
+  inline bool
+  IP6Srv::operator==(IP6Srv::self_type that) const
+  {
+    return _addr == that._addr && _port == that._port;
+  }
+  inline bool
+  IP6Srv::operator!=(IP6Srv::self_type that) const
+  {
+    return _port != that._port || _addr != that._addr;
+  }
+  inline bool
+  IP6Srv::operator<(IP6Srv::self_type that) const
+  {
+    return _addr < that._addr || (_addr == that._addr && _port < that._port);
+  }
+  inline bool
+  IP6Srv::operator<=(IP6Srv::self_type const &that) const
+  {
+    return _addr < that._addr || (_addr == that._addr && _port <= that._port);
+  }
+  inline bool
+  IP6Srv::operator>(IP6Srv::self_type const &that) const
+  {
+    return that < *this;
+  }
+  inline bool
+  IP6Srv::operator>=(IP6Srv::self_type const &that) const
+  {
+    return that <= *this;
+  }
+
+  inline auto
+  IP6Srv::assign(in_port_t port) -> self_type &
+  {
+    _port = port;
+    return *this;
+  }
+
+  inline auto
+  IP6Srv::assign(IP6Addr const &addr) -> self_type &
+  {
+    _addr = addr;
+    return *this;
+  }
+
+  inline auto
+  IP6Srv::assign(IP6Addr const &addr, in_port_t port) -> self_type &
+  {
+    _addr = addr;
+    _port = port;
+    return *this;
+  }
+
+  inline auto
+  IP6Srv::assign(sockaddr_in6 const *s) -> self_type &
+  {
+    _addr = s;
+    _port = ntohs(s->sin6_port);
+    return *this;
+  }
+
+  // --- Generic SRV
+
+  inline IPSrv::IPSrv(const sockaddr_in *s) : _srv(s), _family(AF_INET) {}
+  inline IPSrv::IPSrv(const sockaddr_in6 *s) : _srv(s), _family(AF_INET6) {}
+  inline IPSrv::IPSrv(const sockaddr *sa)
+  {
+    this->assign(sa);
+  }
+
+  inline IPAddr
+  IPSrv::addr() const
+  {
+    return _srv.addr(_family);
+  }
+  inline constexpr sa_family_t
+  IPSrv::family() const
+  {
+    return _family;
+  }
+  inline bool
+  IPSrv::is_ip4() const
+  {
+    return _family == AF_INET;
+  }
+  inline bool
+  IPSrv::is_ip6() const
+  {
+    return _family == AF_INET6;
+  }
+
+  inline auto
+  IPSrv::assign(IP6Addr const &addr) -> self_type &
+  {
+    _srv._ip6.assign(addr, this->host_order_port());
+    _family = addr.family();
+    return *this;
+  }
+
+  inline auto
+  IPSrv::assign(IP4Addr const &addr, in_port_t port) -> self_type &
+  {
+    _srv._ip4.assign(addr, port);
+    _family = addr.family();
+    return *this;
+  }
+
+  inline auto
+  IPSrv::assign(IP6Addr const &addr, in_port_t port) -> self_type &
+  {
+    _srv._ip6.assign(addr, port);
+    _family = addr.family();
+    return *this;
+  }
+
+  inline auto
+  IPSrv::assign(IP4Addr const &addr) -> self_type &
+  {
+    _srv._ip4.assign(addr, this->host_order_port());
+    _family = addr.family();
+    return *this;
+  }
+
+  inline auto
+  IPSrv::assign(in_port_t port) -> self_type &
+  {
+    if (this->is_ip4()) {
+      _srv._ip4.assign(port);
+    } else if (this->is_ip6()) {
+      _srv._ip6.assign(port);
+    }
+    return *this;
+  }
+
+  inline auto
+  IPSrv::assign(IPAddr const &addr) -> self_type &
+  {
+    if (addr.is_ip4()) {
+      this->assign(addr.ip4());
+    } else if (addr.is_ip6()) {
+      this->assign(addr.ip6());
+    }
+    return *this;
+  }
+
+  inline auto
+  IPSrv::assign(IPAddr const &addr, in_port_t port) -> self_type &
+  {
+    if (addr.is_ip4()) {
+      this->assign(addr.ip4(), port);
+      _family = addr.family();
+    } else if (addr.is_ip6()) {
+      this->assign(addr.ip6(), port);
+      _family = addr.family();
+    }
+    return *this;
+  }
+
+  inline auto
+  IPSrv::operator=(IP4Srv const &that) -> self_type &
+  {
+    _family   = that.family();
+    _srv._ip4 = that;
+    return *this;
+  }
+
+  inline auto
+  IPSrv::operator=(IP6Srv const &that) -> self_type &
+  {
+    _family   = that.family();
+    _srv._ip6 = that;
+    return *this;
+  }
+
+  inline auto
+  IPSrv::assign(sockaddr_in const *s) -> self_type &
+  {
+    _family = _srv._ip4.family();
+    _srv._ip4.assign(s);
+    return *this;
+  }
+
+  inline auto
+  IPSrv::assign(sockaddr_in6 const *s) -> self_type &
+  {
+    _family = _srv._ip6.family();
+    _srv._ip6.assign(s);
+    return *this;
+  }
+
+  inline constexpr in_port_t
+  IPSrv::host_order_port() const
+  {
+    return _srv.port(_family);
+  }
+
+  inline in_port_t
+  IPSrv::network_order_port() const
+  {
+    return ntohs(_srv.port(_family));
+  }
+
+  inline IPAddr
+  IPSrv::data::addr(sa_family_t f) const
+  {
+    return (f == AF_INET) ? _ip4.addr() : (f == AF_INET6) ? _ip6.addr() : IPAddr::INVALID;
+  }
+
+  constexpr inline in_port_t
+  IPSrv::data::port(sa_family_t f) const
+  {
+    return (f == AF_INET) ? _ip4.host_order_port() : (f == AF_INET6) ? _ip6.host_order_port() : 0;
+  }
+  // --- Independent comparisons.
+
+  inline bool
+  operator==(IPSrv const &lhs, IP4Srv const &rhs)
+  {
+    return lhs.is_ip4() && lhs.ip4() == rhs;
+  }
+
+  inline bool
+  operator==(IP4Srv const &lhs, IPSrv const &rhs)
+  {
+    return rhs.is_ip4() && rhs.ip4() == lhs;
+  }
+
+  inline bool
+  operator!=(IPSrv const &lhs, IP4Srv const &rhs)
+  {
+    return !lhs.is_ip4() || lhs.ip4() != rhs;
+  }
+
+  inline bool
+  operator!=(IP4Srv const &lhs, IPSrv const &rhs)
+  {
+    return !rhs.is_ip4() || rhs.ip4() != lhs;
+  }
+
+  inline bool
+  operator<(IPSrv const &lhs, IP4Srv const &rhs)
+  {
+    return lhs.is_ip4() && lhs.ip4() < rhs;
+  }
+
+  inline bool
+  operator<(IP4Srv const &lhs, IPSrv const &rhs)
+  {
+    return rhs.is_ip4() && lhs < rhs.ip4();
+  }
+
+  inline bool
+  operator<=(IPSrv const &lhs, IP4Srv const &rhs)
+  {
+    return lhs.is_ip4() && lhs.ip4() <= rhs;
+  }
+
+  inline bool
+  operator<=(IP4Srv const &lhs, IPSrv const &rhs)
+  {
+    return rhs.is_ip4() && lhs <= rhs.ip4();
+  }
+
+  inline bool
+  operator>(IPSrv const &lhs, IP4Srv const &rhs)
+  {
+    return lhs.is_ip4() && lhs.ip4() > rhs;
+  }
+
+  inline bool
+  operator>(IP4Srv const &lhs, IPSrv const &rhs)
+  {
+    return rhs.is_ip4() && lhs > rhs.ip4();
+  }
+
+  inline bool
+  operator>=(IPSrv const &lhs, IP4Srv const &rhs)
+  {
+    return lhs.is_ip4() && lhs.ip4() >= rhs;
+  }
+
+  inline bool
+  operator>=(IP4Srv const &lhs, IPSrv const &rhs)
+  {
+    return rhs.is_ip4() && lhs >= rhs.ip4();
+  }
+
+  inline bool
+  operator==(IPSrv const &lhs, IP6Srv const &rhs)
+  {
+    return lhs.is_ip6() && lhs.ip6() == rhs;
+  }
+
+  inline bool
+  operator==(IP6Srv const &lhs, IPSrv const &rhs)
+  {
+    return rhs.is_ip6() && rhs.ip6() == lhs;
+  }
+
+  inline bool
+  operator!=(IPSrv const &lhs, IP6Srv const &rhs)
+  {
+    return !lhs.is_ip6() || lhs.ip6() != rhs;
+  }
+
+  inline bool
+  operator!=(IP6Srv const &lhs, IPSrv const &rhs)
+  {
+    return !rhs.is_ip6() || rhs.ip6() != lhs;
+  }
+
+  inline bool
+  operator<(IPSrv const &lhs, IP6Srv const &rhs)
+  {
+    return lhs.is_ip6() && lhs.ip6() < rhs;
+  }
+
+  inline bool
+  operator<(IP6Srv const &lhs, IPSrv const &rhs)
+  {
+    return rhs.is_ip6() && lhs < rhs.ip6();
+  }
+
+  inline bool
+  operator<=(IPSrv const &lhs, IP6Srv const &rhs)
+  {
+    return lhs.is_ip6() && lhs.ip6() <= rhs;
+  }
+
+  inline bool
+  operator<=(IP6Srv const &lhs, IPSrv const &rhs)
+  {
+    return rhs.is_ip6() && lhs <= rhs.ip6();
+  }
+
+  inline bool
+  operator>(IPSrv const &lhs, IP6Srv const &rhs)
+  {
+    return lhs.is_ip6() && lhs.ip6() > rhs;
+  }
+
+  inline bool
+  operator>(IP6Srv const &lhs, IPSrv const &rhs)
+  {
+    return rhs.is_ip6() && lhs > rhs.ip6();
+  }
+
+  inline bool
+  operator>=(IPSrv const &lhs, IP6Srv const &rhs)
+  {
+    return lhs.is_ip6() && lhs.ip6() >= rhs;
+  }
+
+  inline bool
+  operator>=(IP6Srv const &lhs, IPSrv const &rhs)
+  {
+    return rhs.is_ip6() && lhs >= rhs.ip6();
+  }
+
+  // --- Cross address equality
+
+  inline bool
+  operator==(IPSrv const &lhs, IP4Addr const &rhs)
+  {
+    return lhs.is_ip4() && lhs.ip4() == rhs;
+  }
+
+  inline bool
+  operator==(IP4Addr const &lhs, IPSrv const &rhs)
+  {
+    return rhs.is_ip4() && lhs == rhs.ip4();
+  }
+
+  inline bool
+  operator!=(IPSrv const &lhs, IP4Addr const &rhs)
+  {
+    return !lhs.is_ip4() || lhs.ip4() != rhs;
+  }
+
+  inline bool
+  operator!=(IP4Addr const &lhs, IPSrv const &rhs)
+  {
+    return !rhs.is_ip4() || lhs != rhs.ip4();
+  }
+
+  inline bool
+  operator==(IPSrv const &lhs, IP6Addr const &rhs)
+  {
+    return lhs.is_ip6() && lhs.ip6() == rhs;
+  }
+
+  inline bool
+  operator==(IP6Addr const &lhs, IPSrv const &rhs)
+  {
+    return rhs.is_ip6() && lhs == rhs.ip6();
+  }
+
+  inline bool
+  operator!=(IPSrv const &lhs, IP6Addr const &rhs)
+  {
+    return !lhs.is_ip6() || lhs.ip6() != rhs;
+  }
+
+  inline bool
+  operator!=(IP6Addr const &lhs, IPSrv const &rhs)
+  {
+    return !rhs.is_ip6() || lhs != rhs.ip6();
+  }
+
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/include/swoc/IntrusiveDList.h
+++ b/code/include/swoc/IntrusiveDList.h
@@ -18,1185 +18,1263 @@
 
 #include "swoc/swoc_version.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
-/** Intrusive doubly linked list container.
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  /** Intrusive doubly linked list container.
 
-    This holds items in a doubly linked list using links in the items. Items are placed in the list
-    by changing the pointers. An item can be in only one list for a set of links, but an item can
-    contain multiple sets of links. This requires different specializations of this template because
-    link access is part of the type specification. Memory for items is not managed by this class -
-    instances must be allocated and released elsewhere. In particular removing an item from the list
-    does not destruct or free the item.
+      This holds items in a doubly linked list using links in the items. Items are placed in the list
+      by changing the pointers. An item can be in only one list for a set of links, but an item can
+      contain multiple sets of links. This requires different specializations of this template because
+      link access is part of the type specification. Memory for items is not managed by this class -
+      instances must be allocated and released elsewhere. In particular removing an item from the list
+      does not destruct or free the item.
 
-    Access to the links is described by a linkage class which is required to contain the following
-    members:
+      Access to the links is described by a linkage class which is required to contain the following
+      members:
 
-    - The static method @c next_ptr which returns a reference to the pointer to the next item.
+      - The static method @c next_ptr which returns a reference to the pointer to the next item.
 
-    - The static method @c prev_ptr which returns a reference to the pointer to the previous item.
+      - The static method @c prev_ptr which returns a reference to the pointer to the previous item.
 
-    The pointer methods take a single argument of @c Item* and must return a reference to a pointer
-    instance. This type is deduced from the methods and is not explicitly specified. It must be
-    cheaply copyable and stateless.
+      The pointer methods take a single argument of @c Item* and must return a reference to a pointer
+      instance. This type is deduced from the methods and is not explicitly specified. It must be
+      cheaply copyable and stateless.
 
-    It is the responsibility of the item class to initialize the link pointers. When an item is
-    removed from the list the link pointers are set to @c nullptr.
+      It is the responsibility of the item class to initialize the link pointers. When an item is
+      removed from the list the link pointers are set to @c nullptr.
 
-    An example declaration woudl be
+      An example declaration woudl be
 
-    @code
-      // Item in the list.
-      struct Thing {
-        Thing* _next {nullptr};
-        Thing* _prev {nullptr};
-        Data _payload;
+      @code
+        // Item in the list.
+        struct Thing {
+          Thing* _next {nullptr};
+          Thing* _prev {nullptr};
+          Data _payload;
 
-        // Linkage descriptor.
-        struct Linkage {
-          static Thing*& next_ptr(Thing* Thing) { return Thing->_next; }
-          static Thing*& prev_ptr(Thing* Thing) { return Thing->_prev; }
+          // Linkage descriptor.
+          struct Linkage {
+            static Thing*& next_ptr(Thing* Thing) { return Thing->_next; }
+            static Thing*& prev_ptr(Thing* Thing) { return Thing->_prev; }
+          };
         };
-      };
 
-      using ThingList = IntrusiveDList<Thing::Linkage>;
-    @endcode
+        using ThingList = IntrusiveDList<Thing::Linkage>;
+      @endcode
 
-    Item access is done by using either STL style iteration, or direct access to the member
-    pointers. A client can have its own mechanism for getting an element to start, or use the @c
-    head and/or @c tail methods to get the first and last elements in the list respectively. Note if
-    the list is empty then @c nullptr will be returned. There are simple and fast conversions
-    between item pointers and iterators.
+      Item access is done by using either STL style iteration, or direct access to the member
+      pointers. A client can have its own mechanism for getting an element to start, or use the @c
+      head and/or @c tail methods to get the first and last elements in the list respectively. Note if
+      the list is empty then @c nullptr will be returned. There are simple and fast conversions
+      between item pointers and iterators.
 
-  */
-template <typename L> class IntrusiveDList {
-  friend class iterator;
-
-public:
-  using self_type = IntrusiveDList; ///< Self reference type.
-  /// The list item type.
-  // Get the result of calling the pointer access function, then strip off reference and pointer
-  // qualifiers. @c nullptr is used instead of the pointer type because this is done precisely
-  // to find that type.
-  using value_type = typename std::remove_pointer<
-    typename std::remove_reference<typename std::invoke_result<decltype(L::next_ptr), std::nullptr_t>::type>::type>::type;
-
-  /// Const iterator.
-  class const_iterator {
-    using self_type = const_iterator; ///< Self reference type.
-    friend class IntrusiveDList;
+    */
+  template <typename L> class IntrusiveDList
+  {
+    friend class iterator;
 
   public:
-    using list_type  = IntrusiveDList;                       ///< Container type.
-    using value_type = const typename list_type::value_type; /// Import for API compliance.
-    // STL algorithm compliance.
-    using iterator_category = std::bidirectional_iterator_tag;
-    using pointer           = value_type *;
-    using reference         = value_type &;
-    using difference_type   = int;
+    using self_type = IntrusiveDList; ///< Self reference type.
+    /// The list item type.
+    // Get the result of calling the pointer access function, then strip off reference and pointer
+    // qualifiers. @c nullptr is used instead of the pointer type because this is done precisely
+    // to find that type.
+    using value_type = typename std::remove_pointer<
+      typename std::remove_reference<typename std::invoke_result<decltype(L::next_ptr), std::nullptr_t>::type>::type>::type;
 
-    /// Default constructor.
-    const_iterator();
+    /// Const iterator.
+    class const_iterator
+    {
+      using self_type = const_iterator; ///< Self reference type.
+      friend class IntrusiveDList;
 
-    /// Pre-increment.
-    /// Move to the next element in the list.
-    /// @return The iterator.
-    self_type &operator++();
+    public:
+      using list_type  = IntrusiveDList;                       ///< Container type.
+      using value_type = const typename list_type::value_type; /// Import for API compliance.
+      // STL algorithm compliance.
+      using iterator_category = std::bidirectional_iterator_tag;
+      using pointer           = value_type *;
+      using reference         = value_type &;
+      using difference_type   = int;
 
-    /// Pre-decrement.
-    /// Move to the previous element in the list.
-    /// @return The iterator.
-    self_type &operator--();
+      /// Default constructor.
+      const_iterator();
 
-    /// Post-increment.
-    /// Move to the next element in the list.
-    /// @return The iterator value before the increment.
-    self_type operator++(int);
+      /// Pre-increment.
+      /// Move to the next element in the list.
+      /// @return The iterator.
+      self_type &operator++();
 
-    /// Post-decrement.
-    /// Move to the previous element in the list.
-    /// @return The iterator value before the decrement.
-    self_type operator--(int);
+      /// Pre-decrement.
+      /// Move to the previous element in the list.
+      /// @return The iterator.
+      self_type &operator--();
 
-    /// Dereference.
-    /// @return A reference to the referent.
-    value_type &operator*() const;
+      /// Post-increment.
+      /// Move to the next element in the list.
+      /// @return The iterator value before the increment.
+      self_type operator++(int);
 
-    /// Dereference.
-    /// @return A pointer to the referent.
-    value_type *operator->() const;
+      /// Post-decrement.
+      /// Move to the previous element in the list.
+      /// @return The iterator value before the decrement.
+      self_type operator--(int);
 
-    /// Convenience conversion to pointer type
-    /// Because of how this list is normally used, being able to pass an iterator as a pointer is quite convienent.
-    /// If the iterator isn't valid, it converts to @c nullptr.
-    operator value_type *() const;
+      /// Dereference.
+      /// @return A reference to the referent.
+      value_type &operator*() const;
 
-    /// Equality
-    bool operator==(self_type const &that) const;
+      /// Dereference.
+      /// @return A pointer to the referent.
+      value_type *operator->() const;
 
-    /// Inequality
-    bool operator!=(self_type const &that) const;
+      /// Convenience conversion to pointer type
+      /// Because of how this list is normally used, being able to pass an iterator as a pointer is quite convienent.
+      /// If the iterator isn't valid, it converts to @c nullptr.
+      operator value_type *() const;
 
-    /// Check if @c std::prev would be valid.
-    /// @return @c true if calling @c std::prev would yield a valid iterator.
-    /// @note Identical to @c has_predecessor.
-    bool has_prev() const;
+      /// Equality
+      bool operator==(self_type const &that) const;
 
-    /// Check if @c std::next would be valid.
-    /// @return @c true if calling @c std::next would yield a valid iterator.
-    bool has_next() const;
+      /// Inequality
+      bool operator!=(self_type const &that) const;
 
-    /// Check if there is a predecessor.
-    /// @return @c true if there is a predecessor element for the current element.
-    /// @note Identical to @c has_prev.
-    bool has_predecessor() const;
+      /// Check if @c std::prev would be valid.
+      /// @return @c true if calling @c std::prev would yield a valid iterator.
+      /// @note Identical to @c has_predecessor.
+      bool has_prev() const;
 
-    /// Check if there is a successor.
-    /// @return @c true if after incrementing, the iterator will reference a value.
-    /// @note This is subtly different from @c has_net. It is false for the last element in the
-    /// iteration. Even though incrementing such an iterator would valid, there would not be a
-    /// successor element.
-    bool has_successor() const;
+      /// Check if @c std::next would be valid.
+      /// @return @c true if calling @c std::next would yield a valid iterator.
+      bool has_next() const;
+
+      /// Check if there is a predecessor.
+      /// @return @c true if there is a predecessor element for the current element.
+      /// @note Identical to @c has_prev.
+      bool has_predecessor() const;
+
+      /// Check if there is a successor.
+      /// @return @c true if after incrementing, the iterator will reference a value.
+      /// @note This is subtly different from @c has_net. It is false for the last element in the
+      /// iteration. Even though incrementing such an iterator would valid, there would not be a
+      /// successor element.
+      bool has_successor() const;
+
+    protected:
+      // These are stored non-const to make implementing @c iterator easier. This class provides the required @c const
+      // protection.
+      list_type *_list{nullptr};                   ///< Needed to decrement from @c end() position.
+      typename list_type::value_type *_v{nullptr}; ///< Referenced element.
+
+      /// Internal constructor for containers.
+      const_iterator(const list_type *list, value_type *v);
+    };
+
+    /// Iterator for the list.
+    class iterator : public const_iterator
+    {
+      using self_type  = iterator;       ///< Self reference type.
+      using super_type = const_iterator; ///< Super class type.
+
+      friend class IntrusiveDList;
+
+    public:
+      using list_type  = IntrusiveDList;                 /// Must hoist this for direct use.
+      using value_type = typename list_type::value_type; /// Import for API compliance.
+      // STL algorithm compliance.
+      using iterator_category = std::bidirectional_iterator_tag;
+      using pointer           = value_type *;
+      using reference         = value_type &;
+
+      /// Default constructor.
+      iterator();
+
+      /// Pre-increment.
+      /// Move to the next element in the list.
+      /// @return The iterator.
+      self_type &operator++();
+
+      /// Pre-decrement.
+      /// Move to the previous element in the list.
+      /// @return The iterator.
+      self_type &operator--();
+
+      /// Post-increment.
+      /// Move to the next element in the list.
+      /// @return The iterator value before the increment.
+      self_type operator++(int);
+
+      /// Post-decrement.
+      /// Move to the previous element in the list.
+      /// @return The iterator value before the decrement.
+      self_type operator--(int);
+
+      /// Dereference.
+      /// @return A reference to the referent.
+      value_type &operator*() const;
+
+      /// Dereference.
+      /// @return A pointer to the referent.
+      value_type *operator->() const;
+
+      /// Convenience conversion to pointer type
+      /// Because of how this list is normally used, being able to pass an iterator as a pointer is quite convenient.
+      /// If the iterator isn't valid, it converts to @c nullptr.
+      operator value_type *() const;
+
+    protected:
+      /// Internal constructor for containers.
+      iterator(list_type *list, value_type *v);
+    };
+
+    /// Construct to empty list.
+    IntrusiveDList() = default;
+
+    IntrusiveDList(self_type const &that) = delete;
+
+    /// Move list to @a this and leave @a that empty.
+    IntrusiveDList(self_type &&that);
+
+    /// No copy assignment because items can't be in two lists and can't copy items.
+    self_type &operator=(const self_type &that) = delete;
+
+    /// Move @a that to @a this.
+    self_type &operator=(self_type &&that);
+
+    /// Empty check.
+    /// @return @c true if the list is empty.
+    bool empty() const;
+
+    /// Presence check (linear time).
+    /// @return @c true if @a v is in the list, @c false if not.
+    bool contains(const value_type *v) const;
+
+    /// Add @a elt as the first element in the list.
+    /// @return This container.
+    self_type &prepend(value_type *v);
+
+    /// Add @a elt as the last element in the list.
+    /// @return This container.
+    self_type &append(value_type *v);
+
+    /// Remove the first element of the list.
+    /// @return A poiner to the removed item, or @c nullptr if the list was empty.
+    value_type *take_head();
+
+    /// Remove the last element of the list.
+    /// @return A poiner to the removed item, or @c nullptr if the list was empty.
+    value_type *take_tail();
+
+    /// Insert a new element @a elt after @a target.
+    /// The caller is responsible for ensuring @a target is in this list and @a elt is not in a list.
+    /// @return This list.
+    self_type &insert_after(value_type *target, value_type *v);
+
+    /// Insert a new element @a v before @a target.
+    /// The caller is responsible for ensuring @a target is in this list and @a elt is not in a list.
+    /// @return This list.
+    self_type &insert_before(value_type *target, value_type *v);
+
+    /// Insert a new element @a elt after @a target.
+    /// If @a target is the end iterator, @a v is appended to the list.
+    /// @return This list.
+    self_type &insert_after(iterator const &target, value_type *v);
+
+    /// Insert a new element @a v before @a target.
+    /// If @a target is the end iterator, @a v is appended to the list.
+    /// @return This list.
+    self_type &insert_before(iterator const &target, value_type *v);
+
+    /// Take @a v out of this list.
+    /// @return The element after @a v.
+    value_type *erase(value_type *v);
+
+    /// Take the element at @a loc out of this list.
+    /// @return Iterator for the next element.
+    iterator erase(const iterator &loc);
+
+    /// Take elements out of the list.
+    /// Remove elements start with @a start up to but not including @a limit.
+    /// @return @a limit
+    iterator erase(const iterator &start, const iterator &limit);
+
+    /** The nth element of the list.
+     *
+     * @param n Index of target element.
+     * @return An iterator to the element, an empty iterator if @a n is too large.
+     *
+     * @note This is linear in @a n, use with caution.
+     */
+    iterator nth(unsigned n);
+
+    /** Remove and return an initial subsequence.
+     *
+     * @param n Number of elements.
+     * @return The list of elements.
+     *
+     * If @a n is more than the length of the list, the entire list is returned.
+     */
+    self_type take_prefix(unsigned n);
+
+    /** Remove and return an initial subsequence.
+     *
+     * @param n Number of elements.
+     * @return The list of elements.
+     *
+     * If @a n is more than the length of the list @a this is unchanged and an empty list returned.
+     */
+    self_type split_prefix(unsigned n);
+
+    /** Remove and return a trailing subsequence.
+     *
+     * @param n Number of elements.
+     * @return The list of elements.
+     *
+     * If @a n is more than the length of the list, the entire list is returned.
+     */
+    self_type take_suffix(unsigned n);
+
+    /** Remove and return a trailing subsequence.
+     *
+     * @param n Number of elements.
+     * @return The list of elements.
+     *
+     * If @a n is more than the length of the list, @a this is unchanged and an empty list returned.
+     */
+    self_type split_suffix(unsigned n);
+
+    /** Append a list.
+     *
+     * @param src List to append.
+     * @return @a this
+     *
+     * The elements are removed from @a src, which becomes empty.
+     */
+    self_type &append(self_type &src);
+
+    /** Prepend a list.
+     *
+     * @param src List to prepend.
+     * @return @a this
+     *
+     * The elements are removed from @a src, which becomes empty.
+     */
+    self_type &prepend(self_type &src);
+
+    /** Splice in a list after an existing element.
+     *
+     * @param target Element in the lsit.
+     * @param src List to splice.
+     * @return @a this
+     */
+    self_type &insert_after(value_type *target, self_type &src);
+
+    /** Splice in a list before an existing element.
+     *
+     * @param target Element in the lsit.
+     * @param src List to splice.
+     * @return @a this
+     */
+    self_type &insert_before(value_type *target, self_type &src);
+
+    /** Splice in a list after an existing element.
+     *
+     * @param target Element in the lsit.
+     * @param src List to splice.
+     * @return @a this
+     */
+    self_type &insert_after(iterator const &target, self_type &src);
+
+    /** Splice in a list before an existing element.
+     *
+     * @param target Element in the lsit.
+     * @param src List to splice.
+     * @return @a this
+     */
+    self_type &insert_before(iterator const &target, self_type &src);
+
+    /// Remove all elements.
+    /// @note @b No memory management is done!
+    /// @return This container.
+    self_type &clear();
+
+    /// @return Number of elements in the list.
+    size_t count() const;
+
+    /// Get an iterator to the first element.
+    iterator begin();
+
+    /// Get an iterator to the first element.
+    const_iterator begin() const;
+
+    /// Get an iterator past the last element.
+    iterator end();
+
+    /// Get an iterator past the last element.
+    const_iterator end() const;
+
+    /** Get an iterator for the item @a v.
+     *
+     * It is the responsibility of the caller that @a v is in the list. The purpose is to make
+     * iteration starting at a specific element easier (i.e. all of the link manipulation and checking
+     * is done by the iterator).
+     *
+     * @return An @c iterator that refers to @a v.
+     */
+    iterator iterator_for(value_type *v);
+
+    const_iterator iterator_for(const value_type *v) const;
+
+    /// Get the first element.
+    value_type *head();
+
+    const value_type *head() const;
+
+    /// Get the last element.
+    value_type *tail();
+
+    const value_type *tail() const;
+
+    /** Apply a functor to every element in the list.
+     * This iterates over the list correctly even if the functor destroys or removes elements.
+     */
+    template <typename F> self_type &apply(F &&f);
 
   protected:
-    // These are stored non-const to make implementing @c iterator easier. This class provides the required @c const
-    // protection.
-    list_type *_list{nullptr};                   ///< Needed to decrement from @c end() position.
-    typename list_type::value_type *_v{nullptr}; ///< Referenced element.
-
-    /// Internal constructor for containers.
-    const_iterator(const list_type *list, value_type *v);
+    value_type *_head{nullptr}; ///< First element in list.
+    value_type *_tail{nullptr}; ///< Last element in list.
+    size_t _count{0};           ///< Number of elements in list.
   };
 
-  /// Iterator for the list.
-  class iterator : public const_iterator {
-    using self_type  = iterator;       ///< Self reference type.
-    using super_type = const_iterator; ///< Super class type.
-
-    friend class IntrusiveDList;
-
-  public:
-    using list_type  = IntrusiveDList;                 /// Must hoist this for direct use.
-    using value_type = typename list_type::value_type; /// Import for API compliance.
-    // STL algorithm compliance.
-    using iterator_category = std::bidirectional_iterator_tag;
-    using pointer           = value_type *;
-    using reference         = value_type &;
-
-    /// Default constructor.
-    iterator();
-
-    /// Pre-increment.
-    /// Move to the next element in the list.
-    /// @return The iterator.
-    self_type &operator++();
-
-    /// Pre-decrement.
-    /// Move to the previous element in the list.
-    /// @return The iterator.
-    self_type &operator--();
-
-    /// Post-increment.
-    /// Move to the next element in the list.
-    /// @return The iterator value before the increment.
-    self_type operator++(int);
-
-    /// Post-decrement.
-    /// Move to the previous element in the list.
-    /// @return The iterator value before the decrement.
-    self_type operator--(int);
-
-    /// Dereference.
-    /// @return A reference to the referent.
-    value_type &operator*() const;
-
-    /// Dereference.
-    /// @return A pointer to the referent.
-    value_type *operator->() const;
-
-    /// Convenience conversion to pointer type
-    /// Because of how this list is normally used, being able to pass an iterator as a pointer is quite convenient.
-    /// If the iterator isn't valid, it converts to @c nullptr.
-    operator value_type *() const;
-
-  protected:
-    /// Internal constructor for containers.
-    iterator(list_type *list, value_type *v);
+  /** Utility class to provide intrusive links.
+   *
+   * @tparam T Class to link.
+   *
+   * The normal use is to declare this as a member to provide the links and the linkage functions.
+   * @code
+   * class Thing {
+   *   // blah blah
+   *   Thing* _next{nullptr};
+   *   Thing* _prev{nullptr};
+   *   using Linkage = swoc::IntrusiveLinkage<Thing, &Thing::_next, &Thing::_prev>;
+   * };
+   * using ThingList = swoc::IntrusiveDList<Thing::Linkage>;
+   * @endcode
+   * The template will default to the names '_next' and '_prev' therefore in the example it could
+   * have been done as
+   * @code
+   *   using Linkage = swoc::IntrusiveLinkage<Thing>;
+   * @endcode
+   */
+  template <typename T, T *(T::*NEXT) = &T::_next, T *(T::*PREV) = &T::_prev> struct IntrusiveLinkage {
+    static T *&next_ptr(T *thing); ///< Retrieve reference to next pointer.
+    static T *&prev_ptr(T *thing); ///< Retrive reference to previous pointer.
   };
 
-  /// Construct to empty list.
-  IntrusiveDList() = default;
+  template <typename T, T *(T::*NEXT), T *(T::*PREV)>
+  T *&
+  IntrusiveLinkage<T, NEXT, PREV>::next_ptr(T *thing)
+  {
+    return thing->*NEXT;
+  }
 
-  IntrusiveDList(self_type const &that) = delete;
+  template <typename T, T *(T::*NEXT), T *(T::*PREV)>
+  T *&
+  IntrusiveLinkage<T, NEXT, PREV>::prev_ptr(T *thing)
+  {
+    return thing->*PREV;
+  }
 
-  /// Move list to @a this and leave @a that empty.
-  IntrusiveDList(self_type &&that);
-
-  /// No copy assignment because items can't be in two lists and can't copy items.
-  self_type &operator=(const self_type &that) = delete;
-
-  /// Move @a that to @a this.
-  self_type &operator=(self_type &&that);
-
-  /// Empty check.
-  /// @return @c true if the list is empty.
-  bool empty() const;
-
-  /// Presence check (linear time).
-  /// @return @c true if @a v is in the list, @c false if not.
-  bool contains(const value_type *v) const;
-
-  /// Add @a elt as the first element in the list.
-  /// @return This container.
-  self_type &prepend(value_type *v);
-
-  /// Add @a elt as the last element in the list.
-  /// @return This container.
-  self_type &append(value_type *v);
-
-  /// Remove the first element of the list.
-  /// @return A poiner to the removed item, or @c nullptr if the list was empty.
-  value_type *take_head();
-
-  /// Remove the last element of the list.
-  /// @return A poiner to the removed item, or @c nullptr if the list was empty.
-  value_type *take_tail();
-
-  /// Insert a new element @a elt after @a target.
-  /// The caller is responsible for ensuring @a target is in this list and @a elt is not in a list.
-  /// @return This list.
-  self_type &insert_after(value_type *target, value_type *v);
-
-  /// Insert a new element @a v before @a target.
-  /// The caller is responsible for ensuring @a target is in this list and @a elt is not in a list.
-  /// @return This list.
-  self_type &insert_before(value_type *target, value_type *v);
-
-  /// Insert a new element @a elt after @a target.
-  /// If @a target is the end iterator, @a v is appended to the list.
-  /// @return This list.
-  self_type &insert_after(iterator const &target, value_type *v);
-
-  /// Insert a new element @a v before @a target.
-  /// If @a target is the end iterator, @a v is appended to the list.
-  /// @return This list.
-  self_type &insert_before(iterator const &target, value_type *v);
-
-  /// Take @a v out of this list.
-  /// @return The element after @a v.
-  value_type *erase(value_type *v);
-
-  /// Take the element at @a loc out of this list.
-  /// @return Iterator for the next element.
-  iterator erase(const iterator &loc);
-
-  /// Take elements out of the list.
-  /// Remove elements start with @a start up to but not including @a limit.
-  /// @return @a limit
-  iterator erase(const iterator &start, const iterator &limit);
-
-  /** The nth element of the list.
+  /** Utility cast to change the underlying type of a pointer reference.
    *
-   * @param n Index of target element.
-   * @return An iterator to the element, an empty iterator if @a n is too large.
+   * @tparam T The resulting pointer reference type.
+   * @tparam P The starting pointer reference type.
+   * @param p A reference to pointer to @a P.
+   * @return A reference to the same pointer memory of type @c T*&.
    *
-   * @note This is linear in @a n, use with caution.
+   * This changes a reference to a pointer to @a P to a reference to a pointer to @a T. This is useful
+   * for intrusive links that are inherited. For instance
+   *
+   * @code
+   * class Thing { Thing* _next; ... }
+   * class BetterThing : public Thing { ... };
+   * @endcode
+   *
+   * To make @c BetterThing work with an intrusive container without making new link members,
+   *
+   * @code
+   * static BetterThing*& next_ptr(BetterThing* bt) {
+   *   return swoc::ptr_ref_cast<BetterThing>(_next);
+   * }
+   * @endcode
+   *
+   * This is both convenient and gets around aliasing warnings from the compiler that can arise from
+   * using @c reinterpret_cast.
    */
-  iterator nth(unsigned n);
+  template <typename T, typename P>
+  T *&
+  ptr_ref_cast(P *&p)
+  {
+    union {
+      P **_p;
+      T **_t;
+    } u{&p};
+    return *(u._t);
+  }
 
-  /** Remove and return an initial subsequence.
+  /** Utility class to provide intrusive links.
    *
-   * @param n Number of elements.
-   * @return The list of elements.
+   * @tparam T Class to link.
    *
-   * If @a n is more than the length of the list, the entire list is returned.
+   * The normal use is to declare this as a member to provide the links and the linkage functions.
+   * @code
+   * class Thing {
+   *   // blah blah
+   *   Thing* _next{nullptr};
+   *   Thing* _prev{nullptr};
+   *   using Linkage = swoc::IntrusiveLinkage<Thing, &Thing::_next, &Thing::_prev>;
+   * };
+   * using ThingList = swoc::IntrusiveDList<Thing::Linkage>;
+   * @endcode
+   * The template will default to the names '_next' and '_prev' therefore in the example it could
+   * have been done as
+   * @code
+   *   using Linkage = swoc::IntrusiveLinkage<Thing>;
+   * @endcode
    */
-  self_type take_prefix(unsigned n);
-
-  /** Remove and return an initial subsequence.
-   *
-   * @param n Number of elements.
-   * @return The list of elements.
-   *
-   * If @a n is more than the length of the list @a this is unchanged and an empty list returned.
-   */
-  self_type split_prefix(unsigned n);
-
-  /** Remove and return a trailing subsequence.
-   *
-   * @param n Number of elements.
-   * @return The list of elements.
-   *
-   * If @a n is more than the length of the list, the entire list is returned.
-   */
-  self_type take_suffix(unsigned n);
-
-  /** Remove and return a trailing subsequence.
-   *
-   * @param n Number of elements.
-   * @return The list of elements.
-   *
-   * If @a n is more than the length of the list, @a this is unchanged and an empty list returned.
-   */
-  self_type split_suffix(unsigned n);
-
-  /** Append a list.
-   *
-   * @param src List to append.
-   * @return @a this
-   *
-   * The elements are removed from @a src, which becomes empty.
-   */
-  self_type & append(self_type & src);
-
-  /** Prepend a list.
-   *
-   * @param src List to prepend.
-   * @return @a this
-   *
-   * The elements are removed from @a src, which becomes empty.
-   */
-  self_type & prepend(self_type & src);
-
-  /** Splice in a list after an existing element.
-   *
-   * @param target Element in the lsit.
-   * @param src List to splice.
-   * @return @a this
-   */
-  self_type &insert_after(value_type *target, self_type & src);
-
-  /** Splice in a list before an existing element.
-   *
-   * @param target Element in the lsit.
-   * @param src List to splice.
-   * @return @a this
-   */
-  self_type &insert_before(value_type *target, self_type & src);
-
-  /** Splice in a list after an existing element.
-   *
-   * @param target Element in the lsit.
-   * @param src List to splice.
-   * @return @a this
-   */
-  self_type &insert_after(iterator const &target, self_type & src);
-
-  /** Splice in a list before an existing element.
-   *
-   * @param target Element in the lsit.
-   * @param src List to splice.
-   * @return @a this
-   */
-  self_type &insert_before(iterator const &target, self_type & src);
-
-  /// Remove all elements.
-  /// @note @b No memory management is done!
-  /// @return This container.
-  self_type &clear();
-
-  /// @return Number of elements in the list.
-  size_t count() const;
-
-  /// Get an iterator to the first element.
-  iterator begin();
-
-  /// Get an iterator to the first element.
-  const_iterator begin() const;
-
-  /// Get an iterator past the last element.
-  iterator end();
-
-  /// Get an iterator past the last element.
-  const_iterator end() const;
-
-  /** Get an iterator for the item @a v.
-   *
-   * It is the responsibility of the caller that @a v is in the list. The purpose is to make
-   * iteration starting at a specific element easier (i.e. all of the link manipulation and checking
-   * is done by the iterator).
-   *
-   * @return An @c iterator that refers to @a v.
-   */
-  iterator iterator_for(value_type *v);
-
-  const_iterator iterator_for(const value_type *v) const;
-
-  /// Get the first element.
-  value_type *head();
-
-  const value_type *head() const;
-
-  /// Get the last element.
-  value_type *tail();
-
-  const value_type *tail() const;
-
-  /** Apply a functor to every element in the list.
-   * This iterates over the list correctly even if the functor destroys or removes elements.
-   */
-  template <typename F> self_type &apply(F &&f);
-
-protected:
-  value_type *_head{nullptr}; ///< First element in list.
-  value_type *_tail{nullptr}; ///< Last element in list.
-  size_t _count{0};           ///< Number of elements in list.
-};
-
-/** Utility class to provide intrusive links.
- *
- * @tparam T Class to link.
- *
- * The normal use is to declare this as a member to provide the links and the linkage functions.
- * @code
- * class Thing {
- *   // blah blah
- *   Thing* _next{nullptr};
- *   Thing* _prev{nullptr};
- *   using Linkage = swoc::IntrusiveLinkage<Thing, &Thing::_next, &Thing::_prev>;
- * };
- * using ThingList = swoc::IntrusiveDList<Thing::Linkage>;
- * @endcode
- * The template will default to the names '_next' and '_prev' therefore in the example it could
- * have been done as
- * @code
- *   using Linkage = swoc::IntrusiveLinkage<Thing>;
- * @endcode
- */
-template <typename T, T *(T::*NEXT) = &T::_next, T *(T::*PREV) = &T::_prev> struct IntrusiveLinkage {
-  static T *&next_ptr(T *thing); ///< Retrieve reference to next pointer.
-  static T *&prev_ptr(T *thing); ///< Retrive reference to previous pointer.
-};
-
-template <typename T, T *(T::*NEXT), T *(T::*PREV)>
-T *&
-IntrusiveLinkage<T, NEXT, PREV>::next_ptr(T *thing) {
-  return thing->*NEXT;
-}
-
-template <typename T, T *(T::*NEXT), T *(T::*PREV)>
-T *&
-IntrusiveLinkage<T, NEXT, PREV>::prev_ptr(T *thing) {
-  return thing->*PREV;
-}
-
-/** Utility cast to change the underlying type of a pointer reference.
- *
- * @tparam T The resulting pointer reference type.
- * @tparam P The starting pointer reference type.
- * @param p A reference to pointer to @a P.
- * @return A reference to the same pointer memory of type @c T*&.
- *
- * This changes a reference to a pointer to @a P to a reference to a pointer to @a T. This is useful
- * for intrusive links that are inherited. For instance
- *
- * @code
- * class Thing { Thing* _next; ... }
- * class BetterThing : public Thing { ... };
- * @endcode
- *
- * To make @c BetterThing work with an intrusive container without making new link members,
- *
- * @code
- * static BetterThing*& next_ptr(BetterThing* bt) {
- *   return swoc::ptr_ref_cast<BetterThing>(_next);
- * }
- * @endcode
- *
- * This is both convenient and gets around aliasing warnings from the compiler that can arise from
- * using @c reinterpret_cast.
- */
-template <typename T, typename P>
-T *&
-ptr_ref_cast(P *&p) {
-  union {
-    P **_p;
-    T **_t;
-  } u{&p};
-  return *(u._t);
-}
-
-/** Utility class to provide intrusive links.
- *
- * @tparam T Class to link.
- *
- * The normal use is to declare this as a member to provide the links and the linkage functions.
- * @code
- * class Thing {
- *   // blah blah
- *   Thing* _next{nullptr};
- *   Thing* _prev{nullptr};
- *   using Linkage = swoc::IntrusiveLinkage<Thing, &Thing::_next, &Thing::_prev>;
- * };
- * using ThingList = swoc::IntrusiveDList<Thing::Linkage>;
- * @endcode
- * The template will default to the names '_next' and '_prev' therefore in the example it could
- * have been done as
- * @code
- *   using Linkage = swoc::IntrusiveLinkage<Thing>;
- * @endcode
- */
-template <typename T, typename L> struct IntrusiveLinkageRebind {
-  static T *&next_ptr(T *thing); ///< Retrieve reference to next pointer.
-  static T *&prev_ptr(T *thing); ///< Retrive reference to previous pointer.
-};
-
-template <typename T, typename L>
-T *&
-IntrusiveLinkageRebind<T, L>::next_ptr(T *thing) {
-  return ptr_ref_cast<T>(L::next_ptr(thing));
-}
-
-template <typename T, typename L>
-T *&
-IntrusiveLinkageRebind<T, L>::prev_ptr(T *thing) {
-  return ptr_ref_cast<T>(L::prev_ptr(thing));
-}
-
-template < typename T > struct IntrusiveLinks {
-  T * _next = nullptr;
-  T * _prev = nullptr;
-};
-
-template < typename T, IntrusiveLinks<T> (T::* links) > struct IntrusiveLinkDescriptor {
-  static T *&next_ptr(T *thing); ///< Retrieve reference to next pointer.
-  static T *&prev_ptr(T *thing); ///< Retrive reference to previous pointer.
-};
-
-// --- Implementation ---
-
-template <typename L> IntrusiveDList<L>::const_iterator::const_iterator() {}
-
-template <typename L>
-IntrusiveDList<L>::const_iterator::const_iterator(const list_type *list, value_type *v)
-  : _list(const_cast<list_type *>(list)), _v(const_cast<typename list_type::value_type *>(v)) {}
-
-template <typename L> IntrusiveDList<L>::iterator::iterator() {}
-
-template <typename L> IntrusiveDList<L>::iterator::iterator(list_type *list, value_type *v) : super_type(list, v) {}
-
-template <typename L>
-auto
-IntrusiveDList<L>::const_iterator::operator++() -> self_type & {
-  _v = L::next_ptr(_v);
-  return *this;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::iterator::operator++() -> self_type & {
-  this->super_type::operator++();
-  return *this;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::const_iterator::operator++(int) -> self_type {
-  self_type tmp(*this);
-  ++*this;
-  return tmp;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::iterator::operator++(int) -> self_type {
-  self_type tmp(*this);
-  ++*this;
-  return tmp;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::const_iterator::operator--() -> self_type & {
-  if (_v) {
-    _v = L::prev_ptr(_v);
-  } else if (_list) {
-    _v = _list->_tail;
-  }
-  return *this;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::iterator::operator--() -> self_type & {
-  this->super_type::operator--();
-  return *this;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::const_iterator::operator--(int) -> self_type {
-  self_type tmp(*this);
-  --*this;
-  return tmp;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::iterator::operator--(int) -> self_type {
-  self_type tmp(*this);
-  --*this;
-  return tmp;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::const_iterator::operator->() const -> value_type * {
-  return _v;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::iterator::operator->() const -> value_type * {
-  return super_type::_v;
-}
-
-template <typename L> IntrusiveDList<L>::const_iterator::operator value_type *() const {
-  return _v;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::const_iterator::operator*() const -> value_type & {
-  return *_v;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::iterator::operator*() const -> value_type & {
-  return *super_type::_v;
-}
-
-template <typename L> IntrusiveDList<L>::iterator::operator value_type *() const {
-  return super_type::_v;
-}
-
-/// --- Main class
-
-template <typename L>
-IntrusiveDList<L>::IntrusiveDList(self_type &&that) : _head(that._head), _tail(that._tail), _count(that._count) {
-  that.clear();
-}
-
-template <typename L>
-bool
-IntrusiveDList<L>::empty() const {
-  return _head == nullptr;
-}
-
-template <typename L>
-bool
-IntrusiveDList<L>::contains(const value_type *v) const {
-  for (auto thing = _head; thing; thing = L::next_ptr(thing)) {
-    if (thing == v)
-      return true;
-  }
-  return false;
-}
-
-template <typename L>
-bool
-IntrusiveDList<L>::const_iterator::operator==(self_type const &that) const {
-  return this->_v == that._v;
-}
-
-template <typename L>
-bool
-IntrusiveDList<L>::const_iterator::operator!=(self_type const &that) const {
-  return this->_v != that._v;
-}
-
-template <typename L>
-bool
-IntrusiveDList<L>::const_iterator::has_predecessor() const {
-  return _v ? nullptr != L::prev_ptr(_v) : !_list->empty();
-}
-
-template <typename L>
-bool
-IntrusiveDList<L>::const_iterator::has_prev() const {
-  return _v ? nullptr != L::prev_ptr(_v) : !_list->empty();
-}
-
-template <typename L>
-bool
-IntrusiveDList<L>::const_iterator::has_successor() const {
-  return _v && nullptr != L::next_ptr(_v);
-}
-
-template <typename L>
-bool
-IntrusiveDList<L>::const_iterator::has_next() const {
-  return nullptr != _v;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::prepend(value_type *v) -> self_type & {
-  L::prev_ptr(v) = nullptr;
-  if (nullptr != (L::next_ptr(v) = _head)) {
-    L::prev_ptr(_head) = v;
-  } else {
-    _tail = v; // transition empty -> non-empty
-  }
-  _head = v;
-  ++_count;
-  return *this;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::append(value_type *v) -> self_type & {
-  L::next_ptr(v) = nullptr;
-  if (nullptr != (L::prev_ptr(v) = _tail)) {
-    L::next_ptr(_tail) = v;
-  } else {
-    _head = v; // transition empty -> non-empty
-  }
-  _tail = v;
-  ++_count;
-  return *this;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::take_head() -> value_type * {
-  value_type *zret = _head;
-  if (_head) {
-    if (nullptr == (_head = L::next_ptr(_head))) {
-      _tail = nullptr; // transition non-empty -> empty
-    } else {
-      L::prev_ptr(_head) = nullptr;
-    }
-    L::next_ptr(zret) = L::prev_ptr(zret) = nullptr;
-    --_count;
-  }
-  return zret;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::take_tail() -> value_type * {
-  value_type *zret = _tail;
-  if (_tail) {
-    if (nullptr == (_tail = L::prev_ptr(_tail))) {
-      _head = nullptr; // transition non-empty -> empty
-    } else {
-      L::next_ptr(_tail) = nullptr;
-    }
-    L::next_ptr(zret) = L::prev_ptr(zret) = nullptr;
-    --_count;
-  }
-  return zret;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::insert_after(value_type *target, value_type *v) -> self_type & {
-  if (target) {
-    if (nullptr != (L::next_ptr(v) = L::next_ptr(target))) {
-      L::prev_ptr(L::next_ptr(v)) = v;
-    } else if (_tail == target) {
-      _tail = v;
-    }
-    L::prev_ptr(v)      = target;
-    L::next_ptr(target) = v;
-
-    ++_count;
-  } else {
-    this->append(v);
-  }
-  return *this;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::insert_after(iterator const &target, value_type *v) -> self_type & {
-  return this->insert_after(target._v, v);
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::insert_before(value_type *target, value_type *v) -> self_type & {
-  if (target) {
-    if (nullptr != (L::prev_ptr(v) = L::prev_ptr(target))) {
-      L::next_ptr(L::prev_ptr(v)) = v;
-    } else if (target == _head) {
-      _head = v;
-    }
-    L::next_ptr(v)      = target;
-    L::prev_ptr(target) = v;
-
-    ++_count;
-  } else {
-    this->append(v);
-  }
-  return *this;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::insert_before(iterator const &target, value_type *v) -> self_type & {
-  return this->insert_before(target._v, v);
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::insert_after(value_type *target, self_type & src) -> self_type & {
-  if (target && src._count > 0) {
-    if (_tail == target) {
-      this->append(src);
-    } else { // invariant - @a target is not tail therefore has a successor.
-      L::next_ptr(src._tail) = L::next_ptr(target); // link @a src tail to @a target successor
-      L::prev_ptr(L::next_ptr(src._tail)) = src._tail;
-
-      L::prev_ptr(src._head) = target; // link @a src head to @target
-      L::next_ptr(target) = src._head;
-
-      _count += src._count;
-      src.clear();
-    }
-  }
-  return *this;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::insert_after(iterator const &target, self_type & src) -> self_type & {
-  return this->insert_after(target._v, src);
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::insert_before(value_type *target, self_type & src) -> self_type & {
-  if (target && src._count > 0) {
-    if (_head == target) {
-      this->prepend(src);
-    } else { // invariant - @a target is not head and therefore has a predecessor.
-      L::prev_ptr(src._head) = L::prev_ptr(target); // link @a src head to @a target predecessor
-      L::next_ptr(L::prev_ptr(target)) = src._head;
-
-      L::next_ptr(src._tail) = target; // link @a src tail to @a target
-      L::prev_ptr(target) = src._tail;
-
-      _count += src._count;
-      src.clear();
-    }
-  }
-  return *this;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::insert_before(iterator const &target, self_type & src) -> self_type & {
-  return this->insert_before(target._v, src);
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::erase(value_type *v) -> value_type * {
-  value_type *zret{nullptr};
-
-  if (L::prev_ptr(v)) {
-    L::next_ptr(L::prev_ptr(v)) = L::next_ptr(v);
-  }
-  if (L::next_ptr(v)) {
-    zret                        = L::next_ptr(v);
-    L::prev_ptr(L::next_ptr(v)) = L::prev_ptr(v);
-  }
-  if (v == _head) {
-    _head = L::next_ptr(v);
-  }
-  if (v == _tail) {
-    _tail = L::prev_ptr(v);
-  }
-  L::prev_ptr(v) = L::next_ptr(v) = nullptr;
-  --_count;
-
-  return zret;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::erase(const iterator &loc) -> iterator {
-  return this->iterator_for(this->erase(loc._v));
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::erase(const iterator &first, const iterator &limit) -> iterator {
-  value_type *spot = first;
-  value_type *prev{L::prev_ptr(spot)};
-  if (prev) {
-    L::next_ptr(prev) = limit;
-  }
-  if (spot == _head) {
-    _head = limit;
-  }
-  // tail is only updated if @a limit is @a end (e.g., @c nullptr).
-  if (nullptr == limit) {
-    _tail = prev;
-  } else {
-    L::prev_ptr(limit) = prev;
-  }
-  // Clear links in removed elements.
-  while (spot != limit) {
-    value_type *target{spot};
-    spot                = L::next_ptr(spot);
-    L::prev_ptr(target) = L::next_ptr(target) = nullptr;
+  template <typename T, typename L> struct IntrusiveLinkageRebind {
+    static T *&next_ptr(T *thing); ///< Retrieve reference to next pointer.
+    static T *&prev_ptr(T *thing); ///< Retrive reference to previous pointer.
   };
 
-  return {limit._v, this};
-}
+  template <typename T, typename L>
+  T *&
+  IntrusiveLinkageRebind<T, L>::next_ptr(T *thing)
+  {
+    return ptr_ref_cast<T>(L::next_ptr(thing));
+  }
 
-template <typename L>
-auto
-IntrusiveDList<L>::operator=(self_type &&that) -> self_type & {
-  if (this != &that) {
-    this->_head  = that._head;
-    this->_tail  = that._tail;
-    this->_count = that._count;
+  template <typename T, typename L>
+  T *&
+  IntrusiveLinkageRebind<T, L>::prev_ptr(T *thing)
+  {
+    return ptr_ref_cast<T>(L::prev_ptr(thing));
+  }
+
+  template <typename T> struct IntrusiveLinks {
+    T *_next = nullptr;
+    T *_prev = nullptr;
+  };
+
+  template <typename T, IntrusiveLinks<T>(T::*links)> struct IntrusiveLinkDescriptor {
+    static T *&next_ptr(T *thing); ///< Retrieve reference to next pointer.
+    static T *&prev_ptr(T *thing); ///< Retrive reference to previous pointer.
+  };
+
+  // --- Implementation ---
+
+  template <typename L> IntrusiveDList<L>::const_iterator::const_iterator() {}
+
+  template <typename L>
+  IntrusiveDList<L>::const_iterator::const_iterator(const list_type *list, value_type *v)
+    : _list(const_cast<list_type *>(list)), _v(const_cast<typename list_type::value_type *>(v))
+  {
+  }
+
+  template <typename L> IntrusiveDList<L>::iterator::iterator() {}
+
+  template <typename L> IntrusiveDList<L>::iterator::iterator(list_type *list, value_type *v) : super_type(list, v) {}
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::const_iterator::operator++() -> self_type &
+  {
+    _v = L::next_ptr(_v);
+    return *this;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::iterator::operator++() -> self_type &
+  {
+    this->super_type::operator++();
+    return *this;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::const_iterator::operator++(int) -> self_type
+  {
+    self_type tmp(*this);
+    ++*this;
+    return tmp;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::iterator::operator++(int) -> self_type
+  {
+    self_type tmp(*this);
+    ++*this;
+    return tmp;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::const_iterator::operator--() -> self_type &
+  {
+    if (_v) {
+      _v = L::prev_ptr(_v);
+    } else if (_list) {
+      _v = _list->_tail;
+    }
+    return *this;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::iterator::operator--() -> self_type &
+  {
+    this->super_type::operator--();
+    return *this;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::const_iterator::operator--(int) -> self_type
+  {
+    self_type tmp(*this);
+    --*this;
+    return tmp;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::iterator::operator--(int) -> self_type
+  {
+    self_type tmp(*this);
+    --*this;
+    return tmp;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::const_iterator::operator->() const -> value_type *
+  {
+    return _v;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::iterator::operator->() const -> value_type *
+  {
+    return super_type::_v;
+  }
+
+  template <typename L> IntrusiveDList<L>::const_iterator::operator value_type *() const
+  {
+    return _v;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::const_iterator::operator*() const -> value_type &
+  {
+    return *_v;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::iterator::operator*() const -> value_type &
+  {
+    return *super_type::_v;
+  }
+
+  template <typename L> IntrusiveDList<L>::iterator::operator value_type *() const
+  {
+    return super_type::_v;
+  }
+
+  /// --- Main class
+
+  template <typename L>
+  IntrusiveDList<L>::IntrusiveDList(self_type &&that) : _head(that._head), _tail(that._tail), _count(that._count)
+  {
     that.clear();
   }
-  return *this;
-}
 
-template <typename L>
-size_t
-IntrusiveDList<L>::count() const {
-  return _count;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::begin() const -> const_iterator {
-  return const_iterator{this, _head};
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::begin() -> iterator {
-  return iterator{this, _head};
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::end() const -> const_iterator {
-  return const_iterator{this, nullptr};
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::end() -> iterator {
-  return iterator{this, nullptr};
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::iterator_for(value_type *v) -> iterator {
-  return iterator{this, v};
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::iterator_for(const value_type *v) const -> const_iterator {
-  return const_iterator{this, v};
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::tail() -> value_type * {
-  return _tail;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::tail() const -> const value_type * {
-  return _tail;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::head() -> value_type * {
-  return _head;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::head() const -> const value_type * {
-  return _head;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::clear() -> self_type & {
-  _head = _tail = nullptr;
-  _count        = 0;
-  return *this;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::nth(unsigned int n) -> iterator {
-  if (n >= _count) {
-    return {};
+  template <typename L>
+  bool
+  IntrusiveDList<L>::empty() const
+  {
+    return _head == nullptr;
   }
 
-  value_type * spot;
-  if (n < _count/2) { // closer to head, count from there..
-    spot = _head;
-    while (n-- > 0) { spot = L::next_ptr(spot); }
-  } else { // count from tail
-    spot = _tail;
-    unsigned idx = _count - 1;
-    while (idx-- > n) { spot = L::prev_ptr(spot); }
-  }
-  return iterator_for(spot);
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::take_prefix(unsigned int n) -> self_type {
-
-  if (n == 0) {
-    return {};
-  }
-
-  if (_count <= n) {
-    return std::move(*this);
-  }
-
-  // Invariant - there is at least one element that will not be taken.
-
-  self_type zret;
-  value_type * spot = this->nth(n); // new @a head for @a this
-
-  zret._count = n;
-  zret._head = _head;
-  zret._tail = L::prev_ptr(spot);
-  L::next_ptr(zret._tail) = nullptr;
-
-  _count -= n;
-  _head = spot;
-  L::prev_ptr(_head) = nullptr;
-
-  return zret;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::split_prefix(unsigned int n) -> self_type {
-  if (n <= _count) {
-    return this->take_prefix(n);
-  }
-  return {};
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::take_suffix(unsigned int n) -> self_type {
-
-  if (n == 0) {
-    return {};
-  }
-
-  if (_count <= n) {
-    return std::move(*this);
-  }
-
-  // Invariant - there is at least one element that will not be taken.
-
-  self_type zret;
-  value_type * spot = this->nth(_count - n - 1); // new @a tail for @a this
-
-  zret._count = n;
-  zret._head = L::next_ptr(spot);
-  L::prev_ptr(zret._head) = nullptr;
-  zret._tail = _tail;
-
-  _count -= n;
-  _tail = spot;
-  L::next_ptr(_tail) = nullptr;
-
-  return zret;
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::split_suffix(unsigned int n) -> self_type {
-  if (n <= _count) {
-    return this->take_suffix(n);
-  }
-  return {};
-}
-
-template <typename L>
-auto
-IntrusiveDList<L>::prepend(IntrusiveDList::self_type &src) -> self_type & {
-  if (src._count > 0) {
-    if (_count == 0) {
-      *this = std::move(src);
-    } else {
-      L::prev_ptr(_head)     = src._tail;
-      L::next_ptr(src._tail) = _head;
-      _count += src._count;
-      _head = src._head;
-      src.clear();
+  template <typename L>
+  bool
+  IntrusiveDList<L>::contains(const value_type *v) const
+  {
+    for (auto thing = _head; thing; thing = L::next_ptr(thing)) {
+      if (thing == v)
+        return true;
     }
+    return false;
   }
-  return *this;
-}
 
-template <typename L>
-auto
-IntrusiveDList<L>::append(IntrusiveDList::self_type &src) -> self_type & {
-  if (src._count > 0) {
-    if (_count == 0) {
-      *this = std::move(src);
+  template <typename L>
+  bool
+  IntrusiveDList<L>::const_iterator::operator==(self_type const &that) const
+  {
+    return this->_v == that._v;
+  }
+
+  template <typename L>
+  bool
+  IntrusiveDList<L>::const_iterator::operator!=(self_type const &that) const
+  {
+    return this->_v != that._v;
+  }
+
+  template <typename L>
+  bool
+  IntrusiveDList<L>::const_iterator::has_predecessor() const
+  {
+    return _v ? nullptr != L::prev_ptr(_v) : !_list->empty();
+  }
+
+  template <typename L>
+  bool
+  IntrusiveDList<L>::const_iterator::has_prev() const
+  {
+    return _v ? nullptr != L::prev_ptr(_v) : !_list->empty();
+  }
+
+  template <typename L>
+  bool
+  IntrusiveDList<L>::const_iterator::has_successor() const
+  {
+    return _v && nullptr != L::next_ptr(_v);
+  }
+
+  template <typename L>
+  bool
+  IntrusiveDList<L>::const_iterator::has_next() const
+  {
+    return nullptr != _v;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::prepend(value_type *v) -> self_type &
+  {
+    L::prev_ptr(v) = nullptr;
+    if (nullptr != (L::next_ptr(v) = _head)) {
+      L::prev_ptr(_head) = v;
     } else {
-      L::next_ptr(_tail)     = src._head;
-      L::prev_ptr(src._head) = _tail;
-      _count += src._count;
-      _tail = src._tail;
-      src.clear();
+      _tail = v; // transition empty -> non-empty
     }
+    _head = v;
+    ++_count;
+    return *this;
   }
-  return *this;
-}
 
-namespace detail {
-/// @cond INTERNAL_DETAIL
-// Make @c apply more convenient by allowing the function to take a reference type or pointer type
-// to the container elements. The pointer type is the base, plus a shim to convert from a reference
-// type functor to a pointer type. The complex return type definition forces only one, but
-// not both, to be valid for a particular functor. This also must be done via free functions and not
-// method overloads because the compiler forces a match up of method definitions and declarations
-// before any template instantiation.
-
-template <typename L, typename F>
-auto
-Intrusive_DList_Apply(IntrusiveDList<L> &list, F &&f)
-  -> decltype(f(*static_cast<typename IntrusiveDList<L>::value_type *>(nullptr)), list) {
-  return list.apply([&f](typename IntrusiveDList<L>::value_type *v) { return f(*v); });
-}
-
-template <typename L, typename F>
-auto
-Intrusive_DList_Apply(IntrusiveDList<L> &list, F &&f)
-  -> decltype(f(static_cast<typename IntrusiveDList<L>::value_type *>(nullptr)), list) {
-  auto spot{list.begin()};
-  auto limit{list.end()};
-  while (spot != limit) {
-    f(spot++); // post increment means @a spot is updated before @a f is applied.
+  template <typename L>
+  auto
+  IntrusiveDList<L>::append(value_type *v) -> self_type &
+  {
+    L::next_ptr(v) = nullptr;
+    if (nullptr != (L::prev_ptr(v) = _tail)) {
+      L::next_ptr(_tail) = v;
+    } else {
+      _head = v; // transition empty -> non-empty
+    }
+    _tail = v;
+    ++_count;
+    return *this;
   }
-  return list;
-}
-} // namespace detail
 
-template <typename L>
-template <typename F>
-auto
-IntrusiveDList<L>::apply(F &&f) -> self_type & {
-  return detail::Intrusive_DList_Apply(*this, f);
-}
-/// @endcond
-}} // namespace swoc::SWOC_VERSION_NS
+  template <typename L>
+  auto
+  IntrusiveDList<L>::take_head() -> value_type *
+  {
+    value_type *zret = _head;
+    if (_head) {
+      if (nullptr == (_head = L::next_ptr(_head))) {
+        _tail = nullptr; // transition non-empty -> empty
+      } else {
+        L::prev_ptr(_head) = nullptr;
+      }
+      L::next_ptr(zret) = L::prev_ptr(zret) = nullptr;
+      --_count;
+    }
+    return zret;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::take_tail() -> value_type *
+  {
+    value_type *zret = _tail;
+    if (_tail) {
+      if (nullptr == (_tail = L::prev_ptr(_tail))) {
+        _head = nullptr; // transition non-empty -> empty
+      } else {
+        L::next_ptr(_tail) = nullptr;
+      }
+      L::next_ptr(zret) = L::prev_ptr(zret) = nullptr;
+      --_count;
+    }
+    return zret;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::insert_after(value_type *target, value_type *v) -> self_type &
+  {
+    if (target) {
+      if (nullptr != (L::next_ptr(v) = L::next_ptr(target))) {
+        L::prev_ptr(L::next_ptr(v)) = v;
+      } else if (_tail == target) {
+        _tail = v;
+      }
+      L::prev_ptr(v)      = target;
+      L::next_ptr(target) = v;
+
+      ++_count;
+    } else {
+      this->append(v);
+    }
+    return *this;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::insert_after(iterator const &target, value_type *v) -> self_type &
+  {
+    return this->insert_after(target._v, v);
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::insert_before(value_type *target, value_type *v) -> self_type &
+  {
+    if (target) {
+      if (nullptr != (L::prev_ptr(v) = L::prev_ptr(target))) {
+        L::next_ptr(L::prev_ptr(v)) = v;
+      } else if (target == _head) {
+        _head = v;
+      }
+      L::next_ptr(v)      = target;
+      L::prev_ptr(target) = v;
+
+      ++_count;
+    } else {
+      this->append(v);
+    }
+    return *this;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::insert_before(iterator const &target, value_type *v) -> self_type &
+  {
+    return this->insert_before(target._v, v);
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::insert_after(value_type *target, self_type &src) -> self_type &
+  {
+    if (target && src._count > 0) {
+      if (_tail == target) {
+        this->append(src);
+      } else {                                                     // invariant - @a target is not tail therefore has a successor.
+        L::next_ptr(src._tail)              = L::next_ptr(target); // link @a src tail to @a target successor
+        L::prev_ptr(L::next_ptr(src._tail)) = src._tail;
+
+        L::prev_ptr(src._head) = target; // link @a src head to @target
+        L::next_ptr(target)    = src._head;
+
+        _count += src._count;
+        src.clear();
+      }
+    }
+    return *this;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::insert_after(iterator const &target, self_type &src) -> self_type &
+  {
+    return this->insert_after(target._v, src);
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::insert_before(value_type *target, self_type &src) -> self_type &
+  {
+    if (target && src._count > 0) {
+      if (_head == target) {
+        this->prepend(src);
+      } else { // invariant - @a target is not head and therefore has a predecessor.
+        L::prev_ptr(src._head)           = L::prev_ptr(target); // link @a src head to @a target predecessor
+        L::next_ptr(L::prev_ptr(target)) = src._head;
+
+        L::next_ptr(src._tail) = target; // link @a src tail to @a target
+        L::prev_ptr(target)    = src._tail;
+
+        _count += src._count;
+        src.clear();
+      }
+    }
+    return *this;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::insert_before(iterator const &target, self_type &src) -> self_type &
+  {
+    return this->insert_before(target._v, src);
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::erase(value_type *v) -> value_type *
+  {
+    value_type *zret{nullptr};
+
+    if (L::prev_ptr(v)) {
+      L::next_ptr(L::prev_ptr(v)) = L::next_ptr(v);
+    }
+    if (L::next_ptr(v)) {
+      zret                        = L::next_ptr(v);
+      L::prev_ptr(L::next_ptr(v)) = L::prev_ptr(v);
+    }
+    if (v == _head) {
+      _head = L::next_ptr(v);
+    }
+    if (v == _tail) {
+      _tail = L::prev_ptr(v);
+    }
+    L::prev_ptr(v) = L::next_ptr(v) = nullptr;
+    --_count;
+
+    return zret;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::erase(const iterator &loc) -> iterator
+  {
+    return this->iterator_for(this->erase(loc._v));
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::erase(const iterator &first, const iterator &limit) -> iterator
+  {
+    value_type *spot = first;
+    value_type *prev{L::prev_ptr(spot)};
+    if (prev) {
+      L::next_ptr(prev) = limit;
+    }
+    if (spot == _head) {
+      _head = limit;
+    }
+    // tail is only updated if @a limit is @a end (e.g., @c nullptr).
+    if (nullptr == limit) {
+      _tail = prev;
+    } else {
+      L::prev_ptr(limit) = prev;
+    }
+    // Clear links in removed elements.
+    while (spot != limit) {
+      value_type *target{spot};
+      spot                = L::next_ptr(spot);
+      L::prev_ptr(target) = L::next_ptr(target) = nullptr;
+    };
+
+    return {limit._v, this};
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::operator=(self_type &&that) -> self_type &
+  {
+    if (this != &that) {
+      this->_head  = that._head;
+      this->_tail  = that._tail;
+      this->_count = that._count;
+      that.clear();
+    }
+    return *this;
+  }
+
+  template <typename L>
+  size_t
+  IntrusiveDList<L>::count() const
+  {
+    return _count;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::begin() const -> const_iterator
+  {
+    return const_iterator{this, _head};
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::begin() -> iterator
+  {
+    return iterator{this, _head};
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::end() const -> const_iterator
+  {
+    return const_iterator{this, nullptr};
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::end() -> iterator
+  {
+    return iterator{this, nullptr};
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::iterator_for(value_type *v) -> iterator
+  {
+    return iterator{this, v};
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::iterator_for(const value_type *v) const -> const_iterator
+  {
+    return const_iterator{this, v};
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::tail() -> value_type *
+  {
+    return _tail;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::tail() const -> const value_type *
+  {
+    return _tail;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::head() -> value_type *
+  {
+    return _head;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::head() const -> const value_type *
+  {
+    return _head;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::clear() -> self_type &
+  {
+    _head = _tail = nullptr;
+    _count        = 0;
+    return *this;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::nth(unsigned int n) -> iterator
+  {
+    if (n >= _count) {
+      return {};
+    }
+
+    value_type *spot;
+    if (n < _count / 2) { // closer to head, count from there..
+      spot = _head;
+      while (n-- > 0) {
+        spot = L::next_ptr(spot);
+      }
+    } else { // count from tail
+      spot         = _tail;
+      unsigned idx = _count - 1;
+      while (idx-- > n) {
+        spot = L::prev_ptr(spot);
+      }
+    }
+    return iterator_for(spot);
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::take_prefix(unsigned int n) -> self_type
+  {
+    if (n == 0) {
+      return {};
+    }
+
+    if (_count <= n) {
+      return std::move(*this);
+    }
+
+    // Invariant - there is at least one element that will not be taken.
+
+    self_type zret;
+    value_type *spot = this->nth(n); // new @a head for @a this
+
+    zret._count             = n;
+    zret._head              = _head;
+    zret._tail              = L::prev_ptr(spot);
+    L::next_ptr(zret._tail) = nullptr;
+
+    _count             -= n;
+    _head               = spot;
+    L::prev_ptr(_head)  = nullptr;
+
+    return zret;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::split_prefix(unsigned int n) -> self_type
+  {
+    if (n <= _count) {
+      return this->take_prefix(n);
+    }
+    return {};
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::take_suffix(unsigned int n) -> self_type
+  {
+    if (n == 0) {
+      return {};
+    }
+
+    if (_count <= n) {
+      return std::move(*this);
+    }
+
+    // Invariant - there is at least one element that will not be taken.
+
+    self_type zret;
+    value_type *spot = this->nth(_count - n - 1); // new @a tail for @a this
+
+    zret._count             = n;
+    zret._head              = L::next_ptr(spot);
+    L::prev_ptr(zret._head) = nullptr;
+    zret._tail              = _tail;
+
+    _count             -= n;
+    _tail               = spot;
+    L::next_ptr(_tail)  = nullptr;
+
+    return zret;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::split_suffix(unsigned int n) -> self_type
+  {
+    if (n <= _count) {
+      return this->take_suffix(n);
+    }
+    return {};
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::prepend(IntrusiveDList::self_type &src) -> self_type &
+  {
+    if (src._count > 0) {
+      if (_count == 0) {
+        *this = std::move(src);
+      } else {
+        L::prev_ptr(_head)      = src._tail;
+        L::next_ptr(src._tail)  = _head;
+        _count                 += src._count;
+        _head                   = src._head;
+        src.clear();
+      }
+    }
+    return *this;
+  }
+
+  template <typename L>
+  auto
+  IntrusiveDList<L>::append(IntrusiveDList::self_type &src) -> self_type &
+  {
+    if (src._count > 0) {
+      if (_count == 0) {
+        *this = std::move(src);
+      } else {
+        L::next_ptr(_tail)      = src._head;
+        L::prev_ptr(src._head)  = _tail;
+        _count                 += src._count;
+        _tail                   = src._tail;
+        src.clear();
+      }
+    }
+    return *this;
+  }
+
+  namespace detail
+  {
+    /// @cond INTERNAL_DETAIL
+    // Make @c apply more convenient by allowing the function to take a reference type or pointer type
+    // to the container elements. The pointer type is the base, plus a shim to convert from a reference
+    // type functor to a pointer type. The complex return type definition forces only one, but
+    // not both, to be valid for a particular functor. This also must be done via free functions and not
+    // method overloads because the compiler forces a match up of method definitions and declarations
+    // before any template instantiation.
+
+    template <typename L, typename F>
+    auto
+    Intrusive_DList_Apply(IntrusiveDList<L> &list, F &&f)
+      -> decltype(f(*static_cast<typename IntrusiveDList<L>::value_type *>(nullptr)), list)
+    {
+      return list.apply([&f](typename IntrusiveDList<L>::value_type *v) { return f(*v); });
+    }
+
+    template <typename L, typename F>
+    auto
+    Intrusive_DList_Apply(IntrusiveDList<L> &list, F &&f)
+      -> decltype(f(static_cast<typename IntrusiveDList<L>::value_type *>(nullptr)), list)
+    {
+      auto spot{list.begin()};
+      auto limit{list.end()};
+      while (spot != limit) {
+        f(spot++); // post increment means @a spot is updated before @a f is applied.
+      }
+      return list;
+    }
+  } // namespace detail
+
+  template <typename L>
+  template <typename F>
+  auto
+  IntrusiveDList<L>::apply(F &&f) -> self_type &
+  {
+    return detail::Intrusive_DList_Apply(*this, f);
+  }
+  /// @endcond
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/include/swoc/IntrusiveHashMap.h
+++ b/code/include/swoc/IntrusiveHashMap.h
@@ -17,677 +17,723 @@
 #include "swoc/swoc_version.h"
 #include "swoc/IntrusiveDList.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
-/** Intrusive Hash Table.
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  /** Intrusive Hash Table.
 
-    Values stored in this container are not destroyed when the container is destroyed or removed from the container.
-    They must be released by the client.
+      Values stored in this container are not destroyed when the container is destroyed or removed from the container.
+      They must be released by the client.
 
-    Duplicate keys are allowed. Clients must walk the list for multiple entries.
-    @see @c Location::operator++()
+      Duplicate keys are allowed. Clients must walk the list for multiple entries.
+      @see @c Location::operator++()
 
-    By default the table automatically expands to limit the average chain length. This can be tuned. If set
-    to @c MANUAL then the table will expand @b only when explicitly requested to do so by the client.
-    @see @c ExpansionPolicy
-    @see @c setExpansionPolicy()
-    @see @c setExpansionLimit()
-    @see @c expand()
+      By default the table automatically expands to limit the average chain length. This can be tuned. If set
+      to @c MANUAL then the table will expand @b only when explicitly requested to do so by the client.
+      @see @c ExpansionPolicy
+      @see @c setExpansionPolicy()
+      @see @c setExpansionLimit()
+      @see @c expand()
 
-    The hash table is configured by a descriptor class. This must contain the following members
+      The hash table is configured by a descriptor class. This must contain the following members
 
-    - The static method <tt>key_type key_of(value_type *)</tt> which returns the key for an instance of @c value_type.
+      - The static method <tt>key_type key_of(value_type *)</tt> which returns the key for an instance of @c value_type.
 
-    - The static method <tt>bool equal(key_type lhs, key_type rhs)</tt> which checks if two instances of @c Key are the same.
+      - The static method <tt>bool equal(key_type lhs, key_type rhs)</tt> which checks if two instances of @c Key are the same.
 
-    - The static method <tt>hash_id hash_of(key_type)</tt> which computes the hash value of the key. @c ID must a numeric type.
+      - The static method <tt>hash_id hash_of(key_type)</tt> which computes the hash value of the key. @c ID must a numeric type.
 
-    - The static method <tt>value_type *& next_ptr(value_type *)</tt> which returns a reference to a forward pointer.
+      - The static method <tt>value_type *& next_ptr(value_type *)</tt> which returns a reference to a forward pointer.
 
-    - The static method <tt>value_type *& prev_ptr(value_type *)</tt> which returns a reference to a backwards pointer.
+      - The static method <tt>value_type *& prev_ptr(value_type *)</tt> which returns a reference to a backwards pointer.
 
-    These are the required members, it is permitted to have other methods (if the descriptor is used for other purposes)
-    or to provide overloads of the methods. Note this is compatible with @c IntrusiveDList.
+      These are the required members, it is permitted to have other methods (if the descriptor is used for other purposes)
+      or to provide overloads of the methods. Note this is compatible with @c IntrusiveDList.
 
-    Several internal types are deduced from these arguments.
+      Several internal types are deduced from these arguments.
 
-    @a Key is the return type of @a key_of and represents the key that distinguishes instances of @a value_type. Two
-    instances of @c value_type are considered the same if their respective @c Key values are @c equal. @c Key is
-    presumed cheap to copy. If the underlying key is not a simple type then @a Key should be a constant pointer or a
-    constant reference. The hash table will never attempt to modify a key.
+      @a Key is the return type of @a key_of and represents the key that distinguishes instances of @a value_type. Two
+      instances of @c value_type are considered the same if their respective @c Key values are @c equal. @c Key is
+      presumed cheap to copy. If the underlying key is not a simple type then @a Key should be a constant pointer or a
+      constant reference. The hash table will never attempt to modify a key.
 
-    @a ID The numeric type that is the hash value for an instance of @a Key.
+      @a ID The numeric type that is the hash value for an instance of @a Key.
 
-    Example for @c HttpServerSession keyed by the origin server IP address.
+      Example for @c HttpServerSession keyed by the origin server IP address.
 
-    @code
-    struct Descriptor {
-      static sockaddr const* key_of(HttpServerSession const* value) { return &value->ip.sa }
-      static bool equal(sockaddr const* lhs, sockaddr const* rhs) { return ats_ip_eq(lhs, rhs); }
-      static uint32_t hash_of(sockaddr const* key) { return ats_ip_hash(key); }
-      static HttpServerSession *& next_ptr(HttpServerSession * ssn) { return ssn->_next; }
-      static HttpServerSession *& prev_ptr(HttpServerSession * ssn) { return ssn->_prev; }
+      @code
+      struct Descriptor {
+        static sockaddr const* key_of(HttpServerSession const* value) { return &value->ip.sa }
+        static bool equal(sockaddr const* lhs, sockaddr const* rhs) { return ats_ip_eq(lhs, rhs); }
+        static uint32_t hash_of(sockaddr const* key) { return ats_ip_hash(key); }
+        static HttpServerSession *& next_ptr(HttpServerSession * ssn) { return ssn->_next; }
+        static HttpServerSession *& prev_ptr(HttpServerSession * ssn) { return ssn->_prev; }
+      };
+      using Table = IntrusiveHashMap<Descriptor>;
+      @endcode
+
+   */
+  template <typename H> class IntrusiveHashMap
+  {
+    using self_type = IntrusiveHashMap;
+
+  public:
+    /// Type of elements in the map.
+    using value_type = typename std::remove_pointer<typename std::remove_reference<decltype(H::next_ptr(nullptr))>::type>::type;
+    /// Key type for the elements.
+    using key_type = decltype(H::key_of(static_cast<value_type *>(nullptr)));
+    /// The numeric hash ID computed from a key.
+    using hash_id = decltype(H::hash_of(H::key_of(static_cast<value_type *>(nullptr))));
+
+    /// When the hash table is expanded.
+    enum ExpansionPolicy {
+      MANUAL,  ///< Client must explicitly expand the table.
+      AVERAGE, ///< Table expands if average chain length exceeds limit. [default]
+      MAXIMUM  ///< Table expands if any chain length exceeds limit.
     };
-    using Table = IntrusiveHashMap<Descriptor>;
-    @endcode
 
- */
-template <typename H> class IntrusiveHashMap {
-  using self_type = IntrusiveHashMap;
-
-public:
-  /// Type of elements in the map.
-  using value_type = typename std::remove_pointer<typename std::remove_reference<decltype(H::next_ptr(nullptr))>::type>::type;
-  /// Key type for the elements.
-  using key_type = decltype(H::key_of(static_cast<value_type *>(nullptr)));
-  /// The numeric hash ID computed from a key.
-  using hash_id = decltype(H::hash_of(H::key_of(static_cast<value_type *>(nullptr))));
-
-  /// When the hash table is expanded.
-  enum ExpansionPolicy {
-    MANUAL,  ///< Client must explicitly expand the table.
-    AVERAGE, ///< Table expands if average chain length exceeds limit. [default]
-    MAXIMUM  ///< Table expands if any chain length exceeds limit.
-  };
-
-protected:
-  /** List of elements.
-   * All table elements are in this list. The buckets reference their starting element in the list, or nothing if
-   * no elements are in that bucket.
-   */
-  using List = IntrusiveDList<H>;
-
-  /// A bucket for the hash map.
-  struct Bucket {
-    /// Support for IntrusiveDList<Bucket::Linkage>, definitions and link storage.
-    struct Linkage {
-      static Bucket *&next_ptr(Bucket *b); ///< Access next pointer.
-      static Bucket *&prev_ptr(Bucket *b); ///< Access prev pointer.
-      Bucket *_prev{nullptr};              ///< Prev pointer.
-      Bucket *_next{nullptr};              ///< Next pointer.
-    } _link;
-
-    value_type *_v{nullptr}; ///< First element in the bucket.
-    size_t _count{0};        ///< Number of elements in the bucket.
-
-    /** Marker for the chain having different keys.
-
-        This is used to determine if expanding the hash map would be useful - buckets that are not mixed
-        will not be changed by an expansion.
+  protected:
+    /** List of elements.
+     * All table elements are in this list. The buckets reference their starting element in the list, or nothing if
+     * no elements are in that bucket.
      */
-    bool _mixed_p{false};
+    using List = IntrusiveDList<H>;
 
-    /// Compute the limit value for iteration in this bucket.
-    /// This is the value of the next bucket, or @c nullptr if no next bucket.
-    value_type *limit() const;
+    /// A bucket for the hash map.
+    struct Bucket {
+      /// Support for IntrusiveDList<Bucket::Linkage>, definitions and link storage.
+      struct Linkage {
+        static Bucket *&next_ptr(Bucket *b); ///< Access next pointer.
+        static Bucket *&prev_ptr(Bucket *b); ///< Access prev pointer.
+        Bucket *_prev{nullptr};              ///< Prev pointer.
+        Bucket *_next{nullptr};              ///< Next pointer.
+      } _link;
 
-    /// Verify @a v is in this bucket.
-    bool contains(value_type *v) const;
+      value_type *_v{nullptr}; ///< First element in the bucket.
+      size_t _count{0};        ///< Number of elements in the bucket.
 
-    void clear(); ///< Reset to initial state.
+      /** Marker for the chain having different keys.
+
+          This is used to determine if expanding the hash map would be useful - buckets that are not mixed
+          will not be changed by an expansion.
+       */
+      bool _mixed_p{false};
+
+      /// Compute the limit value for iteration in this bucket.
+      /// This is the value of the next bucket, or @c nullptr if no next bucket.
+      value_type *limit() const;
+
+      /// Verify @a v is in this bucket.
+      bool contains(value_type *v) const;
+
+      void clear(); ///< Reset to initial state.
+    };
+
+  public:
+    /// The default starting number of buckets.
+    static size_t constexpr DEFAULT_BUCKET_COUNT = 7; ///< POOMA.
+    /// The default expansion policy limit.
+    static size_t constexpr DEFAULT_EXPANSION_LIMIT = 4; ///< Value from previous version.
+    /// Expansion policy if not specified in constructor.
+    static ExpansionPolicy constexpr DEFAULT_EXPANSION_POLICY = AVERAGE;
+
+    using iterator       = typename List::iterator;
+    using const_iterator = typename List::const_iterator;
+
+    /// A range of elements in the map.
+    /// It is a half open range, [first, last) in the usual STL style.
+    /// @internal I tried @c std::pair as a base for this but was unable to get STL container operations to work.
+    struct range : public std::pair<iterator, iterator> {
+      using super_type = std::pair<iterator, iterator>; ///< Super type.
+      using super_type::super_type;                     ///< Use super type constructors.
+
+      // These methods enable treating the range as a view in to the hash map.
+
+      /// Return @a first
+      iterator const &begin() const;
+
+      /// Return @a last
+      iterator const &end() const;
+    };
+
+    /// A range of constant elements in the map.
+    struct const_range : public std::pair<const_iterator, const_iterator> {
+      using super_type = std::pair<const_iterator, const_iterator>; ///< Super type.
+
+      /// Allow implicit conversion of range to const_range.
+      const_range(range const &r);
+
+      using super_type::super_type; ///< Use super type constructors.
+
+      // These methods enable treating the range as a view in to the hash map.
+
+      /// Return @a first
+      const_iterator const &begin() const;
+
+      /// Return @a last
+      const_iterator const &end() const;
+    };
+
+    /// Construct, starting with @n buckets.
+    /// This doubles as the default constructor.
+    IntrusiveHashMap(size_t n = DEFAULT_BUCKET_COUNT);
+
+    /// Move constructor.
+    IntrusiveHashMap(self_type &&that) = default;
+
+    /** Remove all values from the table.
+
+        The values are not cleaned up. The values are not touched in this method, therefore it is safe
+        to destroy them first and then @c clear this table.
+    */
+    self_type &clear();
+
+    iterator begin();             ///< First element.
+    const_iterator begin() const; ///< First element.
+    iterator end();               ///< Past last element.
+    const_iterator end() const;   ///< Past last element.
+
+    /** Insert a value in to the table.
+        The @a value must @b NOT already be in a table of this type.
+        @note The value itself is put in the table, @b not a copy.
+    */
+    void insert(value_type *v);
+
+    /** Find an element with a key equal to @a key.
+
+        @return A element with a matching key, or the end iterator if not found.
+    */
+    const_iterator find(key_type key) const;
+
+    iterator find(key_type key);
+
+    /** Get an iterator for an existing value @a v.
+
+        @return An iterator that references @a v, or the end iterator if @a v is not in the table.
+    */
+    const_iterator find(value_type const *v) const;
+
+    iterator find(value_type *v);
+
+    /** Find the range of objects with keys equal to @a key.
+
+        @return A iterator pair of [first, last) items with equal keys.
+    */
+    const_range equal_range(key_type key) const;
+
+    range equal_range(key_type key);
+
+    /** Get an @c iterator for the value @a v.
+
+        This is a bit obscure but needed in certain cases. Because the interface assumes iterators are always valid
+        this avoid containment checks, which is useful if @a v is already known to be in the container.
+     */
+    iterator iterator_for(value_type *v);
+
+    const_iterator iterator_for(const value_type *v) const;
+
+    /** Remove the value at @a loc from the table.
+
+        @note This does @b not clean up the removed elements. Use carefully to avoid leaks.
+
+        @return An iterator the next value past @a loc. [STL compatibility]
+    */
+    iterator erase(iterator const &loc);
+
+    /// Remove all elements in the @c range @a r.
+    iterator erase(range const &r);
+
+    /// Remove all elements in the range (start, limit]
+    iterator erase(iterator const &start, iterator const &limit);
+
+    /// Remove a @a value from the container.
+    /// @a value is checked for being a member of the container.
+    /// @return @c true if @a value was in the container and removed, @c false if it was not in the container.
+    bool erase(value_type *value);
+
+    /** Apply @a F(value_type&) to every element in the hash map.
+     *
+     * This is similar to a range for loop except the iteration is done in a way where destruction or alternation of
+     * the element does @b not affect the iterator. Primarily this is useful for @c delete to clean up the elements
+     * but it can have other uses.
+     *
+     * @tparam F A functional object of the form <tt>void F(value_type&)</tt>
+     * @param f The function to apply.
+     * @return
+     */
+    template <typename F> self_type &apply(F &&f);
+
+    /** Expand the hash if needed.
+
+        Useful primarily when the expansion policy is set to @c MANUAL.
+     */
+    void expand();
+
+    /// Number of elements in the map.
+    size_t count() const;
+
+    /// Number of buckets in the array.
+    size_t bucket_count() const;
+
+    /// Set the expansion policy to @a policy.
+    self_type &set_expansion_policy(ExpansionPolicy policy);
+
+    /// Get the current expansion policy
+    ExpansionPolicy get_expansion_policy() const;
+
+    /// Set the limit value for the expansion policy.
+    self_type &set_expansion_limit(size_t n);
+
+    /// Set the limit value for the expansion policy.
+    size_t get_expansion_limit() const;
+
+  protected:
+    /// The type of storage for the buckets.
+    using Table = std::vector<Bucket>;
+
+    List _list;   ///< Elements in the table.
+    Table _table; ///< Array of buckets.
+
+    /// List of non-empty buckets.
+    IntrusiveDList<typename Bucket::Linkage> _active_buckets;
+
+    Bucket *bucket_for(key_type key);
+
+    ExpansionPolicy _expansion_policy{DEFAULT_EXPANSION_POLICY}; ///< When to exand the table.
+    size_t _expansion_limit{DEFAULT_EXPANSION_LIMIT};            ///< Limit value for expansion.
+
+    // noncopyable
+    IntrusiveHashMap(const IntrusiveHashMap &) = delete;
+
+    IntrusiveHashMap &operator=(const IntrusiveHashMap &) = delete;
+
+    // Hash table size prime list.
+    static constexpr std::array<size_t, 29> PRIME = {
+      {1, 3, 7, 13, 31, 61, 127, 251, 509, 1021,
+       2039, 4093, 8191, 16381, 32749, 65521, 131071, 262139, 524287, 1048573,
+       2097143, 4194301, 8388593, 16777213, 33554393, 67108859, 134217689, 268435399, 536870909}
+    };
   };
 
-public:
-  /// The default starting number of buckets.
-  static size_t constexpr DEFAULT_BUCKET_COUNT = 7; ///< POOMA.
-  /// The default expansion policy limit.
-  static size_t constexpr DEFAULT_EXPANSION_LIMIT = 4; ///< Value from previous version.
-  /// Expansion policy if not specified in constructor.
-  static ExpansionPolicy constexpr DEFAULT_EXPANSION_POLICY = AVERAGE;
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::Bucket::Linkage::next_ptr(Bucket *b) -> Bucket *&
+  {
+    return b->_link._next;
+  }
 
-  using iterator       = typename List::iterator;
-  using const_iterator = typename List::const_iterator;
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::Bucket::Linkage::prev_ptr(Bucket *b) -> Bucket *&
+  {
+    return b->_link._prev;
+  }
 
-  /// A range of elements in the map.
-  /// It is a half open range, [first, last) in the usual STL style.
-  /// @internal I tried @c std::pair as a base for this but was unable to get STL container operations to work.
-  struct range : public std::pair<iterator, iterator> {
-    using super_type = std::pair<iterator, iterator>; ///< Super type.
-    using super_type::super_type;                     ///< Use super type constructors.
-
-    // These methods enable treating the range as a view in to the hash map.
-
-    /// Return @a first
-    iterator const &begin() const;
-
-    /// Return @a last
-    iterator const &end() const;
+  // This is designed so that if the bucket is empty, then @c nullptr is returned, which will immediately terminate
+  // a search loop on an empty bucket because that will start with a nullptr candidate, matching the limit.
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::Bucket::limit() const -> value_type *
+  {
+    Bucket *n{_link._next};
+    return n ? n->_v : nullptr;
   };
 
-  /// A range of constant elements in the map.
-  struct const_range : public std::pair<const_iterator, const_iterator> {
-    using super_type = std::pair<const_iterator, const_iterator>; ///< Super type.
-
-    /// Allow implicit conversion of range to const_range.
-    const_range(range const &r);
-
-    using super_type::super_type; ///< Use super type constructors.
-
-    // These methods enable treating the range as a view in to the hash map.
-
-    /// Return @a first
-    const_iterator const &begin() const;
-
-    /// Return @a last
-    const_iterator const &end() const;
-  };
-
-  /// Construct, starting with @n buckets.
-  /// This doubles as the default constructor.
-  IntrusiveHashMap(size_t n = DEFAULT_BUCKET_COUNT);
-
-  /// Move constructor.
-  IntrusiveHashMap(self_type &&that) = default;
-
-  /** Remove all values from the table.
-
-      The values are not cleaned up. The values are not touched in this method, therefore it is safe
-      to destroy them first and then @c clear this table.
-  */
-  self_type &clear();
-
-  iterator begin();             ///< First element.
-  const_iterator begin() const; ///< First element.
-  iterator end();               ///< Past last element.
-  const_iterator end() const;   ///< Past last element.
-
-  /** Insert a value in to the table.
-      The @a value must @b NOT already be in a table of this type.
-      @note The value itself is put in the table, @b not a copy.
-  */
-  void insert(value_type *v);
-
-  /** Find an element with a key equal to @a key.
-
-      @return A element with a matching key, or the end iterator if not found.
-  */
-  const_iterator find(key_type key) const;
-
-  iterator find(key_type key);
-
-  /** Get an iterator for an existing value @a v.
-
-      @return An iterator that references @a v, or the end iterator if @a v is not in the table.
-  */
-  const_iterator find(value_type const *v) const;
-
-  iterator find(value_type *v);
-
-  /** Find the range of objects with keys equal to @a key.
-
-      @return A iterator pair of [first, last) items with equal keys.
-  */
-  const_range equal_range(key_type key) const;
-
-  range equal_range(key_type key);
-
-  /** Get an @c iterator for the value @a v.
-
-      This is a bit obscure but needed in certain cases. Because the interface assumes iterators are always valid
-      this avoid containment checks, which is useful if @a v is already known to be in the container.
-   */
-  iterator iterator_for(value_type *v);
-
-  const_iterator iterator_for(const value_type *v) const;
-
-  /** Remove the value at @a loc from the table.
-
-      @note This does @b not clean up the removed elements. Use carefully to avoid leaks.
-
-      @return An iterator the next value past @a loc. [STL compatibility]
-  */
-  iterator erase(iterator const &loc);
-
-  /// Remove all elements in the @c range @a r.
-  iterator erase(range const &r);
-
-  /// Remove all elements in the range (start, limit]
-  iterator erase(iterator const &start, iterator const &limit);
-
-  /// Remove a @a value from the container.
-  /// @a value is checked for being a member of the container.
-  /// @return @c true if @a value was in the container and removed, @c false if it was not in the container.
-  bool erase(value_type *value);
-
-  /** Apply @a F(value_type&) to every element in the hash map.
-   *
-   * This is similar to a range for loop except the iteration is done in a way where destruction or alternation of
-   * the element does @b not affect the iterator. Primarily this is useful for @c delete to clean up the elements
-   * but it can have other uses.
-   *
-   * @tparam F A functional object of the form <tt>void F(value_type&)</tt>
-   * @param f The function to apply.
-   * @return
-   */
-  template <typename F> self_type &apply(F &&f);
-
-  /** Expand the hash if needed.
-
-      Useful primarily when the expansion policy is set to @c MANUAL.
-   */
-  void expand();
-
-  /// Number of elements in the map.
-  size_t count() const;
-
-  /// Number of buckets in the array.
-  size_t bucket_count() const;
-
-  /// Set the expansion policy to @a policy.
-  self_type &set_expansion_policy(ExpansionPolicy policy);
-
-  /// Get the current expansion policy
-  ExpansionPolicy get_expansion_policy() const;
-
-  /// Set the limit value for the expansion policy.
-  self_type &set_expansion_limit(size_t n);
-
-  /// Set the limit value for the expansion policy.
-  size_t get_expansion_limit() const;
-
-protected:
-  /// The type of storage for the buckets.
-  using Table = std::vector<Bucket>;
-
-  List _list;   ///< Elements in the table.
-  Table _table; ///< Array of buckets.
-
-  /// List of non-empty buckets.
-  IntrusiveDList<typename Bucket::Linkage> _active_buckets;
-
-  Bucket *bucket_for(key_type key);
-
-  ExpansionPolicy _expansion_policy{DEFAULT_EXPANSION_POLICY}; ///< When to exand the table.
-  size_t _expansion_limit{DEFAULT_EXPANSION_LIMIT};            ///< Limit value for expansion.
-
-  // noncopyable
-  IntrusiveHashMap(const IntrusiveHashMap &) = delete;
-
-  IntrusiveHashMap &operator=(const IntrusiveHashMap &) = delete;
-
-  // Hash table size prime list.
-  static constexpr std::array<size_t, 29> PRIME = {{1,        3,        7,         13,        31,       61,      127,     251,
-                                                    509,      1021,     2039,      4093,      8191,     16381,   32749,   65521,
-                                                    131071,   262139,   524287,    1048573,   2097143,  4194301, 8388593, 16777213,
-                                                    33554393, 67108859, 134217689, 268435399, 536870909}};
-};
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::Bucket::Linkage::next_ptr(Bucket *b) -> Bucket *& {
-  return b->_link._next;
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::Bucket::Linkage::prev_ptr(Bucket *b) -> Bucket *& {
-  return b->_link._prev;
-}
-
-// This is designed so that if the bucket is empty, then @c nullptr is returned, which will immediately terminate
-// a search loop on an empty bucket because that will start with a nullptr candidate, matching the limit.
-template <typename H>
-auto
-IntrusiveHashMap<H>::Bucket::limit() const -> value_type * {
-  Bucket *n{_link._next};
-  return n ? n->_v : nullptr;
-};
-
-template <typename H>
-void
-IntrusiveHashMap<H>::Bucket::clear() {
-  _v       = nullptr;
-  _count   = 0;
-  _mixed_p = false;
-  // Need to clear these, or they persist after an expansion which breaks the active bucket list.
-  _link._next = _link._prev = nullptr;
-}
-
-template <typename H>
-bool
-IntrusiveHashMap<H>::Bucket::contains(value_type *v) const {
-  value_type *x     = _v;
-  value_type *limit = this->limit();
-  while (x != limit && x != v) {
-    x = H::next_ptr(x);
-  }
-  return x == v;
-}
-
-// ---------------------
-template <typename H>
-auto
-IntrusiveHashMap<H>::range::begin() const -> iterator const & {
-  return super_type::first;
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::range::end() const -> iterator const & {
-  return super_type::second;
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::const_range::begin() const -> const_iterator const & {
-  return super_type::first;
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::const_range::end() const -> const_iterator const & {
-  return super_type::second;
-}
-
-// ---------------------
-
-template <typename H> IntrusiveHashMap<H>::IntrusiveHashMap(size_t n) {
-  if (n) {
-    _table.resize(*std::lower_bound(PRIME.begin(), PRIME.end(), n));
-  }
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::bucket_for(key_type key) -> Bucket * {
-  return &_table[H::hash_of(key) % _table.size()];
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::begin() -> iterator {
-  return _list.begin();
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::begin() const -> const_iterator {
-  return _list.begin();
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::end() -> iterator {
-  return _list.end();
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::end() const -> const_iterator {
-  return _list.end();
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::clear() -> self_type & {
-  for (auto &b : _table) {
-    b.clear();
-  }
-  // Clear container data.
-  _list.clear();
-  _active_buckets.clear();
-  return *this;
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::find(key_type key) -> iterator {
-  Bucket *b         = this->bucket_for(key);
-  value_type *v     = b->_v;
-  value_type *limit = b->limit();
-  while (v != limit && !H::equal(key, H::key_of(v))) {
-    v = H::next_ptr(v);
-  }
-  return v == limit ? _list.end() : _list.iterator_for(v);
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::find(key_type key) const -> const_iterator {
-  return const_cast<self_type *>(this)->find(key);
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::equal_range(key_type key) -> range {
-  iterator first{this->find(key)};
-  iterator last{first};
-  iterator limit{this->end()};
-
-  while (last != limit && H::equal(key, H::key_of(&*last))) {
-    ++last;
+  template <typename H>
+  void
+  IntrusiveHashMap<H>::Bucket::clear()
+  {
+    _v       = nullptr;
+    _count   = 0;
+    _mixed_p = false;
+    // Need to clear these, or they persist after an expansion which breaks the active bucket list.
+    _link._next = _link._prev = nullptr;
   }
 
-  return range{first, last};
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::equal_range(key_type key) const -> const_range {
-  return const_cast<self_type *>(this)->equal_range(key);
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::iterator_for(const value_type *v) const -> const_iterator {
-  return _list.iterator_for(v);
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::iterator_for(value_type *v) -> iterator {
-  return _list.iterator_for(v);
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::find(value_type *v) -> iterator {
-  Bucket *b = this->bucket_for(H::key_of(v));
-  return b->contains(v) ? _list.iterator_for(v) : this->end();
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::find(value_type const *v) const -> const_iterator {
-  return const_cast<self_type *>(this)->find(const_cast<value_type *>(v));
-}
-
-template <typename H>
-void
-IntrusiveHashMap<H>::insert(value_type *v) {
-  auto key         = H::key_of(v);
-  Bucket *bucket   = this->bucket_for(key);
-  value_type *spot = bucket->_v;
-  bool mixed_p     = false; // Found a different key in the bucket.
-
-  if (nullptr == spot) { // currently empty bucket, set it and add to active list.
-    _list.append(v);
-    bucket->_v = v;
-    _active_buckets.append(bucket);
-  } else {
-    value_type *limit = bucket->limit();
-
-    // First search the bucket to see if the key is already in it.
-    while (spot != limit && !H::equal(key, H::key_of(spot))) {
-      spot = H::next_ptr(spot);
+  template <typename H>
+  bool
+  IntrusiveHashMap<H>::Bucket::contains(value_type *v) const
+  {
+    value_type *x     = _v;
+    value_type *limit = this->limit();
+    while (x != limit && x != v) {
+      x = H::next_ptr(x);
     }
-    if (spot != bucket->_v) {
-      mixed_p = true; // found some other key, it's going to be mixed.
+    return x == v;
+  }
+
+  // ---------------------
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::range::begin() const -> iterator const &
+  {
+    return super_type::first;
+  }
+
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::range::end() const -> iterator const &
+  {
+    return super_type::second;
+  }
+
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::const_range::begin() const -> const_iterator const &
+  {
+    return super_type::first;
+  }
+
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::const_range::end() const -> const_iterator const &
+  {
+    return super_type::second;
+  }
+
+  // ---------------------
+
+  template <typename H> IntrusiveHashMap<H>::IntrusiveHashMap(size_t n)
+  {
+    if (n) {
+      _table.resize(*std::lower_bound(PRIME.begin(), PRIME.end(), n));
     }
-    if (spot != limit) {
-      // If an equal key was found, walk past those to insert at the upper end of the range.
-      do {
+  }
+
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::bucket_for(key_type key) -> Bucket *
+  {
+    return &_table[H::hash_of(key) % _table.size()];
+  }
+
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::begin() -> iterator
+  {
+    return _list.begin();
+  }
+
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::begin() const -> const_iterator
+  {
+    return _list.begin();
+  }
+
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::end() -> iterator
+  {
+    return _list.end();
+  }
+
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::end() const -> const_iterator
+  {
+    return _list.end();
+  }
+
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::clear() -> self_type &
+  {
+    for (auto &b : _table) {
+      b.clear();
+    }
+    // Clear container data.
+    _list.clear();
+    _active_buckets.clear();
+    return *this;
+  }
+
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::find(key_type key) -> iterator
+  {
+    Bucket *b         = this->bucket_for(key);
+    value_type *v     = b->_v;
+    value_type *limit = b->limit();
+    while (v != limit && !H::equal(key, H::key_of(v))) {
+      v = H::next_ptr(v);
+    }
+    return v == limit ? _list.end() : _list.iterator_for(v);
+  }
+
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::find(key_type key) const -> const_iterator
+  {
+    return const_cast<self_type *>(this)->find(key);
+  }
+
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::equal_range(key_type key) -> range
+  {
+    iterator first{this->find(key)};
+    iterator last{first};
+    iterator limit{this->end()};
+
+    while (last != limit && H::equal(key, H::key_of(&*last))) {
+      ++last;
+    }
+
+    return range{first, last};
+  }
+
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::equal_range(key_type key) const -> const_range
+  {
+    return const_cast<self_type *>(this)->equal_range(key);
+  }
+
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::iterator_for(const value_type *v) const -> const_iterator
+  {
+    return _list.iterator_for(v);
+  }
+
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::iterator_for(value_type *v) -> iterator
+  {
+    return _list.iterator_for(v);
+  }
+
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::find(value_type *v) -> iterator
+  {
+    Bucket *b = this->bucket_for(H::key_of(v));
+    return b->contains(v) ? _list.iterator_for(v) : this->end();
+  }
+
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::find(value_type const *v) const -> const_iterator
+  {
+    return const_cast<self_type *>(this)->find(const_cast<value_type *>(v));
+  }
+
+  template <typename H>
+  void
+  IntrusiveHashMap<H>::insert(value_type *v)
+  {
+    auto key         = H::key_of(v);
+    Bucket *bucket   = this->bucket_for(key);
+    value_type *spot = bucket->_v;
+    bool mixed_p     = false; // Found a different key in the bucket.
+
+    if (nullptr == spot) { // currently empty bucket, set it and add to active list.
+      _list.append(v);
+      bucket->_v = v;
+      _active_buckets.append(bucket);
+    } else {
+      value_type *limit = bucket->limit();
+
+      // First search the bucket to see if the key is already in it.
+      while (spot != limit && !H::equal(key, H::key_of(spot))) {
         spot = H::next_ptr(spot);
-      } while (spot != limit && H::equal(key, H::key_of(spot)));
-      if (spot != limit) { // something not equal past last equivalent, it's going to be mixed.
-        mixed_p = true;
+      }
+      if (spot != bucket->_v) {
+        mixed_p = true; // found some other key, it's going to be mixed.
+      }
+      if (spot != limit) {
+        // If an equal key was found, walk past those to insert at the upper end of the range.
+        do {
+          spot = H::next_ptr(spot);
+        } while (spot != limit && H::equal(key, H::key_of(spot)));
+        if (spot != limit) { // something not equal past last equivalent, it's going to be mixed.
+          mixed_p = true;
+        }
+      }
+
+      _list.insert_before(spot, v);
+      if (spot == bucket->_v) { // added before the bucket start, update the start.
+        bucket->_v = v;
+      }
+      bucket->_mixed_p = mixed_p;
+    }
+    ++bucket->_count;
+
+    // auto expand if appropriate.
+    if ((AVERAGE == _expansion_policy && (_list.count() / _table.size()) > _expansion_limit) ||
+        (MAXIMUM == _expansion_policy && bucket->_count > _expansion_limit && bucket->_mixed_p)) {
+      this->expand();
+    }
+  }
+
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::erase(iterator const &loc) -> iterator
+  {
+    value_type *v     = loc;
+    iterator zret     = ++(this->iterator_for(v)); // get around no const_iterator -> iterator.
+    Bucket *b         = this->bucket_for(H::key_of(v));
+    value_type *nv    = H::next_ptr(v);
+    value_type *limit = b->limit();
+    if (b->_v == v) {    // removed first element in bucket, update bucket
+      if (limit == nv) { // that was also the only element, deactivate bucket
+        _active_buckets.erase(b);
+        b->clear();
+      } else {
+        b->_v = nv;
+        --b->_count;
       }
     }
+    _list.erase(loc);
+    return zret;
+  }
 
-    _list.insert_before(spot, v);
-    if (spot == bucket->_v) { // added before the bucket start, update the start.
-      bucket->_v = v;
+  template <typename H>
+  bool
+  IntrusiveHashMap<H>::erase(value_type *value)
+  {
+    auto loc = this->find(value);
+    if (loc != this->end()) {
+      this->erase(loc);
+      return true;
     }
-    bucket->_mixed_p = mixed_p;
+    return false;
   }
-  ++bucket->_count;
 
-  // auto expand if appropriate.
-  if ((AVERAGE == _expansion_policy && (_list.count() / _table.size()) > _expansion_limit) ||
-      (MAXIMUM == _expansion_policy && bucket->_count > _expansion_limit && bucket->_mixed_p)) {
-    this->expand();
-  }
-}
-
-template <typename H>
-auto
-IntrusiveHashMap<H>::erase(iterator const &loc) -> iterator {
-  value_type *v     = loc;
-  iterator zret     = ++(this->iterator_for(v)); // get around no const_iterator -> iterator.
-  Bucket *b         = this->bucket_for(H::key_of(v));
-  value_type *nv    = H::next_ptr(v);
-  value_type *limit = b->limit();
-  if (b->_v == v) {    // removed first element in bucket, update bucket
-    if (limit == nv) { // that was also the only element, deactivate bucket
-      _active_buckets.erase(b);
-      b->clear();
-    } else {
-      b->_v = nv;
-      --b->_count;
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::erase(iterator const &start, iterator const &limit) -> iterator
+  {
+    auto spot{start};
+    Bucket *bucket{this->bucket_for(spot)};
+    while (spot != limit) {
+      auto target         = bucket;
+      bucket              = bucket->_link._next; // bump now to avoid forward iteration problems in case of bucket removal.
+      value_type *v_limit = bucket ? bucket->_v : nullptr;
+      while (spot != v_limit && spot != limit) {
+        --(target->_count);
+        ++spot;
+      }
+      if (target->_count == 0) {
+        _active_buckets.erase(target);
+      }
     }
-  }
-  _list.erase(loc);
-  return zret;
-}
+    _list.erase(start, limit);
+    return _list.iterator_for(limit); // convert from const_iterator back to iterator
+  };
 
-template <typename H>
-bool
-IntrusiveHashMap<H>::erase(value_type *value) {
-  auto loc = this->find(value);
-  if (loc != this->end()) {
-    this->erase(loc);
-    return true;
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::erase(range const &r) -> iterator
+  {
+    return this->erase(r.first, r.second);
   }
-  return false;
-}
 
-template <typename H>
-auto
-IntrusiveHashMap<H>::erase(iterator const &start, iterator const &limit) -> iterator {
-  auto spot{start};
-  Bucket *bucket{this->bucket_for(spot)};
-  while (spot != limit) {
-    auto target         = bucket;
-    bucket              = bucket->_link._next; // bump now to avoid forward iteration problems in case of bucket removal.
-    value_type *v_limit = bucket ? bucket->_v : nullptr;
-    while (spot != v_limit && spot != limit) {
-      --(target->_count);
-      ++spot;
+  namespace detail
+  {
+    // Make @c apply more convenient by allowing the function to take a reference type or pointer type to the container
+    // elements. The pointer type is the base, plus a shim to convert from a reference type functor to a pointer pointer
+    // type. The complex return type definition forces only one, but not both, to be valid for a particular functor. This
+    // also must be done via free functions and not method overloads because the compiler forces a match up of method
+    // definitions and declarations before any template instantiation.
+
+    template <typename H, typename F>
+    auto
+    IntrusiveHashMapApply(IntrusiveHashMap<H> &map, F &&f)
+      -> decltype(f(*static_cast<typename IntrusiveHashMap<H>::value_type *>(nullptr)), map)
+    {
+      return map.apply([&f](typename IntrusiveHashMap<H>::value_type *v) { return f(*v); });
     }
-    if (target->_count == 0) {
-      _active_buckets.erase(target);
+
+    template <typename H, typename F>
+    auto
+    IntrusiveHashMapApply(IntrusiveHashMap<H> &map, F &&f)
+      -> decltype(f(static_cast<typename IntrusiveHashMap<H>::value_type *>(nullptr)), map)
+    {
+      auto spot{map.begin()};
+      auto limit{map.end()};
+      while (spot != limit) {
+        f(spot++); // post increment means @a spot is updated before @a f is applied.
+      }
+      return map;
     }
+  } // namespace detail
+
+  template <typename H>
+  template <typename F>
+  auto
+  IntrusiveHashMap<H>::apply(F &&f) -> self_type &
+  {
+    return detail::IntrusiveHashMapApply(*this, f);
+  };
+
+  template <typename H>
+  void
+  IntrusiveHashMap<H>::expand()
+  {
+    ExpansionPolicy org_expansion_policy = _expansion_policy; // save for restore.
+    value_type *old                      = _list.head();      // save for repopulating.
+    auto old_size                        = _table.size();
+
+    // Reset to empty state.
+    this->clear();
+    _table.resize(*std::lower_bound(PRIME.begin(), PRIME.end(), old_size + 1));
+
+    _expansion_policy = MANUAL; // disable any auto expand while we're expanding.
+    while (old) {
+      value_type *v = old;
+      old           = H::next_ptr(old);
+      this->insert(v);
+    }
+    // stashed array gets cleaned up when @a tmp goes out of scope.
+    _expansion_policy = org_expansion_policy; // reset to original value.
   }
-  _list.erase(start, limit);
-  return _list.iterator_for(limit); // convert from const_iterator back to iterator
-};
 
-template <typename H>
-auto
-IntrusiveHashMap<H>::erase(range const &r) -> iterator {
-  return this->erase(r.first, r.second);
-}
-
-namespace detail {
-// Make @c apply more convenient by allowing the function to take a reference type or pointer type to the container
-// elements. The pointer type is the base, plus a shim to convert from a reference type functor to a pointer pointer
-// type. The complex return type definition forces only one, but not both, to be valid for a particular functor. This
-// also must be done via free functions and not method overloads because the compiler forces a match up of method
-// definitions and declarations before any template instantiation.
-
-template <typename H, typename F>
-auto
-IntrusiveHashMapApply(IntrusiveHashMap<H> &map, F &&f)
-  -> decltype(f(*static_cast<typename IntrusiveHashMap<H>::value_type *>(nullptr)), map) {
-  return map.apply([&f](typename IntrusiveHashMap<H>::value_type *v) { return f(*v); });
-}
-
-template <typename H, typename F>
-auto
-IntrusiveHashMapApply(IntrusiveHashMap<H> &map, F &&f)
-  -> decltype(f(static_cast<typename IntrusiveHashMap<H>::value_type *>(nullptr)), map) {
-  auto spot{map.begin()};
-  auto limit{map.end()};
-  while (spot != limit) {
-    f(spot++); // post increment means @a spot is updated before @a f is applied.
+  template <typename H>
+  size_t
+  IntrusiveHashMap<H>::count() const
+  {
+    return _list.count();
   }
-  return map;
-}
-} // namespace detail
 
-template <typename H>
-template <typename F>
-auto
-IntrusiveHashMap<H>::apply(F &&f) -> self_type & {
-  return detail::IntrusiveHashMapApply(*this, f);
-};
-
-template <typename H>
-void
-IntrusiveHashMap<H>::expand() {
-  ExpansionPolicy org_expansion_policy = _expansion_policy; // save for restore.
-  value_type *old                      = _list.head();      // save for repopulating.
-  auto old_size                        = _table.size();
-
-  // Reset to empty state.
-  this->clear();
-  _table.resize(*std::lower_bound(PRIME.begin(), PRIME.end(), old_size + 1));
-
-  _expansion_policy = MANUAL; // disable any auto expand while we're expanding.
-  while (old) {
-    value_type *v = old;
-    old           = H::next_ptr(old);
-    this->insert(v);
+  template <typename H>
+  size_t
+  IntrusiveHashMap<H>::bucket_count() const
+  {
+    return _table.size();
   }
-  // stashed array gets cleaned up when @a tmp goes out of scope.
-  _expansion_policy = org_expansion_policy; // reset to original value.
-}
 
-template <typename H>
-size_t
-IntrusiveHashMap<H>::count() const {
-  return _list.count();
-}
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::set_expansion_policy(ExpansionPolicy policy) -> self_type &
+  {
+    _expansion_policy = policy;
+    return *this;
+  }
 
-template <typename H>
-size_t
-IntrusiveHashMap<H>::bucket_count() const {
-  return _table.size();
-}
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::get_expansion_policy() const -> ExpansionPolicy
+  {
+    return _expansion_policy;
+  }
 
-template <typename H>
-auto
-IntrusiveHashMap<H>::set_expansion_policy(ExpansionPolicy policy) -> self_type & {
-  _expansion_policy = policy;
-  return *this;
-}
+  template <typename H>
+  auto
+  IntrusiveHashMap<H>::set_expansion_limit(size_t n) -> self_type &
+  {
+    _expansion_limit = n;
+    return *this;
+  }
 
-template <typename H>
-auto
-IntrusiveHashMap<H>::get_expansion_policy() const -> ExpansionPolicy {
-  return _expansion_policy;
-}
+  template <typename H>
+  size_t
+  IntrusiveHashMap<H>::get_expansion_limit() const
+  {
+    return _expansion_limit;
+  }
 
-template <typename H>
-auto
-IntrusiveHashMap<H>::set_expansion_limit(size_t n) -> self_type & {
-  _expansion_limit = n;
-  return *this;
-}
-
-template <typename H>
-size_t
-IntrusiveHashMap<H>::get_expansion_limit() const {
-  return _expansion_limit;
-}
-
-}} // namespace swoc::SWOC_VERSION_NS
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/include/swoc/Lexicon.h
+++ b/code/include/swoc/Lexicon.h
@@ -20,851 +20,915 @@
 #include "swoc/bwf_base.h"
 #include "swoc/ext/HashFNV.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
-namespace detail {
-/** Create an r-value reference to a temporary formatted string.
- *
- * @tparam Args Format string argument types.
- * @param fmt Format string.
- * @param args Arguments to format string.
- * @return r-value reference to a @c std::string containing the formatted string.
- *
- * This is used when throwing exceptions.
- */
-template <typename... Args>
-std::string
-what(std::string_view const &fmt, Args &&...args) {
-  std::string zret;
-  return swoc::bwprint_v(zret, fmt, std::forward_as_tuple(args...));
-}
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  namespace detail
+  {
+    /** Create an r-value reference to a temporary formatted string.
+     *
+     * @tparam Args Format string argument types.
+     * @param fmt Format string.
+     * @param args Arguments to format string.
+     * @return r-value reference to a @c std::string containing the formatted string.
+     *
+     * This is used when throwing exceptions.
+     */
+    template <typename... Args>
+    std::string
+    what(std::string_view const &fmt, Args &&...args)
+    {
+      std::string zret;
+      return swoc::bwprint_v(zret, fmt, std::forward_as_tuple(args...));
+    }
 
-// Exported because inner classes in template classes cannot be used in partial specialization
-// which is required for tuple support. This should be removed next time there is a API changing
-// release because tuple access is being deprecated.
-template < typename E > struct lexicon_pair_type {
-  E _value;
-  TextView _name;
+    // Exported because inner classes in template classes cannot be used in partial specialization
+    // which is required for tuple support. This should be removed next time there is a API changing
+    // release because tuple access is being deprecated.
+    template <typename E> struct lexicon_pair_type {
+      E _value;
+      TextView _name;
 
-  /// Constructor.
-  /// @internal Required to make the @c Lexicon constructors work as intended by forbidding
-  /// construction of this type with only a value.
-  lexicon_pair_type(E value, TextView name) : _value(value), _name(name) {}
-};
+      /// Constructor.
+      /// @internal Required to make the @c Lexicon constructors work as intended by forbidding
+      /// construction of this type with only a value.
+      lexicon_pair_type(E value, TextView name) : _value(value), _name(name) {}
+    };
 
-} // namespace detail
+  } // namespace detail
 
-/// Policy template use to specify the hash function for the integral type of @c Lexicon.
-/// The default is @c std::hash but that can be overridden by specializing this method.
-template <typename E>
-size_t
-Lexicon_Hash(E e) {
-  static constexpr std::hash<E> hasher;
-  return hasher(e);
-}
-
-/** A bidirectional mapping between names and enumeration values.
-
-    This is intended to be a support class to make interacting with enumerations easier for
-    configuration and logging. Names and enumerations can then be easily and reliably interchanged.
-    The names are case insensitive but preserving.
-
-    Each enumeration has a @a primary name and an arbitrary number of @a secondary names. When
-    converting from an enumeration, the primary name is used. However, any of the names will be
-    converted to the enumeration. For instance, a @c Lexicon for a boolean might have the primary
-    name of @c TRUE be "true" with the secondary names "1", "yes", "enable". In that case converting
-    @c TRUE would always be "true", while converting any of "true", "1", "yes", or "enable" would
-    yield @c TRUE. This is convenient for parsing configurations to be more tolerant of input.
-
-    The constructors are a bit baroque, but this is necessary in order to be able to declare
-    constant instances of the @c Lexicon. If this isn't necessary, everything that can be done via
-    the constructor can be done with other methods. The implementation of the constructors consists
-    entirely of calls to @c define and @c set_default, the only difference is these methods can
-    be called on a @c const instance from there.
-
-    @note All names and value must be unique across the Lexicon. All name comparisons are case
-    insensitive.
- */
-template <typename E> class Lexicon {
-  using self_type = Lexicon; ///< Self reference type.
-
-protected:
-  struct Item;
-
-public:
-  /// An association of an enumeration value and a name.
-  /// @ note Used for initializer lists that have just a primary value.
-  using Pair = detail::lexicon_pair_type<E>;
-
-  // Deprecated - use the member names now.
-  /// Index in @c Pair for the enumeration value.
-  static constexpr auto VALUE_IDX = 0;
-  /// Index in @c Pair for name.
-  static constexpr auto NAME_IDX = 1;
-
-  /** A function to be called if a value is not found to provide a default name.
-   * @param value The value.
-   * @return A name for the value.
-   *
-   * The name is return by view and therefore managing the lifetime of the name is problematic.
-   * Generally it should be process lifetime, unless some other shorter lifetime can be managed
-   * without a destructor being called. Unfortunately this can't be done any better without
-   * imposing memory management costs on normal use.
-   */
-  using UnknownValueHandler = std::function<TextView(E)>;
-
-  /** A function to be called if a name is not found, to provide a default value.
-   * @param name The name
-   * @return An enumeration value.
-   *
-   * The @a name is provided and a value in the enumeration type is expected.
-   */
-  using UnknownNameHandler = std::function<E(TextView)>;
-
-  /** A default handler.
-   *
-   * This handles providing a default value or name for a missing name or value.
-   */
-  using Default = std::variant<std::monostate, E, TextView, UnknownNameHandler, UnknownValueHandler>;
-
-  /// Element of an initializer list that contains secondary names.
-  /// @note This is used only in the constructor and contains transient data.
-  struct Definition {
-    const E &value;                               ///< Value for definition.
-    std::initializer_list<TextView> const &names; ///< Primary then secondary names.
-  };
-
-  /// Construct empty instance.
-  Lexicon();
-
-  using with       = std::initializer_list<Pair> const &;
-  using with_multi = std::initializer_list<Definition> const &;
-
-  /** Construct with names, possible secondary values, and optional default handlers.
-   *
-   * @param items A list of initializers, each of which is a name and a list of values.
-   * @param handler_1 A default handler.
-   * @param handler_2 A default hander.
-   *
-   * Each item in the intializers must be a @c Definition, that is a name and a list of values.
-   * The first value is the primary value and is required. Subsequent values are optional
-   * and become secondary values.
-   *
-   * The default handlers are optional can be omitted. If so, exceptions are thrown when values
-   * or names not in the @c Lexicon are used. See @c set_default for more details.
-   *
-   * @see set_default.
-   */
-  explicit Lexicon(with_multi items, Default handler_1 = Default{}, Default handler_2 = Default{});
-
-  /** Construct with names / value pairs, and optional default handlers.
-   *
-   * @param items A list of initializers, each of which is a name and a list of values.
-   * @param handler_1 A default handler.
-   * @param handler_2 A default handler.
-   *
-   * Each item in the intializers must be a @c Pair, that is a name and a value.
-   *
-   * The default handlers are optional can be omitted. If so, exceptions are thrown when values
-   * or names not in the @c Lexicon are used. See @c set_default for more details.
-   *
-   * @see set_default.
-   */
-  explicit Lexicon(with items, Default handler_1 = Default{}, Default handler_2 = Default{});
-
-  /** Construct with only default values / handlers.
-   *
-   * @param handler_1 A default handler.
-   * @param handler_2 A default handler.
-   *
-   * @a handler_2 is optional can be omitted. The argument values are the same as for
-   * @c set_default.
-   *
-   * @see set_default.
-   */
-  explicit Lexicon(Default handler_1, Default handler_2 = Default{});
-
-  Lexicon(self_type &&that) = default;
-
-  /** Get the name for a @a value.
-   *
-   * @param value Value to look up.
-   * @return The name for @a value.
-   */
-  TextView operator[](E const &value) const;
-
-  /** Get the value for a @a name.
-   *
-   * @param name Name to look up.
-   * @return The value for the @a name.
-   */
-  E operator[](TextView const &name) const;
-
-  /// Define the @a names for a @a value.
-  /// The first name is the primary name. All @a names must be convertible to @c std::string_view.
-  /// <tt>lexicon.define(Value, primary, [secondary, ... ]);</tt>
-  template <typename... Args> self_type &define(E value, Args &&...names);
-
-  // These are really for consistency with constructors, they're not expected to be commonly used.
-  /// Define a value and names.
-  /// <tt>lexicon.define(Value, { primary, [secondary, ...] });</tt>
-  self_type &define(E value, const std::initializer_list<TextView> &names);
-
-  /** Define a name, value pair.
-   *
-   * @param pair A @c Pair of the name and value to define.
-   * @return @a this.
-   */
-  self_type &define(const Pair &pair);
-
-  /** Define a name with a primary and secondary values.
-   *
-   * @param init The @c Definition with the name and values.
-   * @return @a this.
-   *
-   * This defines the name, with the first value in the value list becoming the primary value
-   * and subsequent values (if any) being the secondary values. A primary value is required but
-   * secondary values are not. This is to make it possible to define all values in this style
-   * even if some do not have secondary values.
-   */
-  self_type &define(const Definition &init);
-
-  /** Set default handler.
-   *
-   * @param handler The handler.
-   * @return @a this.
-   *
-   * The @a handler can be of various types.
-   *
-   * - An enumeration value. This sets the default value handler to return that value for any
-   *   name not found.
-   *
-   * - A @c string_view. The sets the default name handler to return the @c string_view as the
-   *   name for any value not found.
-   *
-   * - A @c DefaultNameHandler. This is a functor that takes an enumeration value parameter and
-   *   returns a @c string_view as the name for any value that is not found.
-   *
-   * - A @c DefaultValueHandler. This is a functor that takes a name as a @c string_view and returns
-   *   an enumeration value as the value for any name that is not found.
-   */
-  self_type &set_default(Default const &handler);
-
-  /// Get the number of values with definitions.
-  size_t count() const;
-
-protected:
-  /// Common features of container iterators.
-  class base_iterator {
-    using self_type = base_iterator;
-
-  public:
-    using value_type        = const Pair;                      ///< Iteration value.
-    using pointer           = value_type *;                    ///< Pointer to iteration value.
-    using reference         = value_type &;                    ///< Reference to iteration value.
-    using difference_type   = ptrdiff_t;                       ///< Type of difference between iterators.
-    using iterator_category = std::bidirectional_iterator_tag; ///< Concepts for iterator.
-    /// Default constructor (invalid iterator)
-    base_iterator() = default;
-    /// Dereference.
-    reference operator*() const;
-    /// Dereference.
-    pointer operator->() const;
-    /// Equality.
-    bool operator==(self_type const &that) const;
-    /// Inequality.
-    bool operator!=(self_type const &that) const;
-
-  protected:
-    explicit base_iterator(Item const *item) : _item(item) {}
-
-    const Item *_item{nullptr}; ///< Current location in the container.
-  };
-
-public:
-  /** Iterator over pairs of values and primary name pairs.
-   *  The value type is a @c Pair with the value and name.
-   */
-  class value_iterator : public base_iterator {
-    using super_type = base_iterator;
-    using self_type  = value_iterator;
-
-  public:
-    using value_type = typename super_type::value_type;
-    using pointer    = typename super_type::pointer;
-    using reference  = typename super_type::reference;
-
-    /// Default constructor.
-    value_iterator() = default;
-
-    /// Copy constructor.
-    value_iterator(self_type const &that) = default;
-
-    /// Move constructor.
-    value_iterator(self_type &&that) = default;
-
-    /// Assignment.
-    self_type &operator=(self_type const &that) = default;
-
-    /// Increment.
-    self_type &operator++();
-
-    /// Increment.
-    self_type operator++(int);
-
-    /// Decrement.
-    self_type &operator--();
-
-    /// Decrement.
-    self_type operator--(int);
-
-  protected:
-    value_iterator(const Item *item) : super_type(item){}; ///< Internal constructor.
-
-    friend Lexicon;
-  };
-
-  class name_iterator : public base_iterator {
-  private:
-    using self_type  = name_iterator;
-    using super_type = base_iterator;
-
-  public:
-    /// Default constructor.
-    name_iterator() = default;
-
-    /// Copy constructor.
-    name_iterator(self_type const &that) = default;
-
-    /// Move constructor.
-    name_iterator(self_type &&that) = default;
-
-    /// Assignment.
-    self_type &operator=(self_type const &that) = default;
-
-    /// Increment.
-    self_type &operator++();
-
-    /// Increment.
-    self_type operator++(int);
-
-    /// Decrement.
-    self_type &operator--();
-
-    /// Decrement.
-    self_type operator--(int);
-
-  protected:
-    name_iterator(const Item *item) : super_type(item){}; ///< Internal constructor.
-
-    friend Lexicon;
-  };
-
-  /// Iterator over values (each with a primary name).
-  using const_iterator = value_iterator;
-  /// Iterator over values.
-  /// @note All iteration is over constant pairs, no modification is possible.
-  using iterator = const_iterator;
-
-  /// Iteration begin.
-  const_iterator begin() const;
-
-  /// Iteration end.
-  const_iterator end() const;
-
-  /// Iteration over names - every value/name pair.
-  name_iterator
-  begin_names() const {
-    return {_by_name.begin()};
-  }
-  /// Iteration over names - every value/name pair.
-  name_iterator
-  end_names() const {
-    return {_by_name.end()};
+  /// Policy template use to specify the hash function for the integral type of @c Lexicon.
+  /// The default is @c std::hash but that can be overridden by specializing this method.
+  template <typename E>
+  size_t
+  Lexicon_Hash(E e)
+  {
+    static constexpr std::hash<E> hasher;
+    return hasher(e);
   }
 
-  /// @cond INTERNAL
-  // Helper struct to return to enable container iteration for names.
-  struct ByNameHelper {
-    self_type const &_lexicon;
-    ByNameHelper(self_type const &self) : _lexicon(self) {}
+  /** A bidirectional mapping between names and enumeration values.
+
+      This is intended to be a support class to make interacting with enumerations easier for
+      configuration and logging. Names and enumerations can then be easily and reliably interchanged.
+      The names are case insensitive but preserving.
+
+      Each enumeration has a @a primary name and an arbitrary number of @a secondary names. When
+      converting from an enumeration, the primary name is used. However, any of the names will be
+      converted to the enumeration. For instance, a @c Lexicon for a boolean might have the primary
+      name of @c TRUE be "true" with the secondary names "1", "yes", "enable". In that case converting
+      @c TRUE would always be "true", while converting any of "true", "1", "yes", or "enable" would
+      yield @c TRUE. This is convenient for parsing configurations to be more tolerant of input.
+
+      The constructors are a bit baroque, but this is necessary in order to be able to declare
+      constant instances of the @c Lexicon. If this isn't necessary, everything that can be done via
+      the constructor can be done with other methods. The implementation of the constructors consists
+      entirely of calls to @c define and @c set_default, the only difference is these methods can
+      be called on a @c const instance from there.
+
+      @note All names and value must be unique across the Lexicon. All name comparisons are case
+      insensitive.
+   */
+  template <typename E> class Lexicon
+  {
+    using self_type = Lexicon; ///< Self reference type.
+
+  protected:
+    struct Item;
+
+  public:
+    /// An association of an enumeration value and a name.
+    /// @ note Used for initializer lists that have just a primary value.
+    using Pair = detail::lexicon_pair_type<E>;
+
+    // Deprecated - use the member names now.
+    /// Index in @c Pair for the enumeration value.
+    static constexpr auto VALUE_IDX = 0;
+    /// Index in @c Pair for name.
+    static constexpr auto NAME_IDX = 1;
+
+    /** A function to be called if a value is not found to provide a default name.
+     * @param value The value.
+     * @return A name for the value.
+     *
+     * The name is return by view and therefore managing the lifetime of the name is problematic.
+     * Generally it should be process lifetime, unless some other shorter lifetime can be managed
+     * without a destructor being called. Unfortunately this can't be done any better without
+     * imposing memory management costs on normal use.
+     */
+    using UnknownValueHandler = std::function<TextView(E)>;
+
+    /** A function to be called if a name is not found, to provide a default value.
+     * @param name The name
+     * @return An enumeration value.
+     *
+     * The @a name is provided and a value in the enumeration type is expected.
+     */
+    using UnknownNameHandler = std::function<E(TextView)>;
+
+    /** A default handler.
+     *
+     * This handles providing a default value or name for a missing name or value.
+     */
+    using Default = std::variant<std::monostate, E, TextView, UnknownNameHandler, UnknownValueHandler>;
+
+    /// Element of an initializer list that contains secondary names.
+    /// @note This is used only in the constructor and contains transient data.
+    struct Definition {
+      const E &value;                               ///< Value for definition.
+      std::initializer_list<TextView> const &names; ///< Primary then secondary names.
+    };
+
+    /// Construct empty instance.
+    Lexicon();
+
+    using with       = std::initializer_list<Pair> const &;
+    using with_multi = std::initializer_list<Definition> const &;
+
+    /** Construct with names, possible secondary values, and optional default handlers.
+     *
+     * @param items A list of initializers, each of which is a name and a list of values.
+     * @param handler_1 A default handler.
+     * @param handler_2 A default hander.
+     *
+     * Each item in the intializers must be a @c Definition, that is a name and a list of values.
+     * The first value is the primary value and is required. Subsequent values are optional
+     * and become secondary values.
+     *
+     * The default handlers are optional can be omitted. If so, exceptions are thrown when values
+     * or names not in the @c Lexicon are used. See @c set_default for more details.
+     *
+     * @see set_default.
+     */
+    explicit Lexicon(with_multi items, Default handler_1 = Default{}, Default handler_2 = Default{});
+
+    /** Construct with names / value pairs, and optional default handlers.
+     *
+     * @param items A list of initializers, each of which is a name and a list of values.
+     * @param handler_1 A default handler.
+     * @param handler_2 A default handler.
+     *
+     * Each item in the intializers must be a @c Pair, that is a name and a value.
+     *
+     * The default handlers are optional can be omitted. If so, exceptions are thrown when values
+     * or names not in the @c Lexicon are used. See @c set_default for more details.
+     *
+     * @see set_default.
+     */
+    explicit Lexicon(with items, Default handler_1 = Default{}, Default handler_2 = Default{});
+
+    /** Construct with only default values / handlers.
+     *
+     * @param handler_1 A default handler.
+     * @param handler_2 A default handler.
+     *
+     * @a handler_2 is optional can be omitted. The argument values are the same as for
+     * @c set_default.
+     *
+     * @see set_default.
+     */
+    explicit Lexicon(Default handler_1, Default handler_2 = Default{});
+
+    Lexicon(self_type &&that) = default;
+
+    /** Get the name for a @a value.
+     *
+     * @param value Value to look up.
+     * @return The name for @a value.
+     */
+    TextView operator[](E const &value) const;
+
+    /** Get the value for a @a name.
+     *
+     * @param name Name to look up.
+     * @return The value for the @a name.
+     */
+    E operator[](TextView const &name) const;
+
+    /// Define the @a names for a @a value.
+    /// The first name is the primary name. All @a names must be convertible to @c std::string_view.
+    /// <tt>lexicon.define(Value, primary, [secondary, ... ]);</tt>
+    template <typename... Args> self_type &define(E value, Args &&...names);
+
+    // These are really for consistency with constructors, they're not expected to be commonly used.
+    /// Define a value and names.
+    /// <tt>lexicon.define(Value, { primary, [secondary, ...] });</tt>
+    self_type &define(E value, const std::initializer_list<TextView> &names);
+
+    /** Define a name, value pair.
+     *
+     * @param pair A @c Pair of the name and value to define.
+     * @return @a this.
+     */
+    self_type &define(const Pair &pair);
+
+    /** Define a name with a primary and secondary values.
+     *
+     * @param init The @c Definition with the name and values.
+     * @return @a this.
+     *
+     * This defines the name, with the first value in the value list becoming the primary value
+     * and subsequent values (if any) being the secondary values. A primary value is required but
+     * secondary values are not. This is to make it possible to define all values in this style
+     * even if some do not have secondary values.
+     */
+    self_type &define(const Definition &init);
+
+    /** Set default handler.
+     *
+     * @param handler The handler.
+     * @return @a this.
+     *
+     * The @a handler can be of various types.
+     *
+     * - An enumeration value. This sets the default value handler to return that value for any
+     *   name not found.
+     *
+     * - A @c string_view. The sets the default name handler to return the @c string_view as the
+     *   name for any value not found.
+     *
+     * - A @c DefaultNameHandler. This is a functor that takes an enumeration value parameter and
+     *   returns a @c string_view as the name for any value that is not found.
+     *
+     * - A @c DefaultValueHandler. This is a functor that takes a name as a @c string_view and returns
+     *   an enumeration value as the value for any name that is not found.
+     */
+    self_type &set_default(Default const &handler);
+
+    /// Get the number of values with definitions.
+    size_t count() const;
+
+  protected:
+    /// Common features of container iterators.
+    class base_iterator
+    {
+      using self_type = base_iterator;
+
+    public:
+      using value_type        = const Pair;                      ///< Iteration value.
+      using pointer           = value_type *;                    ///< Pointer to iteration value.
+      using reference         = value_type &;                    ///< Reference to iteration value.
+      using difference_type   = ptrdiff_t;                       ///< Type of difference between iterators.
+      using iterator_category = std::bidirectional_iterator_tag; ///< Concepts for iterator.
+      /// Default constructor (invalid iterator)
+      base_iterator() = default;
+      /// Dereference.
+      reference operator*() const;
+      /// Dereference.
+      pointer operator->() const;
+      /// Equality.
+      bool operator==(self_type const &that) const;
+      /// Inequality.
+      bool operator!=(self_type const &that) const;
+
+    protected:
+      explicit base_iterator(Item const *item) : _item(item) {}
+
+      const Item *_item{nullptr}; ///< Current location in the container.
+    };
+
+  public:
+    /** Iterator over pairs of values and primary name pairs.
+     *  The value type is a @c Pair with the value and name.
+     */
+    class value_iterator : public base_iterator
+    {
+      using super_type = base_iterator;
+      using self_type  = value_iterator;
+
+    public:
+      using value_type = typename super_type::value_type;
+      using pointer    = typename super_type::pointer;
+      using reference  = typename super_type::reference;
+
+      /// Default constructor.
+      value_iterator() = default;
+
+      /// Copy constructor.
+      value_iterator(self_type const &that) = default;
+
+      /// Move constructor.
+      value_iterator(self_type &&that) = default;
+
+      /// Assignment.
+      self_type &operator=(self_type const &that) = default;
+
+      /// Increment.
+      self_type &operator++();
+
+      /// Increment.
+      self_type operator++(int);
+
+      /// Decrement.
+      self_type &operator--();
+
+      /// Decrement.
+      self_type operator--(int);
+
+    protected:
+      value_iterator(const Item *item) : super_type(item){}; ///< Internal constructor.
+
+      friend Lexicon;
+    };
+
+    class name_iterator : public base_iterator
+    {
+    private:
+      using self_type  = name_iterator;
+      using super_type = base_iterator;
+
+    public:
+      /// Default constructor.
+      name_iterator() = default;
+
+      /// Copy constructor.
+      name_iterator(self_type const &that) = default;
+
+      /// Move constructor.
+      name_iterator(self_type &&that) = default;
+
+      /// Assignment.
+      self_type &operator=(self_type const &that) = default;
+
+      /// Increment.
+      self_type &operator++();
+
+      /// Increment.
+      self_type operator++(int);
+
+      /// Decrement.
+      self_type &operator--();
+
+      /// Decrement.
+      self_type operator--(int);
+
+    protected:
+      name_iterator(const Item *item) : super_type(item){}; ///< Internal constructor.
+
+      friend Lexicon;
+    };
+
+    /// Iterator over values (each with a primary name).
+    using const_iterator = value_iterator;
+    /// Iterator over values.
+    /// @note All iteration is over constant pairs, no modification is possible.
+    using iterator = const_iterator;
+
+    /// Iteration begin.
+    const_iterator begin() const;
+
+    /// Iteration end.
+    const_iterator end() const;
+
+    /// Iteration over names - every value/name pair.
     name_iterator
-    begin() const {
-      return _lexicon.begin_names();
+    begin_names() const
+    {
+      return {_by_name.begin()};
     }
+    /// Iteration over names - every value/name pair.
     name_iterator
-    end() const {
-      return _lexicon.end_names();
+    end_names() const
+    {
+      return {_by_name.end()};
     }
+
+    /// @cond INTERNAL
+    // Helper struct to return to enable container iteration for names.
+    struct ByNameHelper {
+      self_type const &_lexicon;
+      ByNameHelper(self_type const &self) : _lexicon(self) {}
+      name_iterator
+      begin() const
+      {
+        return _lexicon.begin_names();
+      }
+      name_iterator
+      end() const
+      {
+        return _lexicon.end_names();
+      }
+    };
+    /// @endcond
+
+    /** Enable container iteration by name.
+     * The return value is a tempoary of indeterminate type that provides @c begin and @c end methods which
+     * return name based iterators for @a this. This is useful for container based iteration. E.g. to iterate
+     * over all of the value/name pairs,
+     * @code
+     * for ( auto const & pair : lexicon.by_names()) {
+     *   // code
+     * }
+     * @endcode
+     * @return Temporary.
+     */
+    ByNameHelper
+    by_names() const
+    {
+      return {*this};
+    }
+
+  protected:
+    /// Handle providing a default name.
+    using NameDefault = std::variant<std::monostate, std::string_view, UnknownValueHandler>;
+    /// Handle providing a default value.
+    using ValueDefault = std::variant<std::monostate, E, UnknownNameHandler>;
+
+    /// Visitor functor for handling @c NameDefault.
+    struct NameDefaultVisitor {
+      E _value; ///< Value to use for default.
+
+      /// Visitor - invalid value type.
+      std::string_view
+      operator()(std::monostate const &) const
+      {
+        throw std::domain_error("Lexicon: invalid enumeration value");
+      }
+
+      /// Visitor - literal string.
+      std::string_view
+      operator()(TextView const &name) const
+      {
+        return name;
+      }
+
+      /// Visitor - string generator.
+      std::string_view
+      operator()(UnknownValueHandler const &handler) const
+      {
+        return handler(_value);
+      }
+    };
+
+    /// Visitor functor for handling @c ValueDefault.
+    struct ValueDefaultVisitor {
+      std::string_view _name; ///< Name of visited pair.
+
+      /// Vistor - invalid value.
+      E
+      operator()(std::monostate const &) const
+      {
+        throw std::domain_error(detail::what("Lexicon: Unknown name \"{}\"", _name).data());
+      }
+
+      /// Visitor - value.
+      E
+      operator()(E const &value) const
+      {
+        return value;
+      }
+
+      /// Visitor - value generator.
+      E
+      operator()(UnknownNameHandler const &handler) const
+      {
+        return handler(_name);
+      }
+    };
+
+    /// Each unique pair of value and name is stored as an instance of this class.
+    /// The primary is stored first and is therefore found by normal lookup.
+    struct Item {
+      /** Construct with a @a name and a primary @a value.
+       *
+       * @param value The primary value.
+       * @param name The name.
+       *
+       */
+      Item(E value, TextView name);
+
+      Pair _payload; ///< Enumeration and name.
+
+      /// @cond INTERNAL_DETAIL
+      // Intrusive list linkage support.
+      struct NameLinkage {
+        Item *_next{nullptr};
+        Item *_prev{nullptr};
+
+        static Item *&next_ptr(Item *);
+        static Item *&prev_ptr(Item *);
+        static std::string_view key_of(Item *);
+        static uint32_t hash_of(std::string_view s);
+        static bool equal(std::string_view const &lhs, std::string_view const &rhs);
+      } _name_link;
+
+      // Intrusive linkage for value lookup.
+      struct ValueLinkage {
+        Item *_next{nullptr};
+        Item *_prev{nullptr};
+
+        static Item *&next_ptr(Item *);
+        static Item *&prev_ptr(Item *);
+        static E key_of(Item *);
+        static size_t hash_of(E);
+        static bool equal(E lhs, E rhs);
+      } _value_link;
+      /// @endcond
+    };
+
+    /// Copy @a name in to local storage.
+    TextView localize(TextView const &name);
+
+    /// Storage for names.
+    MemArena _arena{1024};
+    /// Access by name.
+    IntrusiveHashMap<typename Item::NameLinkage> _by_name;
+    /// Access by value.
+    IntrusiveHashMap<typename Item::ValueLinkage> _by_value;
+    NameDefault _name_default;   ///< Name to return if no value not found.
+    ValueDefault _value_default; ///< Value to return if name not found.
   };
+
+  // ==============
+  // Implementation
+
+  // ----
+  // Item
+
+  template <typename E> Lexicon<E>::Item::Item(E value, TextView name) : _payload{value, name} {}
+
+  /// @cond INTERNAL_DETAIL
+  template <typename E>
+  auto
+  Lexicon<E>::Item::NameLinkage::next_ptr(Item *item) -> Item *&
+  {
+    return item->_name_link._next;
+  }
+
+  template <typename E>
+  auto
+  Lexicon<E>::Item::NameLinkage::prev_ptr(Item *item) -> Item *&
+  {
+    return item->_name_link._prev;
+  }
+
+  template <typename E>
+  auto
+  Lexicon<E>::Item::ValueLinkage::next_ptr(Item *item) -> Item *&
+  {
+    return item->_value_link._next;
+  }
+
+  template <typename E>
+  auto
+  Lexicon<E>::Item::ValueLinkage::prev_ptr(Item *item) -> Item *&
+  {
+    return item->_value_link._prev;
+  }
+
+  template <typename E>
+  std::string_view
+  Lexicon<E>::Item::NameLinkage::key_of(Item *item)
+  {
+    return item->_payload._name;
+  }
+
+  template <typename E>
+  E
+  Lexicon<E>::Item::ValueLinkage::key_of(Item *item)
+  {
+    return item->_payload._value;
+  }
+
+  template <typename E>
+  uint32_t
+  Lexicon<E>::Item::NameLinkage::hash_of(std::string_view s)
+  {
+    return Hash32FNV1a().hash_immediate(transform_view_of(&toupper, s));
+  }
+
+  template <typename E>
+  size_t
+  Lexicon<E>::Item::ValueLinkage::hash_of(E value)
+  {
+    return Lexicon_Hash<E>(value);
+  }
+
+  template <typename E>
+  bool
+  Lexicon<E>::Item::NameLinkage::equal(std::string_view const &lhs, std::string_view const &rhs)
+  {
+    return 0 == strcasecmp(lhs, rhs);
+  }
+
+  template <typename E>
+  bool
+  Lexicon<E>::Item::ValueLinkage::equal(E lhs, E rhs)
+  {
+    return lhs == rhs;
+  }
   /// @endcond
 
-  /** Enable container iteration by name.
-   * The return value is a tempoary of indeterminate type that provides @c begin and @c end methods which
-   * return name based iterators for @a this. This is useful for container based iteration. E.g. to iterate
-   * over all of the value/name pairs,
-   * @code
-   * for ( auto const & pair : lexicon.by_names()) {
-   *   // code
-   * }
-   * @endcode
-   * @return Temporary.
-   */
-  ByNameHelper
-  by_names() const {
-    return {*this};
-  }
+  // -------
+  // Lexicon
 
-protected:
-  /// Handle providing a default name.
-  using NameDefault = std::variant<std::monostate, std::string_view, UnknownValueHandler>;
-  /// Handle providing a default value.
-  using ValueDefault = std::variant<std::monostate, E, UnknownNameHandler>;
+  template <typename E> Lexicon<E>::Lexicon() {}
 
-  /// Visitor functor for handling @c NameDefault.
-  struct NameDefaultVisitor {
-    E _value; ///< Value to use for default.
-
-    /// Visitor - invalid value type.
-    std::string_view
-    operator()(std::monostate const &) const {
-      throw std::domain_error("Lexicon: invalid enumeration value");
+  template <typename E> Lexicon<E>::Lexicon(with_multi items, Default handler_1, Default handler_2)
+  {
+    for (auto const &item : items) {
+      this->define(item.value, item.names);
     }
 
-    /// Visitor - literal string.
-    std::string_view
-    operator()(TextView const &name) const {
-      return name;
-    }
-
-    /// Visitor - string generator.
-    std::string_view
-    operator()(UnknownValueHandler const &handler) const {
-      return handler(_value);
-    }
-  };
-
-  /// Visitor functor for handling @c ValueDefault.
-  struct ValueDefaultVisitor {
-    std::string_view _name; ///< Name of visited pair.
-
-    /// Vistor - invalid value.
-    E
-    operator()(std::monostate const &) const {
-      throw std::domain_error(detail::what("Lexicon: Unknown name \"{}\"", _name).data());
-    }
-
-    /// Visitor - value.
-    E
-    operator()(E const &value) const {
-      return value;
-    }
-
-    /// Visitor - value generator.
-    E
-    operator()(UnknownNameHandler const &handler) const {
-      return handler(_name);
-    }
-  };
-
-  /// Each unique pair of value and name is stored as an instance of this class.
-  /// The primary is stored first and is therefore found by normal lookup.
-  struct Item {
-    /** Construct with a @a name and a primary @a value.
-     *
-     * @param value The primary value.
-     * @param name The name.
-     *
-     */
-    Item(E value, TextView name);
-
-    Pair _payload; ///< Enumeration and name.
-
-    /// @cond INTERNAL_DETAIL
-    // Intrusive list linkage support.
-    struct NameLinkage {
-      Item *_next{nullptr};
-      Item *_prev{nullptr};
-
-      static Item *&next_ptr(Item *);
-      static Item *&prev_ptr(Item *);
-      static std::string_view key_of(Item *);
-      static uint32_t hash_of(std::string_view s);
-      static bool equal(std::string_view const &lhs, std::string_view const &rhs);
-    } _name_link;
-
-    // Intrusive linkage for value lookup.
-    struct ValueLinkage {
-      Item *_next{nullptr};
-      Item *_prev{nullptr};
-
-      static Item *&next_ptr(Item *);
-      static Item *&prev_ptr(Item *);
-      static E key_of(Item *);
-      static size_t hash_of(E);
-      static bool equal(E lhs, E rhs);
-    } _value_link;
-    /// @endcond
-  };
-
-  /// Copy @a name in to local storage.
-  TextView localize(TextView const &name);
-
-  /// Storage for names.
-  MemArena _arena{1024};
-  /// Access by name.
-  IntrusiveHashMap<typename Item::NameLinkage> _by_name;
-  /// Access by value.
-  IntrusiveHashMap<typename Item::ValueLinkage> _by_value;
-  NameDefault _name_default;   ///< Name to return if no value not found.
-  ValueDefault _value_default; ///< Value to return if name not found.
-};
-
-// ==============
-// Implementation
-
-// ----
-// Item
-
-template <typename E> Lexicon<E>::Item::Item(E value, TextView name) : _payload{value, name} {}
-
-/// @cond INTERNAL_DETAIL
-template <typename E>
-auto
-Lexicon<E>::Item::NameLinkage::next_ptr(Item *item) -> Item *& {
-  return item->_name_link._next;
-}
-
-template <typename E>
-auto
-Lexicon<E>::Item::NameLinkage::prev_ptr(Item *item) -> Item *& {
-  return item->_name_link._prev;
-}
-
-template <typename E>
-auto
-Lexicon<E>::Item::ValueLinkage::next_ptr(Item *item) -> Item *& {
-  return item->_value_link._next;
-}
-
-template <typename E>
-auto
-Lexicon<E>::Item::ValueLinkage::prev_ptr(Item *item) -> Item *& {
-  return item->_value_link._prev;
-}
-
-template <typename E>
-std::string_view
-Lexicon<E>::Item::NameLinkage::key_of(Item *item) {
-  return item->_payload._name;
-}
-
-template <typename E>
-E
-Lexicon<E>::Item::ValueLinkage::key_of(Item *item) {
-  return item->_payload._value;
-}
-
-template <typename E>
-uint32_t
-Lexicon<E>::Item::NameLinkage::hash_of(std::string_view s) {
-  return Hash32FNV1a().hash_immediate(transform_view_of(&toupper, s));
-}
-
-template <typename E>
-size_t
-Lexicon<E>::Item::ValueLinkage::hash_of(E value) {
-  return Lexicon_Hash<E>(value);
-}
-
-template <typename E>
-bool
-Lexicon<E>::Item::NameLinkage::equal(std::string_view const &lhs, std::string_view const &rhs) {
-  return 0 == strcasecmp(lhs, rhs);
-}
-
-template <typename E>
-bool
-Lexicon<E>::Item::ValueLinkage::equal(E lhs, E rhs) {
-  return lhs == rhs;
-}
-/// @endcond
-
-// -------
-// Lexicon
-
-template <typename E> Lexicon<E>::Lexicon() {}
-
-template <typename E> Lexicon<E>::Lexicon(with_multi items, Default handler_1, Default handler_2) {
-  for (auto const &item : items) {
-    this->define(item.value, item.names);
-  }
-
-  for (auto &&h : {handler_1, handler_2}) {
-    this->set_default(h);
-  }
-}
-
-template <typename E> Lexicon<E>::Lexicon(with items, Default handler_1, Default handler_2) {
-  for (auto const &item : items) {
-    this->define(item);
-  }
-
-  for (auto &&h : {handler_1, handler_2}) {
-    this->set_default(h);
-  }
-}
-
-template <typename E> Lexicon<E>::Lexicon(Default handler_1, Default handler_2) {
-  for (auto &&h : {handler_1, handler_2}) {
-    this->set_default(h);
-  }
-}
-
-template <typename E>
-TextView
-Lexicon<E>::localize(TextView const &name) {
-  auto span = _arena.alloc_span<char>(name.size());
-  memcpy(span, name);
-  return {span.data(), span.size()};
-}
-
-template <typename E>
-TextView
-Lexicon<E>::operator[](E const &value) const {
-  if (auto spot = _by_value.find(value); spot != _by_value.end()) {
-    return spot->_payload._name;
-  }
-  return std::visit(NameDefaultVisitor{value}, _name_default);
-}
-
-template <typename E>
-E
-Lexicon<E>::operator[](TextView const &name) const {
-  if (auto spot = _by_name.find(name); spot != _by_name.end()) {
-    return spot->_payload._value;
-  }
-  return std::visit(ValueDefaultVisitor{name}, _value_default);
-}
-
-template <typename E>
-auto
-Lexicon<E>::define(E value, const std::initializer_list<TextView> &names) -> self_type & {
-  if (names.size() < 1) {
-    throw std::invalid_argument("A defined value must have at least a primary name");
-  }
-  for (auto const &name : names) {
-    if (_by_name.find(name) != _by_name.end()) {
-      throw std::invalid_argument(detail::what("Duplicate name '{}' in Lexicon", name));
-    }
-    auto i = _arena.make<Item>(value, this->localize(name));
-    _by_name.insert(i);
-    // Only put primary names in the value table.
-    if (_by_value.find(value) == _by_value.end()) {
-      _by_value.insert(i);
+    for (auto &&h : {handler_1, handler_2}) {
+      this->set_default(h);
     }
   }
-  return *this;
-}
 
-template <typename E>
-template <typename... Args>
-auto
-Lexicon<E>::define(E value, Args &&...names) -> self_type & {
-  static_assert(sizeof...(Args) > 0, "A defined value must have at least a primary name");
-  return this->define(value, {std::forward<Args>(names)...});
-}
+  template <typename E> Lexicon<E>::Lexicon(with items, Default handler_1, Default handler_2)
+  {
+    for (auto const &item : items) {
+      this->define(item);
+    }
 
-template <typename E>
-auto
-Lexicon<E>::define(const Pair &pair) -> self_type & {
-  return this->define(pair._value, pair._name);
-}
-
-template <typename E>
-auto
-Lexicon<E>::define(const Definition &init) -> self_type & {
-  return this->define(init.value, init.names);
-}
-
-template <typename E>
-auto
-Lexicon<E>::set_default(Default const &handler) -> self_type & {
-  switch (handler.index()) {
-  case 0:
-    break;
-  case 1:
-    _value_default = std::get<1>(handler);
-    break;
-  case 3:
-    _value_default = std::get<3>(handler);
-    break;
-  case 2:
-    _name_default = std::get<2>(handler);
-    break;
-  case 4:
-    _name_default = std::get<4>(handler);
-    break;
+    for (auto &&h : {handler_1, handler_2}) {
+      this->set_default(h);
+    }
   }
-  return *this;
-}
 
-template <typename E>
-size_t
-Lexicon<E>::count() const {
-  return _by_value.count();
-}
+  template <typename E> Lexicon<E>::Lexicon(Default handler_1, Default handler_2)
+  {
+    for (auto &&h : {handler_1, handler_2}) {
+      this->set_default(h);
+    }
+  }
 
-template <typename E>
-auto
-Lexicon<E>::begin() const -> const_iterator {
-  return const_iterator{static_cast<const Item *>(_by_value.begin())};
-}
+  template <typename E>
+  TextView
+  Lexicon<E>::localize(TextView const &name)
+  {
+    auto span = _arena.alloc_span<char>(name.size());
+    memcpy(span, name);
+    return {span.data(), span.size()};
+  }
 
-template <typename E>
-auto
-Lexicon<E>::end() const -> const_iterator {
-  return {};
-}
+  template <typename E>
+  TextView
+  Lexicon<E>::operator[](E const &value) const
+  {
+    if (auto spot = _by_value.find(value); spot != _by_value.end()) {
+      return spot->_payload._name;
+    }
+    return std::visit(NameDefaultVisitor{value}, _name_default);
+  }
 
-// Iterators
+  template <typename E>
+  E
+  Lexicon<E>::operator[](TextView const &name) const
+  {
+    if (auto spot = _by_name.find(name); spot != _by_name.end()) {
+      return spot->_payload._value;
+    }
+    return std::visit(ValueDefaultVisitor{name}, _value_default);
+  }
 
-template <typename E>
-auto
-Lexicon<E>::base_iterator::operator*() const -> reference {
-  return _item->_payload;
-}
-
-template <typename E>
-auto
-Lexicon<E>::base_iterator::operator->() const -> pointer {
-  return &(_item->_payload);
-}
-
-template <typename E>
-bool
-Lexicon<E>::base_iterator::operator==(self_type const &that) const {
-  return _item == that._item;
-}
-
-template <typename E>
-bool
-Lexicon<E>::base_iterator::operator!=(self_type const &that) const {
-  return _item != that._item;
-}
-
-template <typename E>
-auto
-Lexicon<E>::value_iterator::operator++() -> self_type & {
-  super_type::_item = super_type::_item->_value_link._next;
-  return *this;
-}
-
-template <typename E>
-auto
-Lexicon<E>::value_iterator::operator++(int) -> self_type {
-  self_type tmp{*this};
-  ++*this;
-  return tmp;
-}
-
-template <typename E>
-auto
-Lexicon<E>::value_iterator::operator--() -> self_type & {
-  super_type::_item = super_type::_item->_value_link->_prev;
-  return *this;
-}
-
-template <typename E>
-auto
-Lexicon<E>::value_iterator::operator--(int) -> self_type {
-  self_type tmp;
-  ++*this;
-  return tmp;
-}
-
-template <typename E>
-auto
-Lexicon<E>::name_iterator::operator++() -> self_type & {
-  super_type::_item = super_type::_item->_name_link._next;
-  return *this;
-}
-
-template <typename E>
-auto
-Lexicon<E>::name_iterator::operator++(int) -> self_type {
-  self_type tmp{*this};
-  ++*this;
-  return tmp;
-}
-
-template <typename E>
-auto
-Lexicon<E>::name_iterator::operator--() -> self_type & {
-  super_type::_item = super_type::_item->_name_link->_prev;
-  return *this;
-}
-
-template <typename E>
-auto
-Lexicon<E>::name_iterator::operator--(int) -> self_type {
-  self_type tmp;
-  ++*this;
-  return tmp;
-}
-
-template <typename E>
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, Lexicon<E> const &lex) {
-  bool sep_p = false;
-  if (spec._type == 's' || spec._type == 'S') {
-    for (auto &&[value, name] : lex) {
-      if (sep_p) {
-        w.write(',');
+  template <typename E>
+  auto
+  Lexicon<E>::define(E value, const std::initializer_list<TextView> &names) -> self_type &
+  {
+    if (names.size() < 1) {
+      throw std::invalid_argument("A defined value must have at least a primary name");
+    }
+    for (auto const &name : names) {
+      if (_by_name.find(name) != _by_name.end()) {
+        throw std::invalid_argument(detail::what("Duplicate name '{}' in Lexicon", name));
       }
-      bwformat(w, spec, name);
-      sep_p = true;
-    }
-  } else if (spec.has_numeric_type()) {
-    for (auto &&[value, name] : lex) {
-      if (sep_p) {
-        w.write(',');
+      auto i = _arena.make<Item>(value, this->localize(name));
+      _by_name.insert(i);
+      // Only put primary names in the value table.
+      if (_by_value.find(value) == _by_value.end()) {
+        _by_value.insert(i);
       }
-      bwformat(w, spec, unsigned(value));
-      sep_p = true;
     }
-  } else {
-    for (auto &&[value, name] : lex) {
-      if (sep_p) {
-        w.write(',');
-      }
-      w.print("[{},{}]", name, unsigned(value));
-      sep_p = true;
-    }
+    return *this;
   }
-  return w;
-}
 
-}} // namespace swoc
+  template <typename E>
+  template <typename... Args>
+  auto
+  Lexicon<E>::define(E value, Args &&...names) -> self_type &
+  {
+    static_assert(sizeof...(Args) > 0, "A defined value must have at least a primary name");
+    return this->define(value, {std::forward<Args>(names)...});
+  }
 
-namespace std {
+  template <typename E>
+  auto
+  Lexicon<E>::define(const Pair &pair) -> self_type &
+  {
+    return this->define(pair._value, pair._name);
+  }
 
-template <size_t IDX, typename E> class tuple_element<IDX, swoc::detail::lexicon_pair_type<E>> {
+  template <typename E>
+  auto
+  Lexicon<E>::define(const Definition &init) -> self_type &
+  {
+    return this->define(init.value, init.names);
+  }
+
+  template <typename E>
+  auto
+  Lexicon<E>::set_default(Default const &handler) -> self_type &
+  {
+    switch (handler.index()) {
+    case 0:
+      break;
+    case 1:
+      _value_default = std::get<1>(handler);
+      break;
+    case 3:
+      _value_default = std::get<3>(handler);
+      break;
+    case 2:
+      _name_default = std::get<2>(handler);
+      break;
+    case 4:
+      _name_default = std::get<4>(handler);
+      break;
+    }
+    return *this;
+  }
+
+  template <typename E>
+  size_t
+  Lexicon<E>::count() const
+  {
+    return _by_value.count();
+  }
+
+  template <typename E>
+  auto
+  Lexicon<E>::begin() const -> const_iterator
+  {
+    return const_iterator{static_cast<const Item *>(_by_value.begin())};
+  }
+
+  template <typename E>
+  auto
+  Lexicon<E>::end() const -> const_iterator
+  {
+    return {};
+  }
+
+  // Iterators
+
+  template <typename E>
+  auto
+  Lexicon<E>::base_iterator::operator*() const -> reference
+  {
+    return _item->_payload;
+  }
+
+  template <typename E>
+  auto
+  Lexicon<E>::base_iterator::operator->() const -> pointer
+  {
+    return &(_item->_payload);
+  }
+
+  template <typename E>
+  bool
+  Lexicon<E>::base_iterator::operator==(self_type const &that) const
+  {
+    return _item == that._item;
+  }
+
+  template <typename E>
+  bool
+  Lexicon<E>::base_iterator::operator!=(self_type const &that) const
+  {
+    return _item != that._item;
+  }
+
+  template <typename E>
+  auto
+  Lexicon<E>::value_iterator::operator++() -> self_type &
+  {
+    super_type::_item = super_type::_item->_value_link._next;
+    return *this;
+  }
+
+  template <typename E>
+  auto
+  Lexicon<E>::value_iterator::operator++(int) -> self_type
+  {
+    self_type tmp{*this};
+    ++*this;
+    return tmp;
+  }
+
+  template <typename E>
+  auto
+  Lexicon<E>::value_iterator::operator--() -> self_type &
+  {
+    super_type::_item = super_type::_item->_value_link->_prev;
+    return *this;
+  }
+
+  template <typename E>
+  auto
+  Lexicon<E>::value_iterator::operator--(int) -> self_type
+  {
+    self_type tmp;
+    ++*this;
+    return tmp;
+  }
+
+  template <typename E>
+  auto
+  Lexicon<E>::name_iterator::operator++() -> self_type &
+  {
+    super_type::_item = super_type::_item->_name_link._next;
+    return *this;
+  }
+
+  template <typename E>
+  auto
+  Lexicon<E>::name_iterator::operator++(int) -> self_type
+  {
+    self_type tmp{*this};
+    ++*this;
+    return tmp;
+  }
+
+  template <typename E>
+  auto
+  Lexicon<E>::name_iterator::operator--() -> self_type &
+  {
+    super_type::_item = super_type::_item->_name_link->_prev;
+    return *this;
+  }
+
+  template <typename E>
+  auto
+  Lexicon<E>::name_iterator::operator--(int) -> self_type
+  {
+    self_type tmp;
+    ++*this;
+    return tmp;
+  }
+
+  template <typename E>
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, Lexicon<E> const &lex)
+  {
+    bool sep_p = false;
+    if (spec._type == 's' || spec._type == 'S') {
+      for (auto &&[value, name] : lex) {
+        if (sep_p) {
+          w.write(',');
+        }
+        bwformat(w, spec, name);
+        sep_p = true;
+      }
+    } else if (spec.has_numeric_type()) {
+      for (auto &&[value, name] : lex) {
+        if (sep_p) {
+          w.write(',');
+        }
+        bwformat(w, spec, unsigned(value));
+        sep_p = true;
+      }
+    } else {
+      for (auto &&[value, name] : lex) {
+        if (sep_p) {
+          w.write(',');
+        }
+        w.print("[{},{}]", name, unsigned(value));
+        sep_p = true;
+      }
+    }
+    return w;
+  }
+
+} // namespace SWOC_VERSION_NS
+} // namespace swoc
+
+namespace std
+{
+
+template <size_t IDX, typename E> class tuple_element<IDX, swoc::detail::lexicon_pair_type<E>>
+{
   static_assert("swoc::Lexicon::Pair tuple index out of range");
 };
 
-template <typename E> class tuple_element<0, swoc::detail::lexicon_pair_type<E>> {
+template <typename E> class tuple_element<0, swoc::detail::lexicon_pair_type<E>>
+{
 public:
   using type = E;
 };
 
-template <typename E> class tuple_element<1, swoc::detail::lexicon_pair_type<E>> {
+template <typename E> class tuple_element<1, swoc::detail::lexicon_pair_type<E>>
+{
 public:
   using type = swoc::TextView;
 };
 
 template <size_t IDX, typename E>
 auto
-get(swoc::detail::lexicon_pair_type<E> const &p) -> typename std::tuple_element<IDX, swoc::detail::lexicon_pair_type<E>>::type {
+get(swoc::detail::lexicon_pair_type<E> const &p) -> typename std::tuple_element<IDX, swoc::detail::lexicon_pair_type<E>>::type
+{
   if constexpr (IDX == 0) {
     return p._value;
   } else if constexpr (IDX == 1) {
@@ -873,4 +937,3 @@ get(swoc::detail::lexicon_pair_type<E> const &p) -> typename std::tuple_element<
 }
 
 } // namespace std
-

--- a/code/include/swoc/MemArena.h
+++ b/code/include/swoc/MemArena.h
@@ -19,682 +19,728 @@
 #include <memory_resource>
 #endif
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
-/** A memory arena.
-
-    The intended use is for allocating many small chunks of memory - few, large allocations are best
-    handled through other mechanisms. The purpose is to amortize the cost of allocation of each
-    chunk across larger internal allocations ("reserving memory"). In addition the allocated memory
-    chunks are presumed to have similar lifetimes so all of the memory in the arena can be released
-    when the arena is destroyed.
- */
-class MemArena
-#if __has_include(<memory_resource>)
-  : public std::pmr::memory_resource
-#endif
+namespace swoc
 {
-  using self_type = MemArena; ///< Self reference type.
+inline namespace SWOC_VERSION_NS
+{
+  /** A memory arena.
 
-public:
-  static constexpr size_t DEFAULT_ALIGNMENT{1}; ///< Default memory alignment.
+      The intended use is for allocating many small chunks of memory - few, large allocations are best
+      handled through other mechanisms. The purpose is to amortize the cost of allocation of each
+      chunk across larger internal allocations ("reserving memory"). In addition the allocated memory
+      chunks are presumed to have similar lifetimes so all of the memory in the arena can be released
+      when the arena is destroyed.
+   */
+  class MemArena
+#if __has_include(<memory_resource>)
+    : public std::pmr::memory_resource
+#endif
+  {
+    using self_type = MemArena; ///< Self reference type.
 
-  /// Convenient alias for use with @c unique_ptr.
-  /// @internal Can't be @c inline because the instantiation requires a complete type.
-  static void (*destroyer)(self_type *);
+  public:
+    static constexpr size_t DEFAULT_ALIGNMENT{1}; ///< Default memory alignment.
 
-  /// Correct type for a unique pointer to an instance.
-  /// Initialization is
-  /// @code
-  ///     MemArena::unique_ptr arena(nullptr, MemArena::destroyer);
-  /// @endcode
-  /// To create the arena on demand
-  /// @code
-  ///    arena.reset(MemArena::construct_self_contained());
-  /// @endcode
-  /// If the unique pointer is to be initialized with an arena, it should probably be a direct member isntead.
-  using unique_ptr = std::unique_ptr<self_type, void (*)(self_type *)>;
+    /// Convenient alias for use with @c unique_ptr.
+    /// @internal Can't be @c inline because the instantiation requires a complete type.
+    static void (*destroyer)(self_type *);
 
-  /// Simple internal arena block of memory. Maintains the underlying memory.
-  struct Block {
-    /// A block must have at least this much free space to not be "full".
-    static constexpr size_t MIN_FREE_SPACE = 16;
+    /// Correct type for a unique pointer to an instance.
+    /// Initialization is
+    /// @code
+    ///     MemArena::unique_ptr arena(nullptr, MemArena::destroyer);
+    /// @endcode
+    /// To create the arena on demand
+    /// @code
+    ///    arena.reset(MemArena::construct_self_contained());
+    /// @endcode
+    /// If the unique pointer is to be initialized with an arena, it should probably be a direct member isntead.
+    using unique_ptr = std::unique_ptr<self_type, void (*)(self_type *)>;
 
-    /// Get the start of the data in this block.
-    char *data();
+    /// Simple internal arena block of memory. Maintains the underlying memory.
+    struct Block {
+      /// A block must have at least this much free space to not be "full".
+      static constexpr size_t MIN_FREE_SPACE = 16;
 
-    /// Get the start of the data in this block.
-    const char *data() const;
+      /// Get the start of the data in this block.
+      char *data();
 
-    /// Amount of unallocated storage.
+      /// Get the start of the data in this block.
+      const char *data() const;
+
+      /// Amount of unallocated storage.
+      size_t remaining() const;
+
+      /** Compute the padding needed such adding it to @a ptr is a multiple of @a align.
+       *
+       * @param ptr Base pointer.
+       * @param align Alignment requirement (must be a power of 2).
+       * @return Value to add to @a ptr to achieve @a align.
+       */
+      static size_t align_padding(void const *ptr, size_t align);
+
+      /** Check if there is @a n bytes of space at @a align.
+       *
+       * @param n Size required.
+       * @param align Alignment required.
+       * @return @c true if there is space, @c false if not.
+       */
+      bool satisfies(size_t n, size_t align) const;
+
+      /// Span of unallocated storage.
+      MemSpan<void> remnant();
+
+      /** Allocate @a n bytes from this block.
+       *
+       * @param n Number of bytes to allocate.
+       * @param align Alignment requirement (default, no alignment).
+       * @return The span of memory allocated.
+       */
+      MemSpan<void> alloc(size_t n, size_t = DEFAULT_ALIGNMENT);
+
+      /** Discard allocations.
+       *
+       * Reset the block state to empty.
+       *
+       * @return @a this.
+       */
+      Block &discard();
+
+      /** Check if the byte at address @a ptr is in this block.
+       *
+       * @param ptr Address of byte to check.
+       * @return @c true if @a ptr is in this block, @c false otherwise.
+       */
+      bool contains(const void *ptr) const;
+
+      /// @return @c true if the block has at least @c MIN_FREE_SPACE bytes free.
+      bool is_full() const;
+
+    protected:
+      friend MemArena; ///< Container.
+
+      /** Override @c operator @c delete.
+       *
+       * This is required because the allocated memory size is larger than the class size which
+       * requires calling @c free directly, skipping the destructor and avoiding complaints about size
+       * mismatches.
+       *
+       * @param ptr Memory to be de-allocated.
+       */
+      static void operator delete(void *ptr) noexcept;
+
+      /** Override placement (non-allocated) @c delete.
+       *
+       * @param ptr Pointer returned from @c new
+       * @param place Value passed to @c new.
+       *
+       * This is called only when the class constructor throws an exception during placement new.
+       *
+       * @note I think the parameters are described correctly, the documentation I can find is a bit
+       * vague on the source of these values. It is required even if the constructor is marked @c
+       * noexcept. Both are kept in order to be documented.
+       *
+       * @internal This is required by ICC, but not GCC. Annoying, but it appears this is a valid
+       * interpretation of the spec. In practice this is never called because the constructor does
+       * not throw.
+       */
+      static void operator delete([[maybe_unused]] void *ptr, void *place) noexcept;
+
+      /** Construct to have @a n bytes of available storage.
+       *
+       * Note this is descriptive - this presumes use via placement new and the size value describes
+       * memory already allocated immediately after this instance.
+       * @param n The amount of storage.
+       */
+      explicit Block(size_t n) noexcept;
+
+      size_t size;         ///< Actual block size.
+      size_t allocated{0}; ///< Current allocated (in use) bytes.
+
+      struct Linkage {
+        /// @cond INTERNAL_DETAIL
+        Block *_next{nullptr};
+        Block *_prev{nullptr};
+
+        static Block *&next_ptr(Block *);
+
+        static Block *&prev_ptr(Block *);
+        /// @endcond
+      } _link; ///< Intrusive list support.
+    };
+
+    /// Intrusive list of blocks.
+    using BlockList = IntrusiveDList<Block::Linkage>;
+
+    /** Construct with reservation hint.
+     *
+     * No memory is initially reserved, but when memory is needed this will be done so at least
+     * @a n bytes of available memory is reserved.
+     *
+     * To pre-reserve call @c alloc(0), e.g.
+     * @code
+     * MemArena arena(512); // Make sure at least 512 bytes available in first block.
+     * arena.alloc(0); // Force allocation of first block.
+     * @endcode
+     *
+     * @param n Minimum number of available bytes in the first internally reserved block.
+     */
+    explicit MemArena(size_t n = DEFAULT_BLOCK_SIZE);
+
+    /** Construct using static block.
+     *
+     * @param static_block A block of memory that is non-deletable.
+     *
+     * @a static_block is used as the first block for allocation and is never deleted. This makes
+     * it possible to have an instance that allocates from stack memory and only allocates from the
+     * heap if the static block becomes full.
+     *
+     * @note There is no default block size because the static block is the initial block. Subsequent
+     * allocations are based on that size.
+     */
+    explicit MemArena(MemSpan<void> static_block);
+
+    /// no copying
+    MemArena(self_type const &that) = delete;
+
+    /// Allow moving the arena.
+    MemArena(self_type &&that) noexcept;
+
+    /// Destructor.
+    ~MemArena();
+
+    /// No copy assignment.
+    self_type &operator=(self_type const &that) = delete;
+
+    /// Move assignment.
+    self_type &operator=(self_type &&that) noexcept;
+
+    /** Make a self-contained instance.
+     *
+     * @param n The initial memory size hint.
+     * @return A new, self contained instance.
+     *
+     * Create an instance of @c MemArena that is stored in its own memory pool. The size hint @a n
+     * is adjusted to account for the space consumed by the @c MemArena instance. This instance
+     * will therefore always have done its initial internal memory allocation to provide space
+     * for itself.
+     *
+     * This is most useful for smaller objects that need to strongly minimize their size when not
+     * allocating memory. In that context, this enables being able to have a memory pool as needed
+     * at the cost of a only single pointer in the instance.
+     *
+     * @note This requires careful attention to detail for freezing and thawing, as the @c MemArena
+     * itself will be in the frozen memory and must be moved to the fresh allocation.
+     *
+     * @note @c delete must not be called on the returned pointer. Instead the @c MemArena destructor
+     * must be explicitly called, which will clean up all of the allocated memory. See the
+     * documentation for further details.
+     */
+    static self_type *construct_self_contained(size_t n = DEFAULT_BLOCK_SIZE);
+
+    /** Allocate @a n bytes of storage.
+
+        Returns a span of memory within the arena. alloc() is self expanding but DOES NOT self
+        coalesce. This means that no matter the arena size, the caller will always be able to alloc()
+        @a n bytes.
+
+        @param n number of bytes to allocate.
+        @param align Required alignment, defaults to 1 (no alignment). Must be a power of 2.
+        @return a MemSpan of the allocated memory.
+     */
+    MemSpan<void> alloc(size_t n, size_t align = DEFAULT_ALIGNMENT);
+
+    /** ALlocate a span of memory sufficient for @a n instance of @a T.
+     *
+     * @tparam T Element type.
+     * @param n Number of instances.
+     * @return A span large enough to hold @a n instances of @a T.
+     *
+     * The instances are @b not initialized / constructed. This only allocates the memory.
+     * This is handy for types that don't need initialization, such as built in types like @c int.
+     * @code
+     *   auto vec = arena.alloc_span<int>(20); // allocate space for 20 ints
+     * @endcode
+     *
+     * The memory is aligned according to @c alignof(T).
+     */
+    template <typename T> MemSpan<T> alloc_span(size_t n);
+
+    /** Allocate and initialize a block of memory as an instance of @a T
+
+        The template type specifies the type to create and any arguments are forwarded to the
+        constructor. Example:
+
+        @code
+        struct Thing { ... };
+        auto thing = arena.make<Thing>(...constructor args...);
+        @endcode
+
+        Do @b not call @c delete an object created this way - that will attempt to free the memory and
+        break. A destructor may be invoked explicitly but the point of this class is that no object in
+        it needs to be deleted, the memory will all be reclaimed when the Arena is destroyed. In
+        general it is a bad idea to make objects in the Arena that own memory that is not also in the
+        Arena.
+    */
+    template <typename T, typename... Args> T *make(Args &&...args);
+
+    /** Freeze reserved memory.
+
+        All internal memory blocks are frozen and will not be involved in future allocations.
+        Subsequent allocation will reserve new internal blocks. By default the first reserved block
+        will be large enough to contain all frozen memory. If this is not correct a different target
+        can be specified as @a n.
+
+        @param n Target number of available bytes in the next reserved internal block.
+        @return @c *this
+     */
+    MemArena &freeze(size_t n = 0);
+
+    /** Unfreeze arena.
+     *
+     * Frozen memory is released.
+     *
+     * @return @c *this
+     */
+    self_type &thaw();
+
+    /** Release all memory.
+
+        Empties the entire arena and deallocates all underlying memory. The hint for the next reserved
+        block size will be @a n if @a n is not zero, otherwise it will be the sum of all allocations
+        when this method was called.
+
+        @param hint Size hint for the next internal allocation.
+        @return @a this
+
+        @see discard
+
+     */
+    MemArena &clear(size_t hint = 0);
+
+    /** Discard all allocations.
+     *
+     * All active internal memory blocks are reset to be empty, discarding any allocations. These blocks
+     * will be re-used by subsequent allocations.
+     *
+     * @param hint Size hint for the next internal allocation.
+     * @return @a this.
+     *
+     * @see clear
+     */
+    MemArena &discard(size_t hint = 0);
+
+    /// @return The amount of memory allocated.
+    size_t size() const;
+
+    /// @return The amount of free space.
     size_t remaining() const;
 
-    /** Compute the padding needed such adding it to @a ptr is a multiple of @a align.
+    /** Get aligned and sized remnant.
      *
-     * @param ptr Base pointer.
-     * @param align Alignment requirement (must be a power of 2).
-     * @return Value to add to @a ptr to achieve @a align.
-     */
-    static size_t align_padding(void const *ptr, size_t align);
-
-    /** Check if there is @a n bytes of space at @a align.
+     * @tparam T Element type.
+     * @param n Number of instances of @a T
+     * @return A span that is in the remnant, correctly aligned with minimal padding.
      *
-     * @param n Size required.
-     * @param align Alignment required.
-     * @return @c true if there is space, @c false if not.
+     * This is guaranteed to be the same bytes as if @c alloc<T> was called. The returned span will
+     * always be the specified size, the remnant will be expanded as needed.
      */
-    bool satisfies(size_t n, size_t align) const;
+    template <typename T> MemSpan<T> remnant_span(size_t n);
 
-    /// Span of unallocated storage.
+    /// @return Contiguous free space in the current internal block.
     MemSpan<void> remnant();
 
-    /** Allocate @a n bytes from this block.
+    /** Get an aligned remnant.
      *
-     * @param n Number of bytes to allocate.
-     * @param align Alignment requirement (default, no alignment).
-     * @return The span of memory allocated.
+     * @param n Remnant size.
+     * @param align Memory alignment (default 1, must be power of 2).
+     * @return Space in the remnant with minimal alignment padding.
+     *
+     * @note This will always return a span of @a n bytes, the remnant will be expanded as needed.
      */
-    MemSpan<void> alloc(size_t n, size_t = DEFAULT_ALIGNMENT);
+    MemSpan<void> remnant(size_t n, size_t align = DEFAULT_ALIGNMENT);
 
-    /** Discard allocations.
+    /** Require @a n bytes of contiguous memory to be available for allocation.
      *
-     * Reset the block state to empty.
+     * @param n Number of bytes.
+     * @param align Align requirement (default is 1, no alignment).
+     * @return @a this
      *
-     * @return @a this.
+     * This forces the @c remnant to be at least @a n bytes of contiguous memory. A subsequent
+     * @c alloc will use this space if the allocation size is at most the remnant size.
      */
-    Block &discard();
+    self_type &require(size_t n, size_t align = DEFAULT_ALIGNMENT);
 
-    /** Check if the byte at address @a ptr is in this block.
+    /// @returns the total number of bytes allocated within the arena.
+    size_t allocated_size() const;
+
+    /** Check if a the byte at @a ptr is in memory owned by this arena.
      *
      * @param ptr Address of byte to check.
-     * @return @c true if @a ptr is in this block, @c false otherwise.
+     * @return @c true if the byte at @a ptr is in the arena, @c false if not.
      */
     bool contains(const void *ptr) const;
 
-    /// @return @c true if the block has at least @c MIN_FREE_SPACE bytes free.
-    bool is_full() const;
+    /** Total memory footprint, including wasted space.
+     * @return Total memory footprint.
+     */
+    size_t reserved_size() const;
+
+    using const_iterator = BlockList::const_iterator; ///< Constant element iteration.
+    using iterator       = const_iterator;            ///< Element iteration.
+
+    /// First active block.
+    const_iterator begin() const;
+
+    /// After Last active block.
+    const_iterator end() const;
+
+    /// First frozen block.
+    const_iterator frozen_begin() const;
+
+    /// After last frozen block.
+    const_iterator frozen_end() const;
 
   protected:
-    friend MemArena; ///< Container.
-
-    /** Override @c operator @c delete.
+    /** Internally allocates a new block of memory of size @a n bytes.
      *
-     * This is required because the allocated memory size is larger than the class size which
-     * requires calling @c free directly, skipping the destructor and avoiding complaints about size
-     * mismatches.
-     *
-     * @param ptr Memory to be de-allocated.
+     * @param n Size of block to allocate.
+     * @return
      */
-    static void operator delete(void *ptr) noexcept;
+    Block *make_block(size_t n);
 
-    /** Override placement (non-allocated) @c delete.
-     *
-     * @param ptr Pointer returned from @c new
-     * @param place Value passed to @c new.
-     *
-     * This is called only when the class constructor throws an exception during placement new.
-     *
-     * @note I think the parameters are described correctly, the documentation I can find is a bit
-     * vague on the source of these values. It is required even if the constructor is marked @c
-     * noexcept. Both are kept in order to be documented.
-     *
-     * @internal This is required by ICC, but not GCC. Annoying, but it appears this is a valid
-     * interpretation of the spec. In practice this is never called because the constructor does
-     * not throw.
-     */
-    static void operator delete([[maybe_unused]] void *ptr, void *place) noexcept;
+    /// Clean up the frozen list.
+    void destroy_frozen();
 
-    /** Construct to have @a n bytes of available storage.
-     *
-     * Note this is descriptive - this presumes use via placement new and the size value describes
-     * memory already allocated immediately after this instance.
-     * @param n The amount of storage.
-     */
-    explicit Block(size_t n) noexcept;
+    /// Clean up the active list
+    void destroy_active();
 
-    size_t size;         ///< Actual block size.
-    size_t allocated{0}; ///< Current allocated (in use) bytes.
+    using Page        = Scalar<4096>;            ///< Size for rounding block sizes.
+    using QuarterPage = Scalar<Page::SCALE / 4>; ///< Quarter page - unit for sub page sizes.
+    using Paragraph   = Scalar<16>;              ///< Minimum unit of memory allocation.
 
-    struct Linkage {
-      /// @cond INTERNAL_DETAIL
-      Block *_next{nullptr};
-      Block *_prev{nullptr};
+    static constexpr size_t ALLOC_HEADER_SIZE = 16; ///< Guess of overhead of @c malloc
+    /// Initial block size to allocate if not specified via API.
+    static constexpr size_t DEFAULT_BLOCK_SIZE = Page::SCALE - Paragraph{round_up(ALLOC_HEADER_SIZE + sizeof(Block))};
 
-      static Block *&next_ptr(Block *);
+    size_t _active_allocated = 0; ///< Total allocations in the active generation.
+    size_t _active_reserved  = 0; ///< Total current reserved memory.
+    /// Total allocations in the previous generation. This is only non-zero while the arena is frozen.
+    size_t _frozen_allocated = 0;
+    /// Total frozen reserved memory.
+    size_t _frozen_reserved = 0;
 
-      static Block *&prev_ptr(Block *);
-      /// @endcond
-    } _link; ///< Intrusive list support.
-  };
+    /// Minimum free space needed in the next allocated block.
+    /// This is not zero iff @c reserve was called.
+    size_t _reserve_hint = 0;
 
-  /// Intrusive list of blocks.
-  using BlockList = IntrusiveDList<Block::Linkage>;
+    BlockList _frozen; ///< Previous generation, frozen memory.
+    BlockList _active; ///< Current generation. Allocate here.
 
-  /** Construct with reservation hint.
-   *
-   * No memory is initially reserved, but when memory is needed this will be done so at least
-   * @a n bytes of available memory is reserved.
-   *
-   * To pre-reserve call @c alloc(0), e.g.
-   * @code
-   * MemArena arena(512); // Make sure at least 512 bytes available in first block.
-   * arena.alloc(0); // Force allocation of first block.
-   * @endcode
-   *
-   * @param n Minimum number of available bytes in the first internally reserved block.
-   */
-  explicit MemArena(size_t n = DEFAULT_BLOCK_SIZE);
+    /// Static block, if any.
+    Block *_static_block = nullptr;
 
-  /** Construct using static block.
-   *
-   * @param static_block A block of memory that is non-deletable.
-   *
-   * @a static_block is used as the first block for allocation and is never deleted. This makes
-   * it possible to have an instance that allocates from stack memory and only allocates from the
-   * heap if the static block becomes full.
-   *
-   * @note There is no default block size because the static block is the initial block. Subsequent
-   * allocations are based on that size.
-   */
-  explicit MemArena(MemSpan<void> static_block);
+    // Note on _active block list - blocks that become full are moved to the end of the list.
+    // This means that when searching for a block with space, the first full block encountered
+    // marks the last block to check. This keeps the set of blocks to check short.
 
-  /// no copying
-  MemArena(self_type const &that) = delete;
-
-  /// Allow moving the arena.
-  MemArena(self_type &&that) noexcept;
-
-  /// Destructor.
-  ~MemArena();
-
-  /// No copy assignment.
-  self_type & operator=(self_type const & that) = delete;
-
-  /// Move assignment.
-  self_type & operator=(self_type &&that) noexcept;
-
-  /** Make a self-contained instance.
-   *
-   * @param n The initial memory size hint.
-   * @return A new, self contained instance.
-   *
-   * Create an instance of @c MemArena that is stored in its own memory pool. The size hint @a n
-   * is adjusted to account for the space consumed by the @c MemArena instance. This instance
-   * will therefore always have done its initial internal memory allocation to provide space
-   * for itself.
-   *
-   * This is most useful for smaller objects that need to strongly minimize their size when not
-   * allocating memory. In that context, this enables being able to have a memory pool as needed
-   * at the cost of a only single pointer in the instance.
-   *
-   * @note This requires careful attention to detail for freezing and thawing, as the @c MemArena
-   * itself will be in the frozen memory and must be moved to the fresh allocation.
-   *
-   * @note @c delete must not be called on the returned pointer. Instead the @c MemArena destructor
-   * must be explicitly called, which will clean up all of the allocated memory. See the
-   * documentation for further details.
-   */
-  static self_type *construct_self_contained(size_t n = DEFAULT_BLOCK_SIZE);
-
-  /** Allocate @a n bytes of storage.
-
-      Returns a span of memory within the arena. alloc() is self expanding but DOES NOT self
-      coalesce. This means that no matter the arena size, the caller will always be able to alloc()
-      @a n bytes.
-
-      @param n number of bytes to allocate.
-      @param align Required alignment, defaults to 1 (no alignment). Must be a power of 2.
-      @return a MemSpan of the allocated memory.
-   */
-  MemSpan<void> alloc(size_t n, size_t align = DEFAULT_ALIGNMENT);
-
-  /** ALlocate a span of memory sufficient for @a n instance of @a T.
-   *
-   * @tparam T Element type.
-   * @param n Number of instances.
-   * @return A span large enough to hold @a n instances of @a T.
-   *
-   * The instances are @b not initialized / constructed. This only allocates the memory.
-   * This is handy for types that don't need initialization, such as built in types like @c int.
-   * @code
-   *   auto vec = arena.alloc_span<int>(20); // allocate space for 20 ints
-   * @endcode
-   *
-   * The memory is aligned according to @c alignof(T).
-   */
-  template <typename T> MemSpan<T> alloc_span(size_t n);
-
-  /** Allocate and initialize a block of memory as an instance of @a T
-
-      The template type specifies the type to create and any arguments are forwarded to the
-      constructor. Example:
-
-      @code
-      struct Thing { ... };
-      auto thing = arena.make<Thing>(...constructor args...);
-      @endcode
-
-      Do @b not call @c delete an object created this way - that will attempt to free the memory and
-      break. A destructor may be invoked explicitly but the point of this class is that no object in
-      it needs to be deleted, the memory will all be reclaimed when the Arena is destroyed. In
-      general it is a bad idea to make objects in the Arena that own memory that is not also in the
-      Arena.
-  */
-  template <typename T, typename... Args> T *make(Args &&... args);
-
-  /** Freeze reserved memory.
-
-      All internal memory blocks are frozen and will not be involved in future allocations.
-      Subsequent allocation will reserve new internal blocks. By default the first reserved block
-      will be large enough to contain all frozen memory. If this is not correct a different target
-      can be specified as @a n.
-
-      @param n Target number of available bytes in the next reserved internal block.
-      @return @c *this
-   */
-  MemArena &freeze(size_t n = 0);
-
-  /** Unfreeze arena.
-   *
-   * Frozen memory is released.
-   *
-   * @return @c *this
-   */
-  self_type &thaw();
-
-  /** Release all memory.
-
-      Empties the entire arena and deallocates all underlying memory. The hint for the next reserved
-      block size will be @a n if @a n is not zero, otherwise it will be the sum of all allocations
-      when this method was called.
-
-      @param hint Size hint for the next internal allocation.
-      @return @a this
-
-      @see discard
-
-   */
-  MemArena &clear(size_t hint = 0);
-
-  /** Discard all allocations.
-   *
-   * All active internal memory blocks are reset to be empty, discarding any allocations. These blocks
-   * will be re-used by subsequent allocations.
-   *
-   * @param hint Size hint for the next internal allocation.
-   * @return @a this.
-   *
-   * @see clear
-   */
-  MemArena &discard(size_t hint = 0);
-
-  /// @return The amount of memory allocated.
-  size_t size() const;
-
-  /// @return The amount of free space.
-  size_t remaining() const;
-
-  /** Get aligned and sized remnant.
-   *
-   * @tparam T Element type.
-   * @param n Number of instances of @a T
-   * @return A span that is in the remnant, correctly aligned with minimal padding.
-   *
-   * This is guaranteed to be the same bytes as if @c alloc<T> was called. The returned span will
-   * always be the specified size, the remnant will be expanded as needed.
-   */
-  template <typename T> MemSpan<T> remnant_span(size_t n);
-
-  /// @return Contiguous free space in the current internal block.
-  MemSpan<void> remnant();
-
-  /** Get an aligned remnant.
-   *
-   * @param n Remnant size.
-   * @param align Memory alignment (default 1, must be power of 2).
-   * @return Space in the remnant with minimal alignment padding.
-   *
-   * @note This will always return a span of @a n bytes, the remnant will be expanded as needed.
-   */
-  MemSpan<void> remnant(size_t n, size_t align = DEFAULT_ALIGNMENT);
-
-  /** Require @a n bytes of contiguous memory to be available for allocation.
-   *
-   * @param n Number of bytes.
-   * @param align Align requirement (default is 1, no alignment).
-   * @return @a this
-   *
-   * This forces the @c remnant to be at least @a n bytes of contiguous memory. A subsequent
-   * @c alloc will use this space if the allocation size is at most the remnant size.
-   */
-  self_type &require(size_t n, size_t align = DEFAULT_ALIGNMENT);
-
-  /// @returns the total number of bytes allocated within the arena.
-  size_t allocated_size() const;
-
-  /** Check if a the byte at @a ptr is in memory owned by this arena.
-   *
-   * @param ptr Address of byte to check.
-   * @return @c true if the byte at @a ptr is in the arena, @c false if not.
-   */
-  bool contains(const void *ptr) const;
-
-  /** Total memory footprint, including wasted space.
-   * @return Total memory footprint.
-   */
-  size_t reserved_size() const;
-
-  using const_iterator = BlockList::const_iterator; ///< Constant element iteration.
-  using iterator       = const_iterator; ///< Element iteration.
-
-  /// First active block.
-  const_iterator begin() const;
-
-  /// After Last active block.
-  const_iterator end() const;
-
-  /// First frozen block.
-  const_iterator frozen_begin() const;
-
-  /// After last frozen block.
-  const_iterator frozen_end() const;
-protected:
-  /** Internally allocates a new block of memory of size @a n bytes.
-   *
-   * @param n Size of block to allocate.
-   * @return
-   */
-  Block *make_block(size_t n);
-
-  /// Clean up the frozen list.
-  void destroy_frozen();
-
-  /// Clean up the active list
-  void destroy_active();
-
-  using Page        = Scalar<4096>;            ///< Size for rounding block sizes.
-  using QuarterPage = Scalar<Page::SCALE / 4>; ///< Quarter page - unit for sub page sizes.
-  using Paragraph   = Scalar<16>;              ///< Minimum unit of memory allocation.
-
-  static constexpr size_t ALLOC_HEADER_SIZE = 16; ///< Guess of overhead of @c malloc
-  /// Initial block size to allocate if not specified via API.
-  static constexpr size_t DEFAULT_BLOCK_SIZE = Page::SCALE - Paragraph{round_up(ALLOC_HEADER_SIZE + sizeof(Block))};
-
-  size_t _active_allocated = 0; ///< Total allocations in the active generation.
-  size_t _active_reserved  = 0; ///< Total current reserved memory.
-  /// Total allocations in the previous generation. This is only non-zero while the arena is frozen.
-  size_t _frozen_allocated = 0;
-  /// Total frozen reserved memory.
-  size_t _frozen_reserved = 0;
-
-  /// Minimum free space needed in the next allocated block.
-  /// This is not zero iff @c reserve was called.
-  size_t _reserve_hint = 0;
-
-  BlockList _frozen; ///< Previous generation, frozen memory.
-  BlockList _active; ///< Current generation. Allocate here.
-
-  /// Static block, if any.
-  Block *_static_block = nullptr;
-
-  // Note on _active block list - blocks that become full are moved to the end of the list.
-  // This means that when searching for a block with space, the first full block encountered
-  // marks the last block to check. This keeps the set of blocks to check short.
-
-private:
+  private:
 #if __has_include(<memory_resource>)
-  // PMR support methods.
+    // PMR support methods.
 
-  /// PMR allocation.
-  void *do_allocate(std::size_t bytes, std::size_t align) override;
+    /// PMR allocation.
+    void *do_allocate(std::size_t bytes, std::size_t align) override;
 
-  /// PMR de-allocation.
-  /// Does nothing.
-  void do_deallocate(void *, size_t, size_t) override;
+    /// PMR de-allocation.
+    /// Does nothing.
+    void do_deallocate(void *, size_t, size_t) override;
 
-  /// PMR comparison of memory resources.
-  /// @return @c true only if @a that is the same instance as @a this.
-  bool do_is_equal(std::pmr::memory_resource const &that) const noexcept override;
+    /// PMR comparison of memory resources.
+    /// @return @c true only if @a that is the same instance as @a this.
+    bool do_is_equal(std::pmr::memory_resource const &that) const noexcept override;
 #endif
-};
-
-/** Arena of a specific type on top of a @c MemArena.
- *
- * @tparam T Type in the arena.
- *
- * A pool of unused / free instances of @a T is kept for reuse. If none are available then a new
- * instance is allocated from the arena.
- */
-template <typename T> class FixedArena {
-  using self_type = FixedArena; ///< Self reference type.
-protected:
-  /// Rebinding type for instances on the free list.
-  struct Item {
-    Item *_next; ///< Next item in the free list.
   };
 
-  Item _list{nullptr}; ///< List of dead instances.
-  MemArena &_arena;    ///< Memory source.
-
-public:
-  /** Construct a pool.
+  /** Arena of a specific type on top of a @c MemArena.
    *
-   * @param arena The arena for memory.
+   * @tparam T Type in the arena.
+   *
+   * A pool of unused / free instances of @a T is kept for reuse. If none are available then a new
+   * instance is allocated from the arena.
    */
-  explicit FixedArena(MemArena &arena);
+  template <typename T> class FixedArena
+  {
+    using self_type = FixedArena; ///< Self reference type.
+  protected:
+    /// Rebinding type for instances on the free list.
+    struct Item {
+      Item *_next; ///< Next item in the free list.
+    };
 
-  /** Create a new instance.
-   *
-   * @tparam Args Constructor argument types.
-   * @param args Constructor arguments.
-   * @return A new instance of @a T.
-   */
-  template <typename... Args> T *make(Args... args);
+    Item _list{nullptr}; ///< List of dead instances.
+    MemArena &_arena;    ///< Memory source.
 
-  /** Destroy an instance.
-   *
-   * @param t The instance to destroy.
-   *
-   * The instance is destructed and then put on the free list for re-use.
-   */
-  void destroy(T *t);
+  public:
+    /** Construct a pool.
+     *
+     * @param arena The arena for memory.
+     */
+    explicit FixedArena(MemArena &arena);
 
-  /// Drop all items in the free list.
-  void clear();
+    /** Create a new instance.
+     *
+     * @tparam Args Constructor argument types.
+     * @param args Constructor arguments.
+     * @return A new instance of @a T.
+     */
+    template <typename... Args> T *make(Args... args);
 
-  /// Access the wrapped arena directly.
-  MemArena & arena();
-};
+    /** Destroy an instance.
+     *
+     * @param t The instance to destroy.
+     *
+     * The instance is destructed and then put on the free list for re-use.
+     */
+    void destroy(T *t);
 
-// --- Implementation ---
-/// @cond INTERNAL_DETAIL
+    /// Drop all items in the free list.
+    void clear();
 
-inline auto
-MemArena::Block::Linkage::next_ptr(Block *b) -> Block *& {
-  return b->_link._next;
-}
+    /// Access the wrapped arena directly.
+    MemArena &arena();
+  };
 
-inline auto
-MemArena::Block::Linkage::prev_ptr(Block *b) -> Block *& {
-  return b->_link._prev;
-}
+  // --- Implementation ---
+  /// @cond INTERNAL_DETAIL
 
-inline MemArena::Block::Block(size_t n) noexcept : size(n) {}
-
-inline char *
-MemArena::Block::data() {
-  return reinterpret_cast<char *>(this + 1);
-}
-
-inline const char *
-MemArena::Block::data() const {
-  return reinterpret_cast<const char *>(this + 1);
-}
-
-inline bool
-MemArena::Block::contains(const void *ptr) const {
-  const char *base = this->data();
-  return base <= ptr && ptr < base + size;
-}
-
-inline size_t
-MemArena::Block::remaining() const {
-  return size - allocated;
-}
-
-inline bool
-MemArena::Block::is_full() const {
-  return this->remaining() < MIN_FREE_SPACE;
-}
-
-inline MemSpan<void>
-MemArena::Block::alloc(size_t n, size_t align) {
-  auto base = this->data() + allocated;
-  auto pad  = align_padding(base, align);
-  if ((n + pad) > this->remaining()) {
-    throw(std::invalid_argument{"MemArena::Block::alloc size is more than remaining."});
+  inline auto
+  MemArena::Block::Linkage::next_ptr(Block *b) -> Block *&
+  {
+    return b->_link._next;
   }
-  MemSpan<void> zret = this->remnant().prefix(n + pad);
-  zret.remove_prefix(pad);
-  allocated += n + pad;
-  return zret;
-}
 
-inline MemSpan<void>
-MemArena::Block::remnant() {
-  return {this->data() + allocated, this->remaining()};
-}
-
-inline MemArena::Block &
-MemArena::Block::discard() {
-  allocated = 0;
-  return *this;
-}
-
-inline void
-MemArena::Block::operator delete(void *ptr) noexcept {
-  ::free(ptr);
-}
-inline void
-MemArena::Block::operator delete([[maybe_unused]] void *ptr, void *place) noexcept {
-  ::free(place);
-}
-
-inline size_t
-MemArena::Block::align_padding(void const *ptr, size_t align) {
-  if (auto delta = uintptr_t(ptr) & (align - 1) ; delta > 0) {
-    return align - delta;
+  inline auto
+  MemArena::Block::Linkage::prev_ptr(Block *b) -> Block *&
+  {
+    return b->_link._prev;
   }
-  return 0;
-}
 
-inline MemArena::MemArena(size_t n) : _reserve_hint(n) {}
+  inline MemArena::Block::Block(size_t n) noexcept : size(n) {}
 
-template <typename T>
-MemSpan<T>
-MemArena::alloc_span(size_t n) {
-  return this->alloc(sizeof(T) * n, alignof(T)).rebind<T>();
-}
-
-template <typename T, typename... Args>
-T *
-MemArena::make(Args &&... args) {
-  return new (this->alloc(sizeof(T), alignof(T)).data()) T(std::forward<Args>(args)...);
-}
-
-template <typename T>
-MemSpan<T>
-MemArena::remnant_span(size_t n) {
-  auto span = this->require(sizeof(T) * n, alignof(T)).remnant();
-  return span.remove_prefix(Block::align_padding(span.data(), alignof(T))).rebind<T>();
-}
-
-template <>
-inline MemSpan<void>
-MemArena::remnant_span<void>(size_t n) { return this->require(n).remnant().prefix(n); }
-
-inline MemSpan<void>
-MemArena::remnant(size_t n, size_t align) { return this->require(n, align).remnant().prefix(n); }
-
-inline size_t
-MemArena::size() const {
-  return _active_allocated;
-}
-
-inline size_t
-MemArena::allocated_size() const {
-  return _frozen_allocated + _active_allocated;
-}
-
-inline size_t
-MemArena::remaining() const {
-  return _active.empty() ? 0 : _active.head()->remaining();
-}
-
-inline MemSpan<void>
-MemArena::remnant() {
-  return _active.empty() ? MemSpan<void>() : _active.head()->remnant();
-}
-
-inline size_t
-MemArena::reserved_size() const {
-  return _active_reserved + _frozen_reserved;
-}
-
-inline auto
-MemArena::begin() const -> const_iterator {
-  return _active.begin();
-}
-
-inline auto
-MemArena::end() const -> const_iterator {
-  return _active.end();
-}
-
-inline auto
-MemArena::frozen_begin() const -> const_iterator {
-  return _frozen.begin();
-}
-
-inline auto
-MemArena::frozen_end() const -> const_iterator {
-  return _frozen.end();
-}
-
-template <typename T> FixedArena<T>::FixedArena(MemArena &arena) : _arena(arena) {
-  static_assert(sizeof(T) >= sizeof(T *));
-}
-
-template <typename T>
-template <typename... Args>
-T *
-FixedArena<T>::make(Args... args) {
-  if (_list._next) {
-    void *t     = _list._next;
-    _list._next = _list._next->_next;
-    return new (t) T(std::forward<Args>(args)...);
+  inline char *
+  MemArena::Block::data()
+  {
+    return reinterpret_cast<char *>(this + 1);
   }
-  return _arena.template make<T>(std::forward<Args>(args)...);
-}
 
-template <typename T>
-void
-FixedArena<T>::destroy(T *t) {
-  if (t) {
-    t->~T(); // destructor.
-    auto item   = reinterpret_cast<Item *>(t);
-    item->_next = _list._next;
-    _list._next = item;
+  inline const char *
+  MemArena::Block::data() const
+  {
+    return reinterpret_cast<const char *>(this + 1);
   }
-}
 
-template <typename T>
-void
-FixedArena<T>::clear() {
-  _list._next = nullptr;
-}
+  inline bool
+  MemArena::Block::contains(const void *ptr) const
+  {
+    const char *base = this->data();
+    return base <= ptr && ptr < base + size;
+  }
 
-template < typename T > MemArena & FixedArena<T>::arena() { return _arena; }
+  inline size_t
+  MemArena::Block::remaining() const
+  {
+    return size - allocated;
+  }
 
-/// @endcond INTERNAL_DETAIL
+  inline bool
+  MemArena::Block::is_full() const
+  {
+    return this->remaining() < MIN_FREE_SPACE;
+  }
 
-}} // namespace swoc::SWOC_VERSION_NS
+  inline MemSpan<void>
+  MemArena::Block::alloc(size_t n, size_t align)
+  {
+    auto base = this->data() + allocated;
+    auto pad  = align_padding(base, align);
+    if ((n + pad) > this->remaining()) {
+      throw(std::invalid_argument{"MemArena::Block::alloc size is more than remaining."});
+    }
+    MemSpan<void> zret = this->remnant().prefix(n + pad);
+    zret.remove_prefix(pad);
+    allocated += n + pad;
+    return zret;
+  }
+
+  inline MemSpan<void>
+  MemArena::Block::remnant()
+  {
+    return {this->data() + allocated, this->remaining()};
+  }
+
+  inline MemArena::Block &
+  MemArena::Block::discard()
+  {
+    allocated = 0;
+    return *this;
+  }
+
+  inline void
+  MemArena::Block::operator delete(void *ptr) noexcept
+  {
+    ::free(ptr);
+  }
+  inline void
+  MemArena::Block::operator delete([[maybe_unused]] void *ptr, void *place) noexcept
+  {
+    ::free(place);
+  }
+
+  inline size_t
+  MemArena::Block::align_padding(void const *ptr, size_t align)
+  {
+    if (auto delta = uintptr_t(ptr) & (align - 1); delta > 0) {
+      return align - delta;
+    }
+    return 0;
+  }
+
+  inline MemArena::MemArena(size_t n) : _reserve_hint(n) {}
+
+  template <typename T>
+  MemSpan<T>
+  MemArena::alloc_span(size_t n)
+  {
+    return this->alloc(sizeof(T) * n, alignof(T)).rebind<T>();
+  }
+
+  template <typename T, typename... Args>
+  T *
+  MemArena::make(Args &&...args)
+  {
+    return new (this->alloc(sizeof(T), alignof(T)).data()) T(std::forward<Args>(args)...);
+  }
+
+  template <typename T>
+  MemSpan<T>
+  MemArena::remnant_span(size_t n)
+  {
+    auto span = this->require(sizeof(T) * n, alignof(T)).remnant();
+    return span.remove_prefix(Block::align_padding(span.data(), alignof(T))).rebind<T>();
+  }
+
+  template <>
+  inline MemSpan<void>
+  MemArena::remnant_span<void>(size_t n)
+  {
+    return this->require(n).remnant().prefix(n);
+  }
+
+  inline MemSpan<void>
+  MemArena::remnant(size_t n, size_t align)
+  {
+    return this->require(n, align).remnant().prefix(n);
+  }
+
+  inline size_t
+  MemArena::size() const
+  {
+    return _active_allocated;
+  }
+
+  inline size_t
+  MemArena::allocated_size() const
+  {
+    return _frozen_allocated + _active_allocated;
+  }
+
+  inline size_t
+  MemArena::remaining() const
+  {
+    return _active.empty() ? 0 : _active.head()->remaining();
+  }
+
+  inline MemSpan<void>
+  MemArena::remnant()
+  {
+    return _active.empty() ? MemSpan<void>() : _active.head()->remnant();
+  }
+
+  inline size_t
+  MemArena::reserved_size() const
+  {
+    return _active_reserved + _frozen_reserved;
+  }
+
+  inline auto
+  MemArena::begin() const -> const_iterator
+  {
+    return _active.begin();
+  }
+
+  inline auto
+  MemArena::end() const -> const_iterator
+  {
+    return _active.end();
+  }
+
+  inline auto
+  MemArena::frozen_begin() const -> const_iterator
+  {
+    return _frozen.begin();
+  }
+
+  inline auto
+  MemArena::frozen_end() const -> const_iterator
+  {
+    return _frozen.end();
+  }
+
+  template <typename T> FixedArena<T>::FixedArena(MemArena &arena) : _arena(arena)
+  {
+    static_assert(sizeof(T) >= sizeof(T *));
+  }
+
+  template <typename T>
+  template <typename... Args>
+  T *
+  FixedArena<T>::make(Args... args)
+  {
+    if (_list._next) {
+      void *t     = _list._next;
+      _list._next = _list._next->_next;
+      return new (t) T(std::forward<Args>(args)...);
+    }
+    return _arena.template make<T>(std::forward<Args>(args)...);
+  }
+
+  template <typename T>
+  void
+  FixedArena<T>::destroy(T *t)
+  {
+    if (t) {
+      t->~T(); // destructor.
+      auto item   = reinterpret_cast<Item *>(t);
+      item->_next = _list._next;
+      _list._next = item;
+    }
+  }
+
+  template <typename T>
+  void
+  FixedArena<T>::clear()
+  {
+    _list._next = nullptr;
+  }
+
+  template <typename T>
+  MemArena &
+  FixedArena<T>::arena()
+  {
+    return _arena;
+  }
+
+  /// @endcond INTERNAL_DETAIL
+
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/include/swoc/MemSpan.h
+++ b/code/include/swoc/MemSpan.h
@@ -24,1722 +24,1853 @@
 #include <vector>
 #include <string_view>
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
-/** A span of contiguous piece of memory.
-
-    A @c MemSpan does not own the memory to which it refers, it is simply a span of part of some
-    (presumably) larger memory object. It acts as a pointer, not a container - copy and assignment
-    change the span, not the memory to which the span refers.
-
-    The purpose is that frequently code needs to work on a specific part of the memory. This can
-    avoid copying or allocation by allocating all needed memory at once and then working with it via
-    instances of this class.
-
-    @note The issue of @c const correctness is tricky. Because this class is intended as a "smart"
-    pointer, its constancy does not carry over to its elements, just as a constant pointer doesn't
-    make its target constant. This makes it different than containers such as @c std::array or
-    @c std::vector. This means when creating an instance based on such containers the constancy of
-    the container affects the element type of the span. E.g.
-
-    - A @c std::array<T,N> maps to a @c MemSpan<T>
-    - A @c const @c std::array<T,N> maps to a @c MemSpan<const T>
-
-    For convenience a @c MemSpan<const T> can be constructed from a @c MemSpan<T> because this maintains
-    @c const correctness and models how a @c T @c const* can be constructed from a @c T* .
- */
-template <typename T> class MemSpan {
-  using self_type = MemSpan; ///< Self reference type.
-
-protected:
-  T *_ptr       = nullptr; ///< Pointer to base of memory chunk.
-  size_t _count = 0;       ///< Number of elements.
-
-public:
-  using value_type     = T; ///< Element type for span.
-  using iterator       = T *; ///< Iterator.
-  using const_iterator = T const *; ///< Constant iterator.
-
-  /// Default constructor (empty buffer).
-  constexpr MemSpan() = default;
-
-  /// Copy constructor.
-  constexpr MemSpan(self_type const &that) = default;
-  /// Copy constructor.
-  constexpr MemSpan(self_type & that) = default;
-
-  /** Construct from a first element @a start and a @a count of elements.
-   *
-   * @param start First element.
-   * @param count Total number of elements.
-   */
-  constexpr MemSpan(value_type *ptr, size_t count);
-
-  /** Construct from a half open range [start, last).
-   *
-   * @param begin Start of range.
-   * @param end Past end of range.
-   */
-  constexpr MemSpan(value_type *begin, value_type *end);
-
-  /** Construct to cover an array.
-   *
-   * @tparam N Number of elements in the array.
-   * @param a The array.
-   */
-  template <auto N> constexpr MemSpan(T (&a)[N]);
-
-  /** Construct from constant @c std::array.
-   *
-   * @tparam N Array size.
-   * @param a Array instance.
-   *
-   * @note Because the elements in a constant array are constant the span value type must be constant.
-   */
-  template < auto N, typename U
-           , typename META = std::enable_if_t<
-               std::conjunction_v<
-                 std::is_const<T>
-               , std::is_same<std::remove_const_t<U>, std::remove_const_t<T>>
-               >
-          >
-    > constexpr MemSpan(std::array<U, N> const& a);
-
-  /** Construct from a @c std::array.
-   *
-   * @tparam N Array size.
-   * @param a Array instance.
-   */
-  template <auto N> constexpr MemSpan(std::array<T, N> & a);
-
-  /** Construct a span of constant values from a span of non-constant.
-   *
-   * @tparam U Span types.
-   * @tparam META Metaprogramming type to control conversion existence.
-   * @param that Source span.
-   *
-   * This enables the standard conversion from non-const to const.
-   */
-  template < typename U
-           , typename META = std::enable_if_t<
-             std::conjunction_v<
-               std::is_const<T>
-               , std::is_same<U, std::remove_const_t<T>>
-   >>>
-   constexpr MemSpan(MemSpan<U> const& that) : _ptr(that.data()), _count(that.count()) {}
-
-
-  /** Construct from any vector like container.
-   *
-   * @tparam C Container type.
-   * @param c container
-   *
-   * The container type must have the methods @c data and @c size which must return values convertible
-   * to the pointer type for @a T and @c size_t respectively.
-   *
-   * @internal A non-const variant of this is needed because passing by CR means imposing constness
-   * on the container which can then undesirably propagate that to the element type. Best example -
-   * constructing from @c std::string. Without this variant it's not possible to construct a @c char
-   * span vs. a @c char @c const.
-   */
-  template < typename C
-            , typename = std::enable_if_t<
-              std::is_convertible_v<decltype(std::declval<C>().data()), T *> &&
-                std::is_convertible_v<decltype(std::declval<C>().size()), size_t>
-              , void
-              >
-            > constexpr MemSpan(C & c);
-
-  /** Construct from any vector like container.
-   *
-   * @tparam C Container type.
-   * @param c container
-   *
-   * The container type must have the methods @c data and @c size which must return values convertible
-   * to the pointer type for @a T and @c size_t respectively.
-   *
-   * @note Because the container is passed as a constant reference, this may cause the span type to
-   * also be a constant element type.
-   */
-  template < typename C
-            , typename = std::enable_if_t<
-              std::is_convertible_v<decltype(std::declval<C>().data()), T *> &&
-                std::is_convertible_v<decltype(std::declval<C>().size()), size_t>
-              , void
-              >
-            > constexpr MemSpan(C const & c);
-
-  /** Construct from nullptr.
-      This implicitly makes the length 0.
-  */
-  constexpr MemSpan(std::nullptr_t);
-
-  /** Equality.
-
-      Compare the span contents.
-
-      @return @c true if the contents of @a that are the same as the content of @a this,
-      @c false otherwise.
-   */
-  constexpr bool operator==(self_type const &that) const;
-
-  /** Identical.
-
-      Check if the spans refer to the same span of memory.
-      @return @c true if @a this and @a that refer to the same span, @c false if not.
-   */
-  bool is_same(self_type const &that) const;
-
-  /** Inequality.
-      @return @c true if @a that does not refer to the same span as @a this,
-      @c false otherwise.
-   */
-  constexpr bool operator!=(self_type const &that) const;
-
-  /// Assignment - the span is copied, not the content.
-  self_type &operator=(self_type const &that) = default;
-
-  /// Access element at index @a idx.
-  T &operator[](size_t idx) const;
-
-  /// Check for empty span.
-  /// @return @c true if the span is empty (no contents), @c false otherwise.
-  bool operator!() const;
-
-  /// Check for non-empty span.
-  /// @return @c true if the span contains bytes.
-  explicit operator bool() const;
-
-  /// Check for empty span (no content).
-  /// @see operator bool
-  constexpr bool empty() const;
-
-  /// @name Accessors.
-  //@{
-  /// Pointer to the first element in the span.
-  constexpr T *begin() const;
-
-  /// Pointer to first element not in the span.
-  constexpr T *end() const;
-
-  /// Number of elements in the span
-  constexpr size_t size() const;
-
-  /// Number of elements in the span
-  /// @note Deprecate for 1.5.0.
-  constexpr size_t count() const;
-
-  /// Number of elements in the span
-  constexpr size_t length() const;
-
-  /// Number of bytes in the span.
-  constexpr size_t data_size() const;
-
-  /// @return Pointer to memory in the span.
-  T * data() const;
-
-  /// @return Pointer to immediate after memory in the span.
-  constexpr T *data_end() const;
-
-  /** Access the first element in the span.
-   *
-   * @return A reference to the first element in the span.
-   */
-  T &front();
-
-  /** Access the last element in the span.
-   *
-   * @return A reference to the last element in the span.
-   */
-  T &back();
-
-  /** Apply a function @a f to every element of the span.
-   *
-   * @tparam F Functor type.
-   * @param f Functor instance.
-   * @return @a this
-   */
-  template <typename F> self_type &apply(F &&f);
-
-  /** Make a copy of @a this span on the same memory but of type @a U.
-   *
-   * @tparam U Type for the created span.
-   * @return A @c MemSpan which contains the same memory as instances of @a U.
-   *
-   * if no type is specified, the default is @c void or @c void @c const according to whether
-   * @a value_type is @c const.
-   */
-  template <typename U = std::conditional_t<std::is_const_v<T>, void const, void> > MemSpan<U> rebind() const;
-
-  /// Set the span.
-  /// This is faster but equivalent to constructing a new span with the same
-  /// arguments and assigning it.
-  /// @return @c this.
-  self_type &assign(T *ptr,      ///< Buffer start.
-                    size_t count ///< # of elements.
-  );
-
-  /** Adjust the span.
-   *
-   * @param first Starting point of the span.
-   * @param last Past the end of the span.
-   * @return @a this
-   */
-  self_type &assign(T *first, T const *last);
-
-  /// Clear the span (become an empty span).
-  self_type &clear();
-
-  /// @return @c true if the byte at @a *p is in the span.
-  bool contains(value_type const *p) const;
-
-  /** Get the initial segment of @a count elements.
-
-      @return An instance that contains the leading @a count elements of @a this.
-  */
-  constexpr self_type prefix(size_t count) const;
-
-  /** Get the initial segment of @a count elements.
-
-      @return An instance that contains the leading @a count elements of @a this.
-
-     @note Synonymn for @c prefix for STL compatibility.
-  */
-  constexpr self_type first(size_t count) const;
-
-  /** Shrink the span by removing @a count leading elements.
-   *
-   * @param count The number of elements to remove.
-   * @return @c *this
-   */
-  self_type &remove_prefix(size_t count);
-
-  /** Remove and return a prefix.
-   *
-   * @param count Number of items in the prefix.
-   * @return The removed prefix.
-   *
-   * @a count items are removed from the beginning of @a this and a view of those elements is returned.
-   */
-  self_type clip_prefix(size_t count);
-
-  /** Get the trailing segment of @a count elements.
-   *
-   * @param count Number of elements to retrieve.
-   * @return An instance that contains the trailing @a count elements of @a this.
-   */
-  constexpr self_type suffix(size_t count) const;
-
-  /** Get the trailing segment of @a count elements.
-   *
-   * @param count Number of elements to retrieve.
-   * @return An instance that contains the trailing @a count elements of @a this.
-   *
-   * @note Synonymn for @c suffix for STL compatibility.
-   */
-  constexpr self_type last(size_t count) const;
-
-  /** Shrink the span by removing @a count trailing elements.
-   *
-   * @param count Number of elements to remove.
-   * @return @c *this
-   */
-  self_type &remove_suffix(size_t count);
-
-  /** Remove and return a suffix.
-   *
-   * @param count Number of items in the suffix.
-   * @return The removed suffix.
-   *
-   * @a count items are removed from the end of @a this and a view of those elements is returned.
-   */
-  self_type clip_suffix(size_t count);
-
-  /** Return a sub span of @a this span.
-   *
-   * @param offset Offset (index) of first element in subspan.
-   * @param count Number of elements in the subspan.
-   * @return A subspan starting at @a offset for @a count elements.
-   *
-   * The result is clipped by @a this - if @a offset is out of range an empty span is returned.
-   * Otherwise @c count is clipped by the number of elements available in @a this.
-   */
-  constexpr self_type subspan(size_t offset, size_t count) const;
-
-  /** Limit the size of the span.
-   *
-   * @param n Maximum number of elements.
-   * @return @a this
-   *
-   * If the number of elements is greater than @a n, the size is changed to @a n.
-   */
-  constexpr self_type &restrict(size_t n);
-
-  /** Construct all elements in the span.
-   *
-   * For each element in the span, construct an instance of the span type using the @a args. If the
-   * instances need destruction this must be done explicitly.
-   */
-  template <typename... Args> self_type & make(Args &&... args);
-
-  /// Destruct all elements in the span.
-  void destroy();
-
-  template <typename U> friend class MemSpan;
-};
-
-/** Specialization for void pointers.
- *
- * Key differences:
- *
- * - No subscript operator.
- * - No array initialization.
- * - Other non-const @c MemSpan types implicitly convert to this type.
- *
- * @internal I tried to be clever about the base template but there were too many differences
- * One major issue was the array initialization did not work at all if the @c void case didn't
- * exclude that. Once separate there are a number of useful tweaks available.
- */
-template <> class MemSpan<void const> {
-  using self_type = MemSpan; ///< Self reference type.
-  template <typename U> friend class MemSpan;
-
-public:
-  using value_type = void const; /// Export base type.
-
-protected:
-  void *_ptr = nullptr; ///< Pointer to base of memory chunk.
-  size_t _size     = 0;       ///< Number of bytes in the chunk.
-
-public:
-  /// Default constructor (empty buffer).
-  constexpr MemSpan() = default;
-
-  /// Copy constructor.
-  constexpr MemSpan(self_type const &that) = default;
-
-  /// Copy assignment
-  constexpr self_type & operator = (self_type const& that) = default;
-
-  /** Construct to cover an array.
-   *
-   * @tparam N Number of elements in the array.
-   * @param a The array.
-   */
-  template <auto N, typename U> constexpr MemSpan(U (&a)[N]);
-
-  /// Special constructor for @c void
-  constexpr MemSpan(MemSpan<void> const& that);
-
-  /** Cross type copy constructor.
-   *
-   * @tparam U Type for source span.
-   * @param that Source span.
-   *`
-   * This enables any @c MemSpan to be automatically converted to a void span, just as any pointer
-   * can convert to a void pointer.
-   */
-  template <typename U> constexpr MemSpan(MemSpan<U> const &that);
-
-  /** Construct from a pointer @a start and a size @a n bytes.
-   *
-   * @param start Start of the span.
-   * @param n # of bytes in the span.
-   */
-  constexpr MemSpan(value_type *ptr, size_t n);
-
-  /** Construct from a half open range of [start, last).
-   *
-   * @param start Start of the range.
-   * @param last Past end of range.
-   */
-  MemSpan(value_type *begin, value_type *end);
-
-  /** Construct from any vector like container.
-   *
-   * @tparam C Container type.
-   * @param c container
-   *
-   * The container type must have the methods @c data and @c size which must return values convertible
-   * to @c void* and @c size_t respectively.
-   */
-  template < typename C
-            , typename = std::enable_if_t<
-                std::is_convertible_v<decltype(std::declval<C>().size()), size_t>
-              , void
-              >
-            > constexpr MemSpan(C const& c);
-
-  /** Construct from nullptr.
-      This implicitly makes the length 0.
-  */
-  constexpr MemSpan(std::nullptr_t);
-
-  /** Equality.
-
-      Compare the span contents.
-
-      @return @c true if the contents of @a that are bytewise the same as the content of @a this,
-      @c false otherwise.
-   */
-  bool operator==(self_type const &that) const;
-
-  /** Equivalent.
-
-      Check if the spans refer to the same span of memory.
-
-      @return @c true if @a this and @a that refer to the same memory, @c false if not.
-   */
-  bool is_same(self_type const &that) const;
-
-  /** Inequality.
-      @return @c true if @a that does not refer to the same span as @a this,
-      @c false otherwise.
-   */
-  bool operator!=(self_type const &that) const;
-
-  /// Check for non-empty span.
-  /// @return @c true if the span contains bytes.
-  explicit operator bool() const;
-
-  /// Check for empty span.
-  /// @return @c true if the span is empty (no contents), @c false otherwise.
-  bool operator!() const;
-
-  /// Check for empty span (no content).
-  /// @see operator bool
-  constexpr bool empty() const;
-
-  /// @return Number of bytes in the span.
-  constexpr size_t size() const;
-
-  /// @return Number of bytes in the span.
-  /// @note Template compatibility.
-  constexpr size_t count() const;
-
-  /// @return Number of bytes in the span.
-  /// @note Template compatibility.
-  constexpr size_t length() const;
-
-  /// Number of bytes in the span.
-  constexpr size_t data_size() const;
-
-  /// Pointer to memory in the span.
-  constexpr value_type *data() const;
-
-  /// Pointer to just after memory in the span.
-  value_type *data_end() const;
-
-  /// Assignment - special handling for @c void.
-  constexpr self_type &operator=(MemSpan<void> const &that);
-
-  /// Assignment - the span is copied, not the content.
-  /// Any type of @c MemSpan can be assigned to @c MemSpan<void>.
-  template <typename U> self_type &operator=(MemSpan<U> const &that);
-
-  /** Update the span.
-   *
-   * @param ptr Start of span memory.
-   * @param n Number of elements in the span.
-   * @return @a this
-   */
-  self_type &assign(value_type *ptr, size_t n);
-
-  /** Update the span.
-   *
-   * @param first First element in the span.
-   * @param last One past the last element in the span.
-   * @return @a this
-   */
-  self_type &assign(value_type *first, value_type const *last);
-
-  /** Create a new span for a different type @a V on the same memory.
-   *
-   * @tparam V Type for the created span.
-   * @return A @c MemSpan which contains the same memory as instances of @a V.
-   */
-  template <typename U> MemSpan<U> rebind() const;
-
-  /** Cast the span as a the instance of a type.
-   *
-   * @tparam U Target type.
-   * @return A pointer to the span as a constant instance of @a U.
-   *
-   * @note This throws if the size is not a match for @a U.
-   */
-  template <typename U> U const * as_ptr() const;
-
-  /// Clear the span (become an empty span).
-  self_type &clear();
-
-  /// @return @c true if the byte at @a *ptr is in the span.
-  bool contains(void const *ptr) const;
-
-  /** Get the initial segment of @a n bytes.
-
-      @return An instance that contains the leading @a n bytes of @a this.
-  */
-  self_type prefix(size_t n) const;
-
-  /** Shrink the span by removing @a n leading bytes.
-   *
-   * @param count The number of elements to remove.
-   * @return @c *this
-   */
-  self_type &remove_prefix(size_t n);
-
-  /** Remove and return a prefix.
-   *
-   * @param n Number of bytes in the prefix.
-   * @return The removed prefix.
-   *
-   * @a n bytes are removed from the beginning of @a this and a view of those elements is returned.
-   */
-  self_type clip_prefix(size_t n);
-
-  /** Get the trailing segment of @a n bytes.
-   *
-   * @param n Number of bytes to retrieve.
-   * @return An instance that contains the trailing @a count elements of @a this.
-   */
-  self_type suffix(size_t n) const;
-
-  /** Shrink the span by removing @a n bytes.
-   *
-   * @param n Number of bytes to remove.
-   * @return @c *this
-   */
-  self_type &remove_suffix(size_t n);
-
-  /** Remove and return a suffix.
-   *
-   * @param n Number of items in the suffix.
-   * @return The removed suffix.
-   *
-   * @a n bytes are removed from the end of @a this and a view of those bytes is returned.
-   */
-  self_type clip_suffix(size_t n);
-
-  /** Return a sub span of @a this span.
-   *
-   * @param offset Offset (index) of first element.
-   * @param n Number of elements.
-   * @return The span starting at @a offset for @a count elements in @a this.
-   *
-   * The result is clipped by @a this - if @a offset is out of range an empty span is returned. Otherwise @c count is clipped by the
-   * number of elements available in @a this. In effect the intersection of the span described by ( @a offset , @a count ) and @a
-   * this span is returned, which may be the empty span.
-   */
-  constexpr self_type subspan(size_t offset, size_t n) const;
-
-  /** Align span for a type.
-   *
-   * @tparam T Alignment type.
-   * @return A suffix of the span suitably aligned for @a T.
-   *
-   * The minimum amount of space is removed from the front to yield an aligned span. If the span is not large
-   * enough to perform the alignment, the pointer is aligned and the size reduced to zero (empty).
-   */
-  template <typename T> self_type align() const;
-
-  /** Force memory alignment.
-   *
-   * @param alignment Alignment size (must be power of 2).
-   * @return An aligned span.
-   *
-   * The minimum amount of space is removed from the front to yield an aligned span. If the span is not large
-   * enough to perform the alignment, the pointer is aligned and the size reduced to zero (empty).
-   */
-  self_type align(size_t alignment) const;
-
-  /** Force memory alignment.
-   *
-   * @param alignment Alignment size (must be power of 2).
-   * @param obj_size Size of instances requiring alignment.
-   * @return An aligned span.
-   *
-   * The minimum amount of space is removed from the front to yield an aligned span. If the span is not large
-   * enough to perform the alignment, the pointer is aligned and the size reduced to zero (empty). Trailing space
-   * is discarded such that the resulting memory space is a multiple of @a size.
-   *
-   * @note @a obj_size should be a multiple of @a alignment. This happens naturally if @c sizeof is used.
-   */
-  self_type align(size_t alignment, size_t obj_size) const;
-
-};
-
-template <> class MemSpan<void> : public MemSpan<void const> {
-  using self_type = MemSpan;
-  using super_type = MemSpan<void const>;
-  template <typename U> friend class MemSpan;
-public:
-  using value_type = void;
-  using pointer_type = value_type *;
-
-  /// Default constructor (empty buffer).
-  constexpr MemSpan() = default;
-
-  /// Copy constructor.
-  constexpr MemSpan(self_type const &that) = default;
-
-  /// Copy assignment
-  constexpr self_type & operator = (self_type const& that) = default;
-
-  /** Cross type copy constructor.
-   *
-   * @tparam U Type for source span.
-   * @param that Source span.
-   *`
-   * This enables any @c MemSpan to be automatically converted to a void span, just as any pointer
-   * can convert to a void pointer.
-   */
-  template <typename U> constexpr MemSpan(MemSpan<U> const &that);
-
-  /** Construct from a pointer @a start and a size @a n bytes.
-   *
-   * @param start Start of the span.
-   * @param n # of bytes in the span.
-   */
-  constexpr MemSpan(value_type *start, size_t n);
-
-  /** Construct from a half open range of [start, last).
-   *
-   * @param begin Start of the range.
-   * @param end Past end of range.
-   */
-  MemSpan(value_type *begin, value_type *end);
-
-  /** Construct to cover an array.
-   *
-   * @tparam N Number of elements in the array.
-   * @tparam U Element type.
-   * @param a The array.
-   */
-  template <auto N, typename U> constexpr MemSpan(U (&a)[N]);
-
-  /** Construct from nullptr.
-      This implicitly makes the length 0.
-  */
-  constexpr MemSpan(std::nullptr_t);
-
-  /// Pointer to memory in the span.
-  constexpr value_type *data() const;
-
-  /// Pointer to just after memory in the span.
-  value_type *data_end() const;
-
-  /// Assignment - the span is copied, not the content.
-  /// Any type of @c MemSpan can be assigned to @c MemSpan<void>.
-  template <typename U> self_type &operator=(MemSpan<U> const &that);
-
-  /** Construct from any vector like container.
-   *
-   * @tparam C Container type.
-   * @param c container
-   *
-   * The container type must have the methods @c data and @c size which must return values convertible
-   * to @c void* and @c size_t respectively.
-   */
-  template < typename C
-            , typename = std::enable_if_t<
-              ! std::is_const_v<decltype(std::declval<C>().data()[0])> &&
-                std::is_convertible_v<decltype(std::declval<C>().size()), size_t>
-              , void
-              >
-            > constexpr MemSpan(C const& c);
-
-  /** Update the span.
-   *
-   * @param ptr Start of span memory.
-   * @param n Number of elements in the span.
-   * @return @a this
-   */
-  self_type &assign(value_type *ptr, size_t n);
-
-  /** Update the span.
-   *
-   * @param first First element in the span.
-   * @param last One past the last element in the span.
-   * @return @a this
-   */
-  self_type &assign(value_type *first, value_type const *last);
-
-   /// @return An instance that contains the leading @a n bytes of @a this.
-  self_type prefix(size_t n) const;
-
-  /** Shrink the span by removing @a n leading bytes.
-   *
-   * @param count The number of elements to remove.
-   * @return @c *this
-   */
-  self_type &remove_prefix(size_t count);
-
-  /** Remove and return a prefix.
-   *
-   * @param count Number of byte in the prefix.
-   * @return The removed prefix.
-   *
-   * @a n bytes are removed from the beginning of @a this and a view of those bytes is returned.
-   */
-  self_type clip_prefix(size_t n);
-
-
-  /** Get the trailing segment of @a n bytes.
-   *
-   * @param n Number of bytes to retrieve.
-   * @return An instance that contains the trailing @a count elements of @a this.
-   */
-  self_type suffix(size_t n) const;
-
-  /** Shrink the span by removing @a n bytes.
-   *
-   * @param n Number of bytes to remove.
-   * @return @c *this
-   */
-  self_type &remove_suffix(size_t n);
-
-  /** Remove and return a suffix.
-   *
-   * @param n Number of items in the suffix.
-   * @return The removed suffix.
-   *
-   * @a n bytes are removed from the end of @a this and a view of those bytes is returned.
-   */
-  self_type clip_suffix(size_t n);
-
-  /** Return a sub span of @a this span.
-   *
-   * @param offset Offset (index) of first element.
-   * @param n Number of elements.
-   * @return The span starting at @a offset for @a count elements in @a this.
-   *
-   * The result is clipped by @a this - if @a offset is out of range an empty span is returned. Otherwise @c count is clipped by the
-   * number of elements available in @a this. In effect the intersection of the span described by ( @a offset , @a count ) and @a
-   * this span is returned, which may be the empty span.
-   */
-  constexpr self_type subspan(size_t offset, size_t n) const;
-
-  /** Align span for a type.
-   *
-   * @tparam T Alignment type.
-   * @return A suffix of the span suitably aligned for @a T.
-   *
-   * The minimum amount of space is removed from the front to yield an aligned span. If the span is not large
-   * enough to perform the alignment, the pointer is aligned and the size reduced to zero (empty).
-   */
-  template <typename T> self_type align() const;
-
-  /** Force memory alignment.
-   *
-   * @param alignment Alignment size (must be power of 2).
-   * @return An aligned span.
-   *
-   * The minimum amount of space is removed from the front to yield an aligned span. If the span is not large
-   * enough to perform the alignment, the pointer is aligned and the size reduced to zero (empty).
-   */
-  self_type align(size_t alignment) const;
-
-  /** Force memory alignment.
-   *
-   * @param alignment Alignment size (must be power of 2).
-   * @param obj_size Size of instances requiring alignment.
-   * @return An aligned span.
-   *
-   * The minimum amount of space is removed from the front to yield an aligned span. If the span is not large
-   * enough to perform the alignment, the pointer is aligned and the size reduced to zero (empty). Trailing space
-   * is discarded such that the resulting memory space is a multiple of @a size.
-   *
-   * @note @a obj_size should be a multiple of @a alignment. This happens naturally if @c sizeof is used.
-   */
-  self_type align(size_t alignment, size_t obj_size) const;
-
-  /** Create a new span for a different type @a V on the same memory.
-   *
-   * @tparam V Type for the created span.
-   * @return A @c MemSpan which contains the same memory as instances of @a V.
-   */
-  template <typename U> MemSpan<U> rebind() const;
-
-  /** Cast the span as a the instance of a type.
-   *
-   * @tparam U Target type.
-   * @return A pointer to the span as a constant instance of @a U.
-   *
-   * @note This throws if the size is not a match for @a U.
-   */
-  template <typename U> U * as_ptr() const;
-
-  /// Clear the span (become an empty span).
-  self_type &clear();
-
-protected:
-  /** Construct from @c const @c void span.
-   *
-   * @param super Source span.
-   *
-   * @note This is protected because it can only be used in situations were @c const correctness
-   * is not violated by converting a @c const span. The primary use is to enable @c void span
-   * method implementations to return a @c const span as @c self_type without explicit casting.
-   * In such cases the original span was not @c const and so there is no violation.
-   */
-  MemSpan(super_type const& super) : super_type(super) {}
-};
-
-
-// -- Implementation --
-
-namespace detail {
-/// @cond INTERNAL_DETAIL
-inline size_t
-ptr_distance(void const *first, void const *last) {
-  return static_cast<const char *>(last) - static_cast<const char *>(first);
-}
-
-template <typename T>
-size_t
-ptr_distance(T const *first, T const *last) {
-  return last - first;
-}
-
-inline void *
-ptr_add(void *ptr, size_t count) {
-  return static_cast<char *>(ptr) + count;
-}
-
-inline void const *
-ptr_add(void const * ptr, size_t count) {
-  return static_cast<char const *>(ptr) + count;
-}
-
-/// @endcond
-
-/** Meta Function to check the type compatibility of two spans..
- *
- * @tparam T Source span type.
- * @tparam U Destination span type.
- *
- * The types are compatible if one is an integral multiple of the other, so the span divides evenly.
- *
- * @a U must not lose constancy compared to @a T.
- *
- * @internal More void handling. This can't go in @c MemSpan because template specialization is
- * invalid in class scope and this needs to be specialized for @c void.
- */
-template <typename T, typename U> struct is_span_compatible {
-  /// @c true if the size of @a T is an integral multiple of the size of @a U or vice versa.
-  static constexpr bool value =
-    (std::ratio<sizeof(T), sizeof(U)>::num == 1 || std::ratio<sizeof(U), sizeof(T)>::num == 1) &&
-    (std::is_const_v<U> || ! std::is_const_v<T>); // can't lose constancy.
-  /** Compute the new size in units of @c sizeof(U).
-   *
-   * @param size Size in bytes.
-   * @return Size in units of @c sizeof(U).
-   *
-   * The critical part of this is the @c static_assert that guarantees the result is an integral
-   * number of instances of @a U.
-   */
-  static size_t count(size_t size);
-};
-
-template <typename T, typename U>
-size_t
-is_span_compatible<T, U>::count(size_t size) {
-  if (size % sizeof(U)) {
-    throw std::invalid_argument("MemSpan rebind where span size is not a multiple of the element size");
-  }
-  return size / sizeof(U);
-}
-
-/// @cond INTERNAL_DETAIL
-// Must specialize for rebinding to @c void because @c sizeof doesn't work. Rebinding from @c void
-// is handled by the @c MemSpan<void>::rebind specialization and doesn't use this mechanism.
-template <typename T> struct is_span_compatible<T, void> {
-  static constexpr bool value = ! std::is_const_v<T>;
-  static size_t count(size_t size);
-};
-
-template <typename T>
-size_t
-is_span_compatible<T, void>::count(size_t size) {
-  return sizeof(T) * size;
-}
-
-template <typename T> struct is_span_compatible<T, void const> {
-  static constexpr bool value = true;
-  static size_t count(size_t size);
-};
-
-template <typename T>
-size_t
-is_span_compatible<T, void const>::count(size_t size) {
-  return sizeof(T) * size;
-}
-/// @endcond
-
-} // namespace detail
-
-// --- Standard memory operations ---
-template class MemSpan<unsigned char>;
-
-template <typename T>
-int
-memcmp(MemSpan<T> const &lhs, MemSpan<T> const &rhs) {
-  int zret = 0;
-  size_t n = lhs.size();
-
-  // Seems a bit ugly but size comparisons must be done anyway to get the memcmp args.
-  if (lhs.count() < rhs.count()) {
-    zret = 1;
-  } else if (lhs.count() > rhs.count()) {
-    zret = -1;
-    n    = rhs.size();
-  }
-  // else the counts are equal therefore @a n and @a zret are already correct.
-
-  int r = std::memcmp(lhs.data(), rhs.data(), n);
-  if (0 != r) { // If we got a not-equal, override the size based result.
-    zret = r;
-  }
-
-  return zret;
-}
-
-using std::memcmp;
-
-template <typename T>
-T *
-memcpy(MemSpan<T> &dst, MemSpan<T> const &src) {
-  return static_cast<T *>(std::memcpy(dst.data(), src.data(), std::min(dst.size(), src.size())));
-}
-
-template <typename T>
-T *
-memcpy(MemSpan<T> &dst, T *src) {
-  return static_cast<T *>(std::memcpy(dst.data(), src, dst.size()));
-}
-
-template <typename T>
-T *
-memcpy(T *dst, MemSpan<T> &src) {
-  return static_cast<T *>(std::memcpy(dst, src.data(), src.size()));
-}
-
-inline char *
-memcpy(MemSpan<char> &span, std::string_view view) {
-  return static_cast<char *>(std::memcpy(span.data(), view.data(), std::min(view.size(), view.size())));
-}
-
-inline void *
-memcpy(MemSpan<void> &span, std::string_view view) {
-  return std::memcpy(span.data(), view.data(), std::min(view.size(), view.size()));
-}
-
-using std::memcpy;
-
-/** Set contents of a span to a fixed @a value.
- *
- * @tparam T Span type.
- * @param dst Span to change.
- * @param value Source value.
- * @return
- */
-template <typename T>
-inline MemSpan<T> const &
-memset(MemSpan<T> const &dst, T const &value) {
-  for (auto &e : dst) {
-    e = value;
-  }
-  return dst;
-}
-
-/// @cond INTERNAL_DETAIL
-
-/** Specialized @c memset.
- *
- * @tparam D Target span type.
- * @tparam S Source value type.
- * @param dst Target span.
- * @param c Source data.
- * @return @a dst
- *
- * If @a D and @a S are size 1 and instances of @a S can convert to @a D this directly calls @c memset.
- * This handles the various synonyms for a single byte, such as @c char, @c unsigned @c char, @c uint8_t, etc.
- */
-template < typename D, typename S >
-auto memset(MemSpan<D> const& dst, S c) -> std::enable_if_t<sizeof(D) == 1 && sizeof(S) == 1 && std::is_convertible_v<S,D>, MemSpan<D>>
+namespace swoc
 {
-  D d = c;
-  std::memset(dst.data(), d, dst.size());
-  return dst;
-}
+inline namespace SWOC_VERSION_NS
+{
+  /** A span of contiguous piece of memory.
 
-// Optimization for @c char.
-inline MemSpan<void> const &
-memset(MemSpan<void> const &dst, char c) {
-  std::memset(dst.data(), c, dst.size());
-  return dst;
-}
+      A @c MemSpan does not own the memory to which it refers, it is simply a span of part of some
+      (presumably) larger memory object. It acts as a pointer, not a container - copy and assignment
+      change the span, not the memory to which the span refers.
 
-/// @endcond
+      The purpose is that frequently code needs to work on a specific part of the memory. This can
+      avoid copying or allocation by allocating all needed memory at once and then working with it via
+      instances of this class.
 
-using std::memset;
+      @note The issue of @c const correctness is tricky. Because this class is intended as a "smart"
+      pointer, its constancy does not carry over to its elements, just as a constant pointer doesn't
+      make its target constant. This makes it different than containers such as @c std::array or
+      @c std::vector. This means when creating an instance based on such containers the constancy of
+      the container affects the element type of the span. E.g.
 
-// --- MemSpan<T> ---
+      - A @c std::array<T,N> maps to a @c MemSpan<T>
+      - A @c const @c std::array<T,N> maps to a @c MemSpan<const T>
 
-template <typename T> constexpr MemSpan<T>::MemSpan(T *ptr, size_t count) : _ptr{ptr}, _count{count} {}
+      For convenience a @c MemSpan<const T> can be constructed from a @c MemSpan<T> because this maintains
+      @c const correctness and models how a @c T @c const* can be constructed from a @c T* .
+   */
+  template <typename T> class MemSpan
+  {
+    using self_type = MemSpan; ///< Self reference type.
 
-template <typename T> constexpr MemSpan<T>::MemSpan(T *begin, T *end) : _ptr{begin}, _count{detail::ptr_distance(begin, end)} {}
+  protected:
+    T *_ptr       = nullptr; ///< Pointer to base of memory chunk.
+    size_t _count = 0;       ///< Number of elements.
 
-template <typename T> template <auto N> constexpr MemSpan<T>::MemSpan(T (&a)[N]) : _ptr{a}, _count{N} {
-  // Magic for string literals to drop the trailing nul terminator, which is almost always what is expected.
-  if constexpr (N > 0 && std::is_same_v<char const, T>) {
-    if (a[N-1] == 0) {
-      _count -= 1;
+  public:
+    using value_type     = T;         ///< Element type for span.
+    using iterator       = T *;       ///< Iterator.
+    using const_iterator = T const *; ///< Constant iterator.
+
+    /// Default constructor (empty buffer).
+    constexpr MemSpan() = default;
+
+    /// Copy constructor.
+    constexpr MemSpan(self_type const &that) = default;
+    /// Copy constructor.
+    constexpr MemSpan(self_type &that) = default;
+
+    /** Construct from a first element @a start and a @a count of elements.
+     *
+     * @param start First element.
+     * @param count Total number of elements.
+     */
+    constexpr MemSpan(value_type *ptr, size_t count);
+
+    /** Construct from a half open range [start, last).
+     *
+     * @param begin Start of range.
+     * @param end Past end of range.
+     */
+    constexpr MemSpan(value_type *begin, value_type *end);
+
+    /** Construct to cover an array.
+     *
+     * @tparam N Number of elements in the array.
+     * @param a The array.
+     */
+    template <auto N> constexpr MemSpan(T (&a)[N]);
+
+    /** Construct from constant @c std::array.
+     *
+     * @tparam N Array size.
+     * @param a Array instance.
+     *
+     * @note Because the elements in a constant array are constant the span value type must be constant.
+     */
+    template <auto N, typename U,
+              typename META = std::enable_if_t<
+                std::conjunction_v<std::is_const<T>, std::is_same<std::remove_const_t<U>, std::remove_const_t<T>>>>>
+    constexpr MemSpan(std::array<U, N> const &a);
+
+    /** Construct from a @c std::array.
+     *
+     * @tparam N Array size.
+     * @param a Array instance.
+     */
+    template <auto N> constexpr MemSpan(std::array<T, N> &a);
+
+    /** Construct a span of constant values from a span of non-constant.
+     *
+     * @tparam U Span types.
+     * @tparam META Metaprogramming type to control conversion existence.
+     * @param that Source span.
+     *
+     * This enables the standard conversion from non-const to const.
+     */
+    template <typename U,
+              typename META = std::enable_if_t<std::conjunction_v<std::is_const<T>, std::is_same<U, std::remove_const_t<T>>>>>
+    constexpr MemSpan(MemSpan<U> const &that) : _ptr(that.data()), _count(that.count())
+    {
+    }
+
+    /** Construct from any vector like container.
+     *
+     * @tparam C Container type.
+     * @param c container
+     *
+     * The container type must have the methods @c data and @c size which must return values convertible
+     * to the pointer type for @a T and @c size_t respectively.
+     *
+     * @internal A non-const variant of this is needed because passing by CR means imposing constness
+     * on the container which can then undesirably propagate that to the element type. Best example -
+     * constructing from @c std::string. Without this variant it's not possible to construct a @c char
+     * span vs. a @c char @c const.
+     */
+    template <typename C, typename = std::enable_if_t<std::is_convertible_v<decltype(std::declval<C>().data()), T *> &&
+                                                        std::is_convertible_v<decltype(std::declval<C>().size()), size_t>,
+                                                      void>>
+    constexpr MemSpan(C &c);
+
+    /** Construct from any vector like container.
+     *
+     * @tparam C Container type.
+     * @param c container
+     *
+     * The container type must have the methods @c data and @c size which must return values convertible
+     * to the pointer type for @a T and @c size_t respectively.
+     *
+     * @note Because the container is passed as a constant reference, this may cause the span type to
+     * also be a constant element type.
+     */
+    template <typename C, typename = std::enable_if_t<std::is_convertible_v<decltype(std::declval<C>().data()), T *> &&
+                                                        std::is_convertible_v<decltype(std::declval<C>().size()), size_t>,
+                                                      void>>
+    constexpr MemSpan(C const &c);
+
+    /** Construct from nullptr.
+        This implicitly makes the length 0.
+    */
+    constexpr MemSpan(std::nullptr_t);
+
+    /** Equality.
+
+        Compare the span contents.
+
+        @return @c true if the contents of @a that are the same as the content of @a this,
+        @c false otherwise.
+     */
+    constexpr bool operator==(self_type const &that) const;
+
+    /** Identical.
+
+        Check if the spans refer to the same span of memory.
+        @return @c true if @a this and @a that refer to the same span, @c false if not.
+     */
+    bool is_same(self_type const &that) const;
+
+    /** Inequality.
+        @return @c true if @a that does not refer to the same span as @a this,
+        @c false otherwise.
+     */
+    constexpr bool operator!=(self_type const &that) const;
+
+    /// Assignment - the span is copied, not the content.
+    self_type &operator=(self_type const &that) = default;
+
+    /// Access element at index @a idx.
+    T &operator[](size_t idx) const;
+
+    /// Check for empty span.
+    /// @return @c true if the span is empty (no contents), @c false otherwise.
+    bool operator!() const;
+
+    /// Check for non-empty span.
+    /// @return @c true if the span contains bytes.
+    explicit operator bool() const;
+
+    /// Check for empty span (no content).
+    /// @see operator bool
+    constexpr bool empty() const;
+
+    /// @name Accessors.
+    //@{
+    /// Pointer to the first element in the span.
+    constexpr T *begin() const;
+
+    /// Pointer to first element not in the span.
+    constexpr T *end() const;
+
+    /// Number of elements in the span
+    constexpr size_t size() const;
+
+    /// Number of elements in the span
+    /// @note Deprecate for 1.5.0.
+    constexpr size_t count() const;
+
+    /// Number of elements in the span
+    constexpr size_t length() const;
+
+    /// Number of bytes in the span.
+    constexpr size_t data_size() const;
+
+    /// @return Pointer to memory in the span.
+    T *data() const;
+
+    /// @return Pointer to immediate after memory in the span.
+    constexpr T *data_end() const;
+
+    /** Access the first element in the span.
+     *
+     * @return A reference to the first element in the span.
+     */
+    T &front();
+
+    /** Access the last element in the span.
+     *
+     * @return A reference to the last element in the span.
+     */
+    T &back();
+
+    /** Apply a function @a f to every element of the span.
+     *
+     * @tparam F Functor type.
+     * @param f Functor instance.
+     * @return @a this
+     */
+    template <typename F> self_type &apply(F &&f);
+
+    /** Make a copy of @a this span on the same memory but of type @a U.
+     *
+     * @tparam U Type for the created span.
+     * @return A @c MemSpan which contains the same memory as instances of @a U.
+     *
+     * if no type is specified, the default is @c void or @c void @c const according to whether
+     * @a value_type is @c const.
+     */
+    template <typename U = std::conditional_t<std::is_const_v<T>, void const, void>> MemSpan<U> rebind() const;
+
+    /// Set the span.
+    /// This is faster but equivalent to constructing a new span with the same
+    /// arguments and assigning it.
+    /// @return @c this.
+    self_type &assign(T *ptr,      ///< Buffer start.
+                      size_t count ///< # of elements.
+    );
+
+    /** Adjust the span.
+     *
+     * @param first Starting point of the span.
+     * @param last Past the end of the span.
+     * @return @a this
+     */
+    self_type &assign(T *first, T const *last);
+
+    /// Clear the span (become an empty span).
+    self_type &clear();
+
+    /// @return @c true if the byte at @a *p is in the span.
+    bool contains(value_type const *p) const;
+
+    /** Get the initial segment of @a count elements.
+
+        @return An instance that contains the leading @a count elements of @a this.
+    */
+    constexpr self_type prefix(size_t count) const;
+
+    /** Get the initial segment of @a count elements.
+
+        @return An instance that contains the leading @a count elements of @a this.
+
+       @note Synonymn for @c prefix for STL compatibility.
+    */
+    constexpr self_type first(size_t count) const;
+
+    /** Shrink the span by removing @a count leading elements.
+     *
+     * @param count The number of elements to remove.
+     * @return @c *this
+     */
+    self_type &remove_prefix(size_t count);
+
+    /** Remove and return a prefix.
+     *
+     * @param count Number of items in the prefix.
+     * @return The removed prefix.
+     *
+     * @a count items are removed from the beginning of @a this and a view of those elements is returned.
+     */
+    self_type clip_prefix(size_t count);
+
+    /** Get the trailing segment of @a count elements.
+     *
+     * @param count Number of elements to retrieve.
+     * @return An instance that contains the trailing @a count elements of @a this.
+     */
+    constexpr self_type suffix(size_t count) const;
+
+    /** Get the trailing segment of @a count elements.
+     *
+     * @param count Number of elements to retrieve.
+     * @return An instance that contains the trailing @a count elements of @a this.
+     *
+     * @note Synonymn for @c suffix for STL compatibility.
+     */
+    constexpr self_type last(size_t count) const;
+
+    /** Shrink the span by removing @a count trailing elements.
+     *
+     * @param count Number of elements to remove.
+     * @return @c *this
+     */
+    self_type &remove_suffix(size_t count);
+
+    /** Remove and return a suffix.
+     *
+     * @param count Number of items in the suffix.
+     * @return The removed suffix.
+     *
+     * @a count items are removed from the end of @a this and a view of those elements is returned.
+     */
+    self_type clip_suffix(size_t count);
+
+    /** Return a sub span of @a this span.
+     *
+     * @param offset Offset (index) of first element in subspan.
+     * @param count Number of elements in the subspan.
+     * @return A subspan starting at @a offset for @a count elements.
+     *
+     * The result is clipped by @a this - if @a offset is out of range an empty span is returned.
+     * Otherwise @c count is clipped by the number of elements available in @a this.
+     */
+    constexpr self_type subspan(size_t offset, size_t count) const;
+
+    /** Limit the size of the span.
+     *
+     * @param n Maximum number of elements.
+     * @return @a this
+     *
+     * If the number of elements is greater than @a n, the size is changed to @a n.
+     */
+    constexpr self_type &restrict(size_t n);
+
+    /** Construct all elements in the span.
+     *
+     * For each element in the span, construct an instance of the span type using the @a args. If the
+     * instances need destruction this must be done explicitly.
+     */
+    template <typename... Args> self_type &make(Args &&...args);
+
+    /// Destruct all elements in the span.
+    void destroy();
+
+    template <typename U> friend class MemSpan;
+  };
+
+  /** Specialization for void pointers.
+   *
+   * Key differences:
+   *
+   * - No subscript operator.
+   * - No array initialization.
+   * - Other non-const @c MemSpan types implicitly convert to this type.
+   *
+   * @internal I tried to be clever about the base template but there were too many differences
+   * One major issue was the array initialization did not work at all if the @c void case didn't
+   * exclude that. Once separate there are a number of useful tweaks available.
+   */
+  template <> class MemSpan<void const>
+  {
+    using self_type = MemSpan; ///< Self reference type.
+    template <typename U> friend class MemSpan;
+
+  public:
+    using value_type = void const; /// Export base type.
+
+  protected:
+    void *_ptr   = nullptr; ///< Pointer to base of memory chunk.
+    size_t _size = 0;       ///< Number of bytes in the chunk.
+
+  public:
+    /// Default constructor (empty buffer).
+    constexpr MemSpan() = default;
+
+    /// Copy constructor.
+    constexpr MemSpan(self_type const &that) = default;
+
+    /// Copy assignment
+    constexpr self_type &operator=(self_type const &that) = default;
+
+    /** Construct to cover an array.
+     *
+     * @tparam N Number of elements in the array.
+     * @param a The array.
+     */
+    template <auto N, typename U> constexpr MemSpan(U (&a)[N]);
+
+    /// Special constructor for @c void
+    constexpr MemSpan(MemSpan<void> const &that);
+
+    /** Cross type copy constructor.
+     *
+     * @tparam U Type for source span.
+     * @param that Source span.
+     *`
+     * This enables any @c MemSpan to be automatically converted to a void span, just as any pointer
+     * can convert to a void pointer.
+     */
+    template <typename U> constexpr MemSpan(MemSpan<U> const &that);
+
+    /** Construct from a pointer @a start and a size @a n bytes.
+     *
+     * @param start Start of the span.
+     * @param n # of bytes in the span.
+     */
+    constexpr MemSpan(value_type *ptr, size_t n);
+
+    /** Construct from a half open range of [start, last).
+     *
+     * @param start Start of the range.
+     * @param last Past end of range.
+     */
+    MemSpan(value_type *begin, value_type *end);
+
+    /** Construct from any vector like container.
+     *
+     * @tparam C Container type.
+     * @param c container
+     *
+     * The container type must have the methods @c data and @c size which must return values convertible
+     * to @c void* and @c size_t respectively.
+     */
+    template <typename C, typename = std::enable_if_t<std::is_convertible_v<decltype(std::declval<C>().size()), size_t>, void>>
+    constexpr MemSpan(C const &c);
+
+    /** Construct from nullptr.
+        This implicitly makes the length 0.
+    */
+    constexpr MemSpan(std::nullptr_t);
+
+    /** Equality.
+
+        Compare the span contents.
+
+        @return @c true if the contents of @a that are bytewise the same as the content of @a this,
+        @c false otherwise.
+     */
+    bool operator==(self_type const &that) const;
+
+    /** Equivalent.
+
+        Check if the spans refer to the same span of memory.
+
+        @return @c true if @a this and @a that refer to the same memory, @c false if not.
+     */
+    bool is_same(self_type const &that) const;
+
+    /** Inequality.
+        @return @c true if @a that does not refer to the same span as @a this,
+        @c false otherwise.
+     */
+    bool operator!=(self_type const &that) const;
+
+    /// Check for non-empty span.
+    /// @return @c true if the span contains bytes.
+    explicit operator bool() const;
+
+    /// Check for empty span.
+    /// @return @c true if the span is empty (no contents), @c false otherwise.
+    bool operator!() const;
+
+    /// Check for empty span (no content).
+    /// @see operator bool
+    constexpr bool empty() const;
+
+    /// @return Number of bytes in the span.
+    constexpr size_t size() const;
+
+    /// @return Number of bytes in the span.
+    /// @note Template compatibility.
+    constexpr size_t count() const;
+
+    /// @return Number of bytes in the span.
+    /// @note Template compatibility.
+    constexpr size_t length() const;
+
+    /// Number of bytes in the span.
+    constexpr size_t data_size() const;
+
+    /// Pointer to memory in the span.
+    constexpr value_type *data() const;
+
+    /// Pointer to just after memory in the span.
+    value_type *data_end() const;
+
+    /// Assignment - special handling for @c void.
+    constexpr self_type &operator=(MemSpan<void> const &that);
+
+    /// Assignment - the span is copied, not the content.
+    /// Any type of @c MemSpan can be assigned to @c MemSpan<void>.
+    template <typename U> self_type &operator=(MemSpan<U> const &that);
+
+    /** Update the span.
+     *
+     * @param ptr Start of span memory.
+     * @param n Number of elements in the span.
+     * @return @a this
+     */
+    self_type &assign(value_type *ptr, size_t n);
+
+    /** Update the span.
+     *
+     * @param first First element in the span.
+     * @param last One past the last element in the span.
+     * @return @a this
+     */
+    self_type &assign(value_type *first, value_type const *last);
+
+    /** Create a new span for a different type @a V on the same memory.
+     *
+     * @tparam V Type for the created span.
+     * @return A @c MemSpan which contains the same memory as instances of @a V.
+     */
+    template <typename U> MemSpan<U> rebind() const;
+
+    /** Cast the span as a the instance of a type.
+     *
+     * @tparam U Target type.
+     * @return A pointer to the span as a constant instance of @a U.
+     *
+     * @note This throws if the size is not a match for @a U.
+     */
+    template <typename U> U const *as_ptr() const;
+
+    /// Clear the span (become an empty span).
+    self_type &clear();
+
+    /// @return @c true if the byte at @a *ptr is in the span.
+    bool contains(void const *ptr) const;
+
+    /** Get the initial segment of @a n bytes.
+
+        @return An instance that contains the leading @a n bytes of @a this.
+    */
+    self_type prefix(size_t n) const;
+
+    /** Shrink the span by removing @a n leading bytes.
+     *
+     * @param count The number of elements to remove.
+     * @return @c *this
+     */
+    self_type &remove_prefix(size_t n);
+
+    /** Remove and return a prefix.
+     *
+     * @param n Number of bytes in the prefix.
+     * @return The removed prefix.
+     *
+     * @a n bytes are removed from the beginning of @a this and a view of those elements is returned.
+     */
+    self_type clip_prefix(size_t n);
+
+    /** Get the trailing segment of @a n bytes.
+     *
+     * @param n Number of bytes to retrieve.
+     * @return An instance that contains the trailing @a count elements of @a this.
+     */
+    self_type suffix(size_t n) const;
+
+    /** Shrink the span by removing @a n bytes.
+     *
+     * @param n Number of bytes to remove.
+     * @return @c *this
+     */
+    self_type &remove_suffix(size_t n);
+
+    /** Remove and return a suffix.
+     *
+     * @param n Number of items in the suffix.
+     * @return The removed suffix.
+     *
+     * @a n bytes are removed from the end of @a this and a view of those bytes is returned.
+     */
+    self_type clip_suffix(size_t n);
+
+    /** Return a sub span of @a this span.
+     *
+     * @param offset Offset (index) of first element.
+     * @param n Number of elements.
+     * @return The span starting at @a offset for @a count elements in @a this.
+     *
+     * The result is clipped by @a this - if @a offset is out of range an empty span is returned. Otherwise @c count is clipped by
+     * the number of elements available in @a this. In effect the intersection of the span described by ( @a offset , @a count ) and
+     * @a this span is returned, which may be the empty span.
+     */
+    constexpr self_type subspan(size_t offset, size_t n) const;
+
+    /** Align span for a type.
+     *
+     * @tparam T Alignment type.
+     * @return A suffix of the span suitably aligned for @a T.
+     *
+     * The minimum amount of space is removed from the front to yield an aligned span. If the span is not large
+     * enough to perform the alignment, the pointer is aligned and the size reduced to zero (empty).
+     */
+    template <typename T> self_type align() const;
+
+    /** Force memory alignment.
+     *
+     * @param alignment Alignment size (must be power of 2).
+     * @return An aligned span.
+     *
+     * The minimum amount of space is removed from the front to yield an aligned span. If the span is not large
+     * enough to perform the alignment, the pointer is aligned and the size reduced to zero (empty).
+     */
+    self_type align(size_t alignment) const;
+
+    /** Force memory alignment.
+     *
+     * @param alignment Alignment size (must be power of 2).
+     * @param obj_size Size of instances requiring alignment.
+     * @return An aligned span.
+     *
+     * The minimum amount of space is removed from the front to yield an aligned span. If the span is not large
+     * enough to perform the alignment, the pointer is aligned and the size reduced to zero (empty). Trailing space
+     * is discarded such that the resulting memory space is a multiple of @a size.
+     *
+     * @note @a obj_size should be a multiple of @a alignment. This happens naturally if @c sizeof is used.
+     */
+    self_type align(size_t alignment, size_t obj_size) const;
+  };
+
+  template <> class MemSpan<void> : public MemSpan<void const>
+  {
+    using self_type  = MemSpan;
+    using super_type = MemSpan<void const>;
+    template <typename U> friend class MemSpan;
+
+  public:
+    using value_type   = void;
+    using pointer_type = value_type *;
+
+    /// Default constructor (empty buffer).
+    constexpr MemSpan() = default;
+
+    /// Copy constructor.
+    constexpr MemSpan(self_type const &that) = default;
+
+    /// Copy assignment
+    constexpr self_type &operator=(self_type const &that) = default;
+
+    /** Cross type copy constructor.
+     *
+     * @tparam U Type for source span.
+     * @param that Source span.
+     *`
+     * This enables any @c MemSpan to be automatically converted to a void span, just as any pointer
+     * can convert to a void pointer.
+     */
+    template <typename U> constexpr MemSpan(MemSpan<U> const &that);
+
+    /** Construct from a pointer @a start and a size @a n bytes.
+     *
+     * @param start Start of the span.
+     * @param n # of bytes in the span.
+     */
+    constexpr MemSpan(value_type *start, size_t n);
+
+    /** Construct from a half open range of [start, last).
+     *
+     * @param begin Start of the range.
+     * @param end Past end of range.
+     */
+    MemSpan(value_type *begin, value_type *end);
+
+    /** Construct to cover an array.
+     *
+     * @tparam N Number of elements in the array.
+     * @tparam U Element type.
+     * @param a The array.
+     */
+    template <auto N, typename U> constexpr MemSpan(U (&a)[N]);
+
+    /** Construct from nullptr.
+        This implicitly makes the length 0.
+    */
+    constexpr MemSpan(std::nullptr_t);
+
+    /// Pointer to memory in the span.
+    constexpr value_type *data() const;
+
+    /// Pointer to just after memory in the span.
+    value_type *data_end() const;
+
+    /// Assignment - the span is copied, not the content.
+    /// Any type of @c MemSpan can be assigned to @c MemSpan<void>.
+    template <typename U> self_type &operator=(MemSpan<U> const &that);
+
+    /** Construct from any vector like container.
+     *
+     * @tparam C Container type.
+     * @param c container
+     *
+     * The container type must have the methods @c data and @c size which must return values convertible
+     * to @c void* and @c size_t respectively.
+     */
+    template <typename C, typename = std::enable_if_t<!std::is_const_v<decltype(std::declval<C>().data()[0])> &&
+                                                        std::is_convertible_v<decltype(std::declval<C>().size()), size_t>,
+                                                      void>>
+    constexpr MemSpan(C const &c);
+
+    /** Update the span.
+     *
+     * @param ptr Start of span memory.
+     * @param n Number of elements in the span.
+     * @return @a this
+     */
+    self_type &assign(value_type *ptr, size_t n);
+
+    /** Update the span.
+     *
+     * @param first First element in the span.
+     * @param last One past the last element in the span.
+     * @return @a this
+     */
+    self_type &assign(value_type *first, value_type const *last);
+
+    /// @return An instance that contains the leading @a n bytes of @a this.
+    self_type prefix(size_t n) const;
+
+    /** Shrink the span by removing @a n leading bytes.
+     *
+     * @param count The number of elements to remove.
+     * @return @c *this
+     */
+    self_type &remove_prefix(size_t count);
+
+    /** Remove and return a prefix.
+     *
+     * @param count Number of byte in the prefix.
+     * @return The removed prefix.
+     *
+     * @a n bytes are removed from the beginning of @a this and a view of those bytes is returned.
+     */
+    self_type clip_prefix(size_t n);
+
+    /** Get the trailing segment of @a n bytes.
+     *
+     * @param n Number of bytes to retrieve.
+     * @return An instance that contains the trailing @a count elements of @a this.
+     */
+    self_type suffix(size_t n) const;
+
+    /** Shrink the span by removing @a n bytes.
+     *
+     * @param n Number of bytes to remove.
+     * @return @c *this
+     */
+    self_type &remove_suffix(size_t n);
+
+    /** Remove and return a suffix.
+     *
+     * @param n Number of items in the suffix.
+     * @return The removed suffix.
+     *
+     * @a n bytes are removed from the end of @a this and a view of those bytes is returned.
+     */
+    self_type clip_suffix(size_t n);
+
+    /** Return a sub span of @a this span.
+     *
+     * @param offset Offset (index) of first element.
+     * @param n Number of elements.
+     * @return The span starting at @a offset for @a count elements in @a this.
+     *
+     * The result is clipped by @a this - if @a offset is out of range an empty span is returned. Otherwise @c count is clipped by
+     * the number of elements available in @a this. In effect the intersection of the span described by ( @a offset , @a count ) and
+     * @a this span is returned, which may be the empty span.
+     */
+    constexpr self_type subspan(size_t offset, size_t n) const;
+
+    /** Align span for a type.
+     *
+     * @tparam T Alignment type.
+     * @return A suffix of the span suitably aligned for @a T.
+     *
+     * The minimum amount of space is removed from the front to yield an aligned span. If the span is not large
+     * enough to perform the alignment, the pointer is aligned and the size reduced to zero (empty).
+     */
+    template <typename T> self_type align() const;
+
+    /** Force memory alignment.
+     *
+     * @param alignment Alignment size (must be power of 2).
+     * @return An aligned span.
+     *
+     * The minimum amount of space is removed from the front to yield an aligned span. If the span is not large
+     * enough to perform the alignment, the pointer is aligned and the size reduced to zero (empty).
+     */
+    self_type align(size_t alignment) const;
+
+    /** Force memory alignment.
+     *
+     * @param alignment Alignment size (must be power of 2).
+     * @param obj_size Size of instances requiring alignment.
+     * @return An aligned span.
+     *
+     * The minimum amount of space is removed from the front to yield an aligned span. If the span is not large
+     * enough to perform the alignment, the pointer is aligned and the size reduced to zero (empty). Trailing space
+     * is discarded such that the resulting memory space is a multiple of @a size.
+     *
+     * @note @a obj_size should be a multiple of @a alignment. This happens naturally if @c sizeof is used.
+     */
+    self_type align(size_t alignment, size_t obj_size) const;
+
+    /** Create a new span for a different type @a V on the same memory.
+     *
+     * @tparam V Type for the created span.
+     * @return A @c MemSpan which contains the same memory as instances of @a V.
+     */
+    template <typename U> MemSpan<U> rebind() const;
+
+    /** Cast the span as a the instance of a type.
+     *
+     * @tparam U Target type.
+     * @return A pointer to the span as a constant instance of @a U.
+     *
+     * @note This throws if the size is not a match for @a U.
+     */
+    template <typename U> U *as_ptr() const;
+
+    /// Clear the span (become an empty span).
+    self_type &clear();
+
+  protected:
+    /** Construct from @c const @c void span.
+     *
+     * @param super Source span.
+     *
+     * @note This is protected because it can only be used in situations were @c const correctness
+     * is not violated by converting a @c const span. The primary use is to enable @c void span
+     * method implementations to return a @c const span as @c self_type without explicit casting.
+     * In such cases the original span was not @c const and so there is no violation.
+     */
+    MemSpan(super_type const &super) : super_type(super) {}
+  };
+
+  // -- Implementation --
+
+  namespace detail
+  {
+    /// @cond INTERNAL_DETAIL
+    inline size_t
+    ptr_distance(void const *first, void const *last)
+    {
+      return static_cast<const char *>(last) - static_cast<const char *>(first);
+    }
+
+    template <typename T>
+    size_t
+    ptr_distance(T const *first, T const *last)
+    {
+      return last - first;
+    }
+
+    inline void *
+    ptr_add(void *ptr, size_t count)
+    {
+      return static_cast<char *>(ptr) + count;
+    }
+
+    inline void const *
+    ptr_add(void const *ptr, size_t count)
+    {
+      return static_cast<char const *>(ptr) + count;
+    }
+
+    /// @endcond
+
+    /** Meta Function to check the type compatibility of two spans..
+     *
+     * @tparam T Source span type.
+     * @tparam U Destination span type.
+     *
+     * The types are compatible if one is an integral multiple of the other, so the span divides evenly.
+     *
+     * @a U must not lose constancy compared to @a T.
+     *
+     * @internal More void handling. This can't go in @c MemSpan because template specialization is
+     * invalid in class scope and this needs to be specialized for @c void.
+     */
+    template <typename T, typename U> struct is_span_compatible {
+      /// @c true if the size of @a T is an integral multiple of the size of @a U or vice versa.
+      static constexpr bool value = (std::ratio<sizeof(T), sizeof(U)>::num == 1 || std::ratio<sizeof(U), sizeof(T)>::num == 1) &&
+                                    (std::is_const_v<U> || !std::is_const_v<T>); // can't lose constancy.
+      /** Compute the new size in units of @c sizeof(U).
+       *
+       * @param size Size in bytes.
+       * @return Size in units of @c sizeof(U).
+       *
+       * The critical part of this is the @c static_assert that guarantees the result is an integral
+       * number of instances of @a U.
+       */
+      static size_t count(size_t size);
+    };
+
+    template <typename T, typename U>
+    size_t
+    is_span_compatible<T, U>::count(size_t size)
+    {
+      if (size % sizeof(U)) {
+        throw std::invalid_argument("MemSpan rebind where span size is not a multiple of the element size");
+      }
+      return size / sizeof(U);
+    }
+
+    /// @cond INTERNAL_DETAIL
+    // Must specialize for rebinding to @c void because @c sizeof doesn't work. Rebinding from @c void
+    // is handled by the @c MemSpan<void>::rebind specialization and doesn't use this mechanism.
+    template <typename T> struct is_span_compatible<T, void> {
+      static constexpr bool value = !std::is_const_v<T>;
+      static size_t count(size_t size);
+    };
+
+    template <typename T>
+    size_t
+    is_span_compatible<T, void>::count(size_t size)
+    {
+      return sizeof(T) * size;
+    }
+
+    template <typename T> struct is_span_compatible<T, void const> {
+      static constexpr bool value = true;
+      static size_t count(size_t size);
+    };
+
+    template <typename T>
+    size_t
+    is_span_compatible<T, void const>::count(size_t size)
+    {
+      return sizeof(T) * size;
+    }
+    /// @endcond
+
+  } // namespace detail
+
+  // --- Standard memory operations ---
+  template class MemSpan<unsigned char>;
+
+  template <typename T>
+  int
+  memcmp(MemSpan<T> const &lhs, MemSpan<T> const &rhs)
+  {
+    int zret = 0;
+    size_t n = lhs.size();
+
+    // Seems a bit ugly but size comparisons must be done anyway to get the memcmp args.
+    if (lhs.count() < rhs.count()) {
+      zret = 1;
+    } else if (lhs.count() > rhs.count()) {
+      zret = -1;
+      n    = rhs.size();
+    }
+    // else the counts are equal therefore @a n and @a zret are already correct.
+
+    int r = std::memcmp(lhs.data(), rhs.data(), n);
+    if (0 != r) { // If we got a not-equal, override the size based result.
+      zret = r;
+    }
+
+    return zret;
+  }
+
+  using std::memcmp;
+
+  template <typename T>
+  T *
+  memcpy(MemSpan<T> &dst, MemSpan<T> const &src)
+  {
+    return static_cast<T *>(std::memcpy(dst.data(), src.data(), std::min(dst.size(), src.size())));
+  }
+
+  template <typename T>
+  T *
+  memcpy(MemSpan<T> &dst, T *src)
+  {
+    return static_cast<T *>(std::memcpy(dst.data(), src, dst.size()));
+  }
+
+  template <typename T>
+  T *
+  memcpy(T *dst, MemSpan<T> &src)
+  {
+    return static_cast<T *>(std::memcpy(dst, src.data(), src.size()));
+  }
+
+  inline char *
+  memcpy(MemSpan<char> &span, std::string_view view)
+  {
+    return static_cast<char *>(std::memcpy(span.data(), view.data(), std::min(view.size(), view.size())));
+  }
+
+  inline void *
+  memcpy(MemSpan<void> &span, std::string_view view)
+  {
+    return std::memcpy(span.data(), view.data(), std::min(view.size(), view.size()));
+  }
+
+  using std::memcpy;
+
+  /** Set contents of a span to a fixed @a value.
+   *
+   * @tparam T Span type.
+   * @param dst Span to change.
+   * @param value Source value.
+   * @return
+   */
+  template <typename T>
+  inline MemSpan<T> const &
+  memset(MemSpan<T> const &dst, T const &value)
+  {
+    for (auto &e : dst) {
+      e = value;
+    }
+    return dst;
+  }
+
+  /// @cond INTERNAL_DETAIL
+
+  /** Specialized @c memset.
+   *
+   * @tparam D Target span type.
+   * @tparam S Source value type.
+   * @param dst Target span.
+   * @param c Source data.
+   * @return @a dst
+   *
+   * If @a D and @a S are size 1 and instances of @a S can convert to @a D this directly calls @c memset.
+   * This handles the various synonyms for a single byte, such as @c char, @c unsigned @c char, @c uint8_t, etc.
+   */
+  template <typename D, typename S>
+  auto
+  memset(MemSpan<D> const &dst, S c)
+    -> std::enable_if_t<sizeof(D) == 1 && sizeof(S) == 1 && std::is_convertible_v<S, D>, MemSpan<D>>
+  {
+    D d = c;
+    std::memset(dst.data(), d, dst.size());
+    return dst;
+  }
+
+  // Optimization for @c char.
+  inline MemSpan<void> const &
+  memset(MemSpan<void> const &dst, char c)
+  {
+    std::memset(dst.data(), c, dst.size());
+    return dst;
+  }
+
+  /// @endcond
+
+  using std::memset;
+
+  // --- MemSpan<T> ---
+
+  template <typename T> constexpr MemSpan<T>::MemSpan(T *ptr, size_t count) : _ptr{ptr}, _count{count} {}
+
+  template <typename T> constexpr MemSpan<T>::MemSpan(T *begin, T *end) : _ptr{begin}, _count{detail::ptr_distance(begin, end)} {}
+
+  template <typename T> template <auto N> constexpr MemSpan<T>::MemSpan(T (&a)[N]) : _ptr{a}, _count{N}
+  {
+    // Magic for string literals to drop the trailing nul terminator, which is almost always what is expected.
+    if constexpr (N > 0 && std::is_same_v<char const, T>) {
+      if (a[N - 1] == 0) {
+        _count -= 1;
+      }
     }
   }
-}
 
-template <typename T> constexpr MemSpan<T>::MemSpan(std::nullptr_t) {}
+  template <typename T> constexpr MemSpan<T>::MemSpan(std::nullptr_t) {}
 
-template <typename T> template <auto N, typename U, typename META> constexpr MemSpan<T>::MemSpan(std::array<U,N> const& a) : _ptr{a.data()} , _count{a.size()} {}
-template <typename T> template <auto N> constexpr MemSpan<T>::MemSpan(std::array<T,N> & a) : _ptr{a.data()} , _count{a.size()} {}
-template <typename T> template <typename C, typename> constexpr MemSpan<T>::MemSpan(C & c) : _ptr(c.data()), _count(c.size()) {}
-template <typename T> template <typename C, typename> constexpr MemSpan<T>::MemSpan(C const& c) : _ptr(c.data()), _count(c.size()) {}
+  template <typename T>
+  template <auto N, typename U, typename META>
+  constexpr MemSpan<T>::MemSpan(std::array<U, N> const &a) : _ptr{a.data()}, _count{a.size()}
+  {
+  }
+  template <typename T> template <auto N> constexpr MemSpan<T>::MemSpan(std::array<T, N> &a) : _ptr{a.data()}, _count{a.size()} {}
+  template <typename T> template <typename C, typename> constexpr MemSpan<T>::MemSpan(C &c) : _ptr(c.data()), _count(c.size()) {}
+  template <typename T> template <typename C, typename> constexpr MemSpan<T>::MemSpan(C const &c) : _ptr(c.data()), _count(c.size())
+  {
+  }
 
-template <typename T>
-MemSpan<T> &
-MemSpan<T>::assign(T *ptr, size_t count) {
-  _ptr   = ptr;
-  _count = count;
-  return *this;
-}
+  template <typename T>
+  MemSpan<T> &
+  MemSpan<T>::assign(T *ptr, size_t count)
+  {
+    _ptr   = ptr;
+    _count = count;
+    return *this;
+  }
 
-template <typename T>
-MemSpan<T> &
-MemSpan<T>::assign(T *first, T const *last) {
-  _ptr   = first;
-  _count = detail::ptr_distance(first, last);
-  return *this;
-}
+  template <typename T>
+  MemSpan<T> &
+  MemSpan<T>::assign(T *first, T const *last)
+  {
+    _ptr   = first;
+    _count = detail::ptr_distance(first, last);
+    return *this;
+  }
 
-template <typename T>
-MemSpan<T> &
-MemSpan<T>::clear() {
-  _ptr   = nullptr;
-  _count = 0;
-  return *this;
-}
-
-template <typename T>
-bool
-MemSpan<T>::is_same(self_type const &that) const {
-  return _ptr == that._ptr && _count == that._count;
-}
-
-template <typename T>
-constexpr bool
-MemSpan<T>::operator==(self_type const &that) const {
-  return _count == that._count && (_ptr == that._ptr || 0 == memcmp(_ptr, that._ptr, this->size()));
-}
-
-template <typename T>
-constexpr bool
-MemSpan<T>::operator!=(self_type const &that) const {
-  return !(*this == that);
-}
-
-template <typename T>
-bool
-MemSpan<T>::operator!() const {
-  return _count == 0;
-}
-
-template <typename T> MemSpan<T>::operator bool() const {
-  return _count != 0;
-}
-
-template <typename T> constexpr
-bool
-MemSpan<T>::empty() const {
-  return _count == 0;
-}
-
-template <typename T> constexpr
-T *
-MemSpan<T>::begin() const {
-  return _ptr;
-}
-
-template <typename T>
-T *
-MemSpan<T>::data() const {
-  return _ptr;
-}
-
-template <typename T> constexpr
-T *
-MemSpan<T>::data_end() const {
-  return _ptr + _count;
-}
-
-template <typename T> constexpr
-T *
-MemSpan<T>::end() const {
-  return _ptr + _count;
-}
-
-template <typename T>
-T &
-MemSpan<T>::operator[](size_t idx) const {
-  return _ptr[idx];
-}
-
-template <typename T> constexpr
-size_t
-MemSpan<T>::size() const {
-  return _count;
-}
-
-template <typename T> constexpr
-  size_t
-  MemSpan<T>::count() const {
-  return _count;
-}
-
-template <typename T> constexpr
-  size_t
-  MemSpan<T>::length() const {
-  return _count;
-}
-
-template <typename T>
-constexpr size_t
-MemSpan<T>::data_size() const {
-  return _count * sizeof(T);
-}
-
-template <typename T>
-bool
-MemSpan<T>::contains(T const *ptr) const {
-  return _ptr <= ptr && ptr < _ptr + _count;
-}
-
-template <typename T> constexpr
-auto
-MemSpan<T>::prefix(size_t count) const -> self_type {
-  return {_ptr, std::min(count, _count)};
-}
-
-template <typename T> constexpr
-auto
-MemSpan<T>::first(size_t count) const -> self_type {
-  return this->prefix(count);
-}
-
-template <typename T>
-auto
-MemSpan<T>::remove_prefix(size_t count) -> self_type & {
-  count = std::min(_count, count);
-  _count -= count;
-  _ptr += count;
-  return *this;
-}
-
-template <typename T> constexpr
-auto
-MemSpan<T>::suffix(size_t count) const -> self_type {
-  count = std::min(_count, count);
-  return {(_ptr + _count) - count, count};
-}
-
-template <typename T>
-constexpr MemSpan<T>
-MemSpan<T>::last(size_t count) const {
-  return this->suffix(count);
-}
-
-template <typename T>
-MemSpan<T> &
-MemSpan<T>::remove_suffix(size_t count) {
-  _count -= std::min(count, _count);
-  return *this;
-}
-
-template <typename T>
-auto
-MemSpan<T>::clip_prefix(size_t count) -> self_type {
-  if (count >= _count) {
-    auto zret = *this;
+  template <typename T>
+  MemSpan<T> &
+  MemSpan<T>::clear()
+  {
+    _ptr   = nullptr;
     _count = 0;
+    return *this;
+  }
+
+  template <typename T>
+  bool
+  MemSpan<T>::is_same(self_type const &that) const
+  {
+    return _ptr == that._ptr && _count == that._count;
+  }
+
+  template <typename T>
+  constexpr bool
+  MemSpan<T>::operator==(self_type const &that) const
+  {
+    return _count == that._count && (_ptr == that._ptr || 0 == memcmp(_ptr, that._ptr, this->size()));
+  }
+
+  template <typename T>
+  constexpr bool
+  MemSpan<T>::operator!=(self_type const &that) const
+  {
+    return !(*this == that);
+  }
+
+  template <typename T>
+  bool
+  MemSpan<T>::operator!() const
+  {
+    return _count == 0;
+  }
+
+  template <typename T> MemSpan<T>::operator bool() const
+  {
+    return _count != 0;
+  }
+
+  template <typename T>
+  constexpr bool
+  MemSpan<T>::empty() const
+  {
+    return _count == 0;
+  }
+
+  template <typename T>
+  constexpr T *
+  MemSpan<T>::begin() const
+  {
+    return _ptr;
+  }
+
+  template <typename T>
+  T *
+  MemSpan<T>::data() const
+  {
+    return _ptr;
+  }
+
+  template <typename T>
+  constexpr T *
+  MemSpan<T>::data_end() const
+  {
+    return _ptr + _count;
+  }
+
+  template <typename T>
+  constexpr T *
+  MemSpan<T>::end() const
+  {
+    return _ptr + _count;
+  }
+
+  template <typename T>
+  T &
+  MemSpan<T>::operator[](size_t idx) const
+  {
+    return _ptr[idx];
+  }
+
+  template <typename T>
+  constexpr size_t
+  MemSpan<T>::size() const
+  {
+    return _count;
+  }
+
+  template <typename T>
+  constexpr size_t
+  MemSpan<T>::count() const
+  {
+    return _count;
+  }
+
+  template <typename T>
+  constexpr size_t
+  MemSpan<T>::length() const
+  {
+    return _count;
+  }
+
+  template <typename T>
+  constexpr size_t
+  MemSpan<T>::data_size() const
+  {
+    return _count * sizeof(T);
+  }
+
+  template <typename T>
+  bool
+  MemSpan<T>::contains(T const *ptr) const
+  {
+    return _ptr <= ptr && ptr < _ptr + _count;
+  }
+
+  template <typename T>
+  constexpr auto
+  MemSpan<T>::prefix(size_t count) const -> self_type
+  {
+    return {_ptr, std::min(count, _count)};
+  }
+
+  template <typename T>
+  constexpr auto
+  MemSpan<T>::first(size_t count) const -> self_type
+  {
+    return this->prefix(count);
+  }
+
+  template <typename T>
+  auto
+  MemSpan<T>::remove_prefix(size_t count) -> self_type &
+  {
+    count   = std::min(_count, count);
+    _count -= count;
+    _ptr   += count;
+    return *this;
+  }
+
+  template <typename T>
+  constexpr auto
+  MemSpan<T>::suffix(size_t count) const -> self_type
+  {
+    count = std::min(_count, count);
+    return {(_ptr + _count) - count, count};
+  }
+
+  template <typename T>
+  constexpr MemSpan<T>
+  MemSpan<T>::last(size_t count) const
+  {
+    return this->suffix(count);
+  }
+
+  template <typename T>
+  MemSpan<T> &
+  MemSpan<T>::remove_suffix(size_t count)
+  {
+    _count -= std::min(count, _count);
+    return *this;
+  }
+
+  template <typename T>
+  auto
+  MemSpan<T>::clip_prefix(size_t count) -> self_type
+  {
+    if (count >= _count) {
+      auto zret = *this;
+      _count    = 0;
+      return zret;
+    }
+    self_type zret{_ptr, count};
+    _ptr   += count;
+    _count -= count;
     return zret;
   }
-  self_type zret { _ptr, count };
-  _ptr += count;
-  _count -= count;
-  return zret;
-}
 
-template <typename T>
-auto
-MemSpan<T>::clip_suffix(size_t count) -> self_type {
-  if (count >= _count) {
-    auto zret = *this;
-    _count = 0;
-    return zret;
+  template <typename T>
+  auto
+  MemSpan<T>::clip_suffix(size_t count) -> self_type
+  {
+    if (count >= _count) {
+      auto zret = *this;
+      _count    = 0;
+      return zret;
+    }
+    _count -= count;
+    return {_ptr + _count, count};
   }
-  _count -= count;
-  return { _ptr + _count , count };
-}
 
-template <typename T>
-constexpr MemSpan<T>
-MemSpan<T>::subspan(size_t offset, size_t count) const {
-  return offset < _count ? self_type{this->data() + offset, std::min(count, _count - offset)} : self_type{};
-}
-
-template <typename T>
-T &
-MemSpan<T>::front() {
-  return *_ptr;
-}
-
-template <typename T>
-T &
-MemSpan<T>::back() {
-  return _ptr[_count - 1];
-}
-
-template <typename T>
-template <typename F>
-typename MemSpan<T>::self_type &
-MemSpan<T>::apply(F &&f) {
-  for (auto &item : *this) {
-    f(item);
+  template <typename T>
+  constexpr MemSpan<T>
+  MemSpan<T>::subspan(size_t offset, size_t count) const
+  {
+    return offset < _count ? self_type{this->data() + offset, std::min(count, _count - offset)} : self_type{};
   }
-  return *this;
-}
 
-template <typename T>
-template <typename U>
-MemSpan<U>
-MemSpan<T>::rebind() const {
-  static_assert(detail::is_span_compatible<T, U>::value,
-                "MemSpan only allows rebinding between types where the sizes are such that one is an integral multiple of the other.");
-  using VOID_PTR = std::conditional_t<std::is_const_v<U>, const void *, void*>;
-  return {static_cast<U *>(static_cast<VOID_PTR>(_ptr)), detail::is_span_compatible<T, U>::count(this->data_size())};
-}
-
-template <typename T>
-template <typename... Args>
-auto
-MemSpan<T>::make(Args &&...args) -> self_type & {
-  for ( T * elt = this->data(), * limit = this->data_end() ; elt < limit ; ++elt ) {
-    new (elt) T(std::forward<Args>(args)...);
+  template <typename T>
+  T &
+  MemSpan<T>::front()
+  {
+    return *_ptr;
   }
-  return *this;
-}
 
-template <typename T>
-void
-MemSpan<T>::destroy() {
-  for ( T * elt = this->data(), * limit = this->data_end() ; elt < limit ; ++elt ) {
-    std::destroy_at(elt);
+  template <typename T>
+  T &
+  MemSpan<T>::back()
+  {
+    return _ptr[_count - 1];
   }
-}
 
-// --- void specializations ---
+  template <typename T>
+  template <typename F>
+  typename MemSpan<T>::self_type &
+  MemSpan<T>::apply(F &&f)
+  {
+    for (auto &item : *this) {
+      f(item);
+    }
+    return *this;
+  }
 
-template <typename U> constexpr MemSpan<void const>::MemSpan(MemSpan<U> const &that) : _ptr(const_cast<std::remove_const_t<U> *>(that._ptr)), _size(sizeof(U) * that.size()) {}
-template <typename U> constexpr MemSpan<void>::MemSpan(MemSpan<U> const &that) : super_type(that) { static_assert(!std::is_const_v<U>, "MemSpan<void> does not support constant memory."); }
+  template <typename T>
+  template <typename U>
+  MemSpan<U>
+  MemSpan<T>::rebind() const
+  {
+    static_assert(
+      detail::is_span_compatible<T, U>::value,
+      "MemSpan only allows rebinding between types where the sizes are such that one is an integral multiple of the other.");
+    using VOID_PTR = std::conditional_t<std::is_const_v<U>, const void *, void *>;
+    return {static_cast<U *>(static_cast<VOID_PTR>(_ptr)), detail::is_span_compatible<T, U>::count(this->data_size())};
+  }
 
-inline constexpr MemSpan<void const>::MemSpan(MemSpan<void> const &that) : _ptr(that._ptr), _size(that.size()) {}
+  template <typename T>
+  template <typename... Args>
+  auto
+  MemSpan<T>::make(Args &&...args) -> self_type &
+  {
+    for (T *elt = this->data(), *limit = this->data_end(); elt < limit; ++elt) {
+      new (elt) T(std::forward<Args>(args)...);
+    }
+    return *this;
+  }
 
-inline constexpr MemSpan<void const>::MemSpan(value_type *ptr, size_t n) : _ptr{const_cast<void*>(ptr)}, _size{n} {}
-inline constexpr MemSpan<void>::MemSpan(value_type *ptr, size_t n) : super_type(ptr, n) {}
-
-inline MemSpan<void const>::MemSpan(value_type *begin, value_type *end) : _ptr{const_cast<void*>(begin)}, _size{detail::ptr_distance(begin, end)} {}
-inline MemSpan<void >::MemSpan(value_type *begin, value_type *end) : super_type(begin, end) {}
-
-template <auto N, typename U>
-constexpr MemSpan<void const>::MemSpan(U (&a)[N]) : _ptr(const_cast<std::remove_const_t<U>*>(a)), _size(N * sizeof(U)) {
-  // Magic for string literals to drop the trailing nul terminator, which is almost always what is expected.
-  if constexpr (N > 0 && std::is_same_v<char const, U>) {
-    if (a[N-1] == 0) {
-      _size -= 1;
+  template <typename T>
+  void
+  MemSpan<T>::destroy()
+  {
+    for (T *elt = this->data(), *limit = this->data_end(); elt < limit; ++elt) {
+      std::destroy_at(elt);
     }
   }
-}
-template <auto N, typename U>
-constexpr MemSpan<void>::MemSpan(U (&a)[N]) : super_type(a) {
-  static_assert(!std::is_const_v<U>, "Error: constructing non-constant view with constant data.");
-}
 
-template <typename C, typename>
-constexpr MemSpan<void const>::MemSpan(C const &c)
-  : _ptr(const_cast<std::remove_const_t<std::remove_reference_t<decltype(*(std::declval<C>().data()))>> *>(c.data()))
-    , _size(c.size() * sizeof(*(std::declval<C>().data()))) {}
-template <typename C, typename>
-constexpr MemSpan<void>::MemSpan(C const &c) : super_type(c) {}
+  // --- void specializations ---
 
-inline constexpr MemSpan<void const>::MemSpan(std::nullptr_t) {}
-inline constexpr MemSpan<void>::MemSpan(std::nullptr_t) {}
+  template <typename U>
+  constexpr MemSpan<void const>::MemSpan(MemSpan<U> const &that)
+    : _ptr(const_cast<std::remove_const_t<U> *>(that._ptr)), _size(sizeof(U) * that.size())
+  {
+  }
+  template <typename U> constexpr MemSpan<void>::MemSpan(MemSpan<U> const &that) : super_type(that)
+  {
+    static_assert(!std::is_const_v<U>, "MemSpan<void> does not support constant memory.");
+  }
 
-inline bool
-MemSpan<void const>::is_same(self_type const &that) const {
-  return _ptr == that._ptr && _size == that._size;
-}
+  inline constexpr MemSpan<void const>::MemSpan(MemSpan<void> const &that) : _ptr(that._ptr), _size(that.size()) {}
 
-inline bool
-MemSpan<void const>::operator==(self_type const &that) const {
-  return _size == that._size && (_ptr == that._ptr || 0 == memcmp(_ptr, that._ptr, _size));
-}
+  inline constexpr MemSpan<void const>::MemSpan(value_type *ptr, size_t n) : _ptr{const_cast<void *>(ptr)}, _size{n} {}
+  inline constexpr MemSpan<void>::MemSpan(value_type *ptr, size_t n) : super_type(ptr, n) {}
 
-inline bool
-MemSpan<void const>::operator!=(self_type const &that) const {
-  return !(*this == that);
-}
+  inline MemSpan<void const>::MemSpan(value_type *begin, value_type *end)
+    : _ptr{const_cast<void *>(begin)}, _size{detail::ptr_distance(begin, end)}
+  {
+  }
+  inline MemSpan<void>::MemSpan(value_type *begin, value_type *end) : super_type(begin, end) {}
 
-inline MemSpan<void const>::operator bool() const {
-  return _size != 0;
-}
+  template <auto N, typename U>
+  constexpr MemSpan<void const>::MemSpan(U (&a)[N]) : _ptr(const_cast<std::remove_const_t<U> *>(a)), _size(N * sizeof(U))
+  {
+    // Magic for string literals to drop the trailing nul terminator, which is almost always what is expected.
+    if constexpr (N > 0 && std::is_same_v<char const, U>) {
+      if (a[N - 1] == 0) {
+        _size -= 1;
+      }
+    }
+  }
+  template <auto N, typename U> constexpr MemSpan<void>::MemSpan(U (&a)[N]) : super_type(a)
+  {
+    static_assert(!std::is_const_v<U>, "Error: constructing non-constant view with constant data.");
+  }
 
-inline bool
-MemSpan<void const>::operator!() const {
-  return _size == 0;
-}
+  template <typename C, typename>
+  constexpr MemSpan<void const>::MemSpan(C const &c)
+    : _ptr(const_cast<std::remove_const_t<std::remove_reference_t<decltype(*(std::declval<C>().data()))>> *>(c.data())),
+      _size(c.size() * sizeof(*(std::declval<C>().data())))
+  {
+  }
+  template <typename C, typename> constexpr MemSpan<void>::MemSpan(C const &c) : super_type(c) {}
 
-inline constexpr bool
-MemSpan<void const>::empty() const {
-  return _size == 0;
-}
+  inline constexpr MemSpan<void const>::MemSpan(std::nullptr_t) {}
+  inline constexpr MemSpan<void>::MemSpan(std::nullptr_t) {}
 
-template <typename U>
-auto
-MemSpan<void const>::operator=(MemSpan<U> const &that) -> self_type & {
-  _ptr  = that._ptr;
-  _size = sizeof(U) * that.size();
-  return *this;
-}
+  inline bool
+  MemSpan<void const>::is_same(self_type const &that) const
+  {
+    return _ptr == that._ptr && _size == that._size;
+  }
 
-inline constexpr auto
-MemSpan<void const>::operator=(MemSpan<void> const &that) -> self_type & {
-  _ptr  = that._ptr;
-  _size = that.size();
-  return *this;
-}
+  inline bool
+  MemSpan<void const>::operator==(self_type const &that) const
+  {
+    return _size == that._size && (_ptr == that._ptr || 0 == memcmp(_ptr, that._ptr, _size));
+  }
 
-template <typename U>
-auto
-MemSpan<void>::operator=(MemSpan<U> const &that) -> self_type & {
-  static_assert(! std::is_const_v<U>, "Cannot assign constant pointer to MemSpan<void>");
-  this->super_type::operator=(that);
-  return *this;
-}
+  inline bool
+  MemSpan<void const>::operator!=(self_type const &that) const
+  {
+    return !(*this == that);
+  }
 
-inline auto
-MemSpan<void const>::assign(value_type *ptr, size_t n) -> self_type & {
-  _ptr  = const_cast<void*>(ptr);
-  _size = n;
-  return *this;
-}
+  inline MemSpan<void const>::operator bool() const
+  {
+    return _size != 0;
+  }
 
-inline auto
-MemSpan<void>::assign(value_type * ptr, size_t n) -> self_type & {
-  super_type::assign(ptr, n);
-  return *this;
-}
+  inline bool
+  MemSpan<void const>::operator!() const
+  {
+    return _size == 0;
+  }
 
-inline auto
-MemSpan<void const>::assign(value_type *first, value_type const *last) -> self_type & {
-  _ptr  = const_cast<void*>(first);
-  _size = detail::ptr_distance(first, last);
-  return *this;
-}
+  inline constexpr bool
+  MemSpan<void const>::empty() const
+  {
+    return _size == 0;
+  }
 
-inline auto
-MemSpan<void>::assign(value_type *first, value_type const *last) -> self_type & {
-  super_type::assign(first, last);
-  return *this;
-}
+  template <typename U>
+  auto
+  MemSpan<void const>::operator=(MemSpan<U> const &that) -> self_type &
+  {
+    _ptr  = that._ptr;
+    _size = sizeof(U) * that.size();
+    return *this;
+  }
 
-inline auto
-MemSpan<void const>::clear() -> self_type & {
-  _ptr  = nullptr;
-  _size = 0;
-  return *this;
-}
+  inline constexpr auto
+  MemSpan<void const>::operator=(MemSpan<void> const &that) -> self_type &
+  {
+    _ptr  = that._ptr;
+    _size = that.size();
+    return *this;
+  }
 
-inline auto
-MemSpan<void>::clear() -> self_type & {
-  super_type::clear();
-  return *this;
-}
+  template <typename U>
+  auto
+  MemSpan<void>::operator=(MemSpan<U> const &that) -> self_type &
+  {
+    static_assert(!std::is_const_v<U>, "Cannot assign constant pointer to MemSpan<void>");
+    this->super_type::operator=(that);
+    return *this;
+  }
 
-inline constexpr void const *
-MemSpan<void const>::data() const {
-  return _ptr;
-}
+  inline auto
+  MemSpan<void const>::assign(value_type *ptr, size_t n) -> self_type &
+  {
+    _ptr  = const_cast<void *>(ptr);
+    _size = n;
+    return *this;
+  }
 
-inline constexpr void *
-MemSpan<void>::data() const {
-  return _ptr;
-}
+  inline auto
+  MemSpan<void>::assign(value_type *ptr, size_t n) -> self_type &
+  {
+    super_type::assign(ptr, n);
+    return *this;
+  }
 
-inline void const *
-MemSpan<void const>::data_end() const {
-  return detail::ptr_add(_ptr, _size);
-}
+  inline auto
+  MemSpan<void const>::assign(value_type *first, value_type const *last) -> self_type &
+  {
+    _ptr  = const_cast<void *>(first);
+    _size = detail::ptr_distance(first, last);
+    return *this;
+  }
 
-inline void *
-MemSpan<void>::data_end() const {
-  return detail::ptr_add(_ptr, _size);
-}
+  inline auto
+  MemSpan<void>::assign(value_type *first, value_type const *last) -> self_type &
+  {
+    super_type::assign(first, last);
+    return *this;
+  }
 
-inline constexpr size_t
-MemSpan<void const>::size() const {
-  return _size;
-}
-
-inline constexpr size_t
-MemSpan<void const>::count() const {
-  return _size;
-}
-
-inline constexpr size_t
-MemSpan<void const>::length() const {
-  return _size;
-}
-
-inline constexpr size_t
-MemSpan<void const>::data_size() const {
-  return _size;
-}
-
-inline bool
-MemSpan<void const>::contains(value_type const *ptr) const {
-  return _ptr <= ptr && ptr < this->data_end();
-}
-
-inline auto
-MemSpan<void const>::prefix(size_t n) const -> self_type {
-  return {_ptr, std::min(n, _size)};
-}
-
-inline auto
-MemSpan<void>::prefix(size_t n) const -> self_type {
-  return {_ptr, std::min(n, _size)};
-}
-
-inline auto
-MemSpan<void const>::remove_prefix(size_t n) -> self_type & {
-  n = std::min(_size, n);
-  _size -= n;
-  _ptr = detail::ptr_add(_ptr, n);
-  return *this;
-}
-
-inline auto
-MemSpan<void>::remove_prefix(size_t n) -> self_type & {
-  super_type::remove_prefix(n);
-  return *this;
-}
-
-inline auto
-MemSpan<void const>::suffix(size_t n) const -> self_type {
-  n = std::min(n, _size);
-  return {detail::ptr_add(this->data_end(), -n), n};
-}
-
-inline auto
-MemSpan<void>::suffix(size_t n) const -> self_type {
-  n = std::min(n, _size);
-  return {detail::ptr_add(this->data_end(), -n), n};
-}
-
-inline auto
-MemSpan<void const>::remove_suffix(size_t n) -> self_type & {
-  _size -= std::min(n, _size);
-  return *this;
-}
-
-inline auto
-MemSpan<void>::remove_suffix(size_t n) -> self_type & {
-  this->super_type::remove_suffix(n);
-  return *this;
-}
-
-inline auto
-MemSpan<void const>::clip_prefix(size_t n) -> self_type {
-  if (n >= _size) {
-    auto zret = *this;
+  inline auto
+  MemSpan<void const>::clear() -> self_type &
+  {
+    _ptr  = nullptr;
     _size = 0;
+    return *this;
+  }
+
+  inline auto
+  MemSpan<void>::clear() -> self_type &
+  {
+    super_type::clear();
+    return *this;
+  }
+
+  inline constexpr void const *
+  MemSpan<void const>::data() const
+  {
+    return _ptr;
+  }
+
+  inline constexpr void *
+  MemSpan<void>::data() const
+  {
+    return _ptr;
+  }
+
+  inline void const *
+  MemSpan<void const>::data_end() const
+  {
+    return detail::ptr_add(_ptr, _size);
+  }
+
+  inline void *
+  MemSpan<void>::data_end() const
+  {
+    return detail::ptr_add(_ptr, _size);
+  }
+
+  inline constexpr size_t
+  MemSpan<void const>::size() const
+  {
+    return _size;
+  }
+
+  inline constexpr size_t
+  MemSpan<void const>::count() const
+  {
+    return _size;
+  }
+
+  inline constexpr size_t
+  MemSpan<void const>::length() const
+  {
+    return _size;
+  }
+
+  inline constexpr size_t
+  MemSpan<void const>::data_size() const
+  {
+    return _size;
+  }
+
+  inline bool
+  MemSpan<void const>::contains(value_type const *ptr) const
+  {
+    return _ptr <= ptr && ptr < this->data_end();
+  }
+
+  inline auto
+  MemSpan<void const>::prefix(size_t n) const -> self_type
+  {
+    return {_ptr, std::min(n, _size)};
+  }
+
+  inline auto
+  MemSpan<void>::prefix(size_t n) const -> self_type
+  {
+    return {_ptr, std::min(n, _size)};
+  }
+
+  inline auto
+  MemSpan<void const>::remove_prefix(size_t n) -> self_type &
+  {
+    n      = std::min(_size, n);
+    _size -= n;
+    _ptr   = detail::ptr_add(_ptr, n);
+    return *this;
+  }
+
+  inline auto
+  MemSpan<void>::remove_prefix(size_t n) -> self_type &
+  {
+    super_type::remove_prefix(n);
+    return *this;
+  }
+
+  inline auto
+  MemSpan<void const>::suffix(size_t n) const -> self_type
+  {
+    n = std::min(n, _size);
+    return {detail::ptr_add(this->data_end(), -n), n};
+  }
+
+  inline auto
+  MemSpan<void>::suffix(size_t n) const -> self_type
+  {
+    n = std::min(n, _size);
+    return {detail::ptr_add(this->data_end(), -n), n};
+  }
+
+  inline auto
+  MemSpan<void const>::remove_suffix(size_t n) -> self_type &
+  {
+    _size -= std::min(n, _size);
+    return *this;
+  }
+
+  inline auto
+  MemSpan<void>::remove_suffix(size_t n) -> self_type &
+  {
+    this->super_type::remove_suffix(n);
+    return *this;
+  }
+
+  inline auto
+  MemSpan<void const>::clip_prefix(size_t n) -> self_type
+  {
+    if (n >= _size) {
+      auto zret = *this;
+      _size     = 0;
+      return zret;
+    }
+    self_type zret{_ptr, n};
+    _ptr   = detail::ptr_add(_ptr, n);
+    _size -= n;
     return zret;
   }
-  self_type zret { _ptr, n };
-  _ptr = detail::ptr_add(_ptr, n);
-  _size -= n;
-  return zret;
-}
 
-inline auto
-MemSpan<void>::clip_prefix(size_t n) -> self_type { return super_type::clip_prefix(n); }
-
-inline auto
-MemSpan<void const>::clip_suffix(size_t n) -> self_type {
-  if (n >= _size) {
-    auto zret = *this;
-    _size = 0;
-    return zret;
+  inline auto
+  MemSpan<void>::clip_prefix(size_t n) -> self_type
+  {
+    return super_type::clip_prefix(n);
   }
-  _size -= n;
-  return { detail::ptr_add(_ptr, _size) , n };
-}
 
-inline auto
-MemSpan<void>::clip_suffix(size_t n) -> self_type { return super_type::clip_suffix(n); }
-
-inline constexpr auto
-MemSpan<void const>::subspan(size_t offset, size_t n) const -> self_type {
-  return offset <= _size ? self_type{detail::ptr_add(this->data(), offset), std::min(n, _size - offset)} : self_type{};
-}
-
-inline constexpr auto
-MemSpan<void>::subspan(size_t offset, size_t n) const -> self_type {
-  return offset <= _size ? self_type{detail::ptr_add(this->data(), offset), std::min(n, _size - offset)} : self_type{};
-}
-
-template <typename T>
-constexpr auto
-MemSpan<T>::restrict(size_t n) -> self_type & {
-  _count = std::min(_count, n);
-  return *this;
-}
-
-template <typename T> auto
-MemSpan<void const>::align() const -> self_type { return this->align(alignof(T), sizeof(T)); }
-
-template <typename T> auto
-MemSpan<void>::align() const -> self_type { return this->align(alignof(T), sizeof(T)); }
-
-inline auto
-MemSpan<void const>::align(size_t alignment) const -> self_type {
-  auto p = uintptr_t(_ptr);
-  auto padding = p & (alignment - 1);
-  size_t size = 0;
-  if (_size > padding) { // if there's not enough to pad, result is zero size.
-    size = _size - padding;
+  inline auto
+  MemSpan<void const>::clip_suffix(size_t n) -> self_type
+  {
+    if (n >= _size) {
+      auto zret = *this;
+      _size     = 0;
+      return zret;
+    }
+    _size -= n;
+    return {detail::ptr_add(_ptr, _size), n};
   }
-  return { reinterpret_cast<void*>(p + padding), size };
-}
 
-inline auto
-MemSpan<void>::align(size_t alignment) const -> self_type {
-  auto && [ ptr, size ] = super_type::align(alignment);
-  return { ptr, size };
-}
-
-inline auto
-MemSpan<void const>::align(size_t alignment, size_t obj_size) const -> self_type {
-  auto p = uintptr_t(_ptr);
-  auto padding = p & (alignment - 1);
-  size_t size = 0;
-  if (_size > padding) { // if there's not enough to pad, result is zero size.
-    size = ((_size - padding) / obj_size ) * obj_size;
+  inline auto
+  MemSpan<void>::clip_suffix(size_t n) -> self_type
+  {
+    return super_type::clip_suffix(n);
   }
-  return { reinterpret_cast<void*>(p + padding), size };
-}
 
-inline auto
-MemSpan<void>::align(size_t alignment, size_t obj_size) const -> self_type {
-  auto && [ ptr, n ] = super_type::align(alignment, obj_size);
-  return { ptr, n };
-}
-
-template < typename U > MemSpan<U>
-MemSpan<void const>::rebind() const {
-  static_assert(std::is_const_v<U>, "Cannot rebind MemSpan<const void> to non-const type.");
-  return {static_cast<U *>(_ptr), detail::is_span_compatible<value_type, U>::count(_size)};
-}
-
-template < typename U > MemSpan<U>
-MemSpan<void>::rebind() const {
-  return {static_cast<U *>(_ptr), detail::is_span_compatible<value_type, U>::count(_size)};
-}
-
-// Specialize so that @c void -> @c void rebinding compiles and works as expected.
-template <>
-inline auto
-MemSpan<void const>::rebind() const -> self_type {
-  return *this;
-}
-
-template <>
-inline auto
-MemSpan<void>::rebind() const -> self_type {
-  return *this;
-}
-
-template <>
-inline auto
-MemSpan<void>::rebind() const -> MemSpan<void const> {
-  return { _ptr, _size };
-}
-
-template <typename U> U *
-MemSpan<void>::as_ptr() const {
-  if (_size != sizeof(U)) {
-    throw std::invalid_argument("MemSpan::as size is not compatible with target type.");
+  inline constexpr auto
+  MemSpan<void const>::subspan(size_t offset, size_t n) const -> self_type
+  {
+    return offset <= _size ? self_type{detail::ptr_add(this->data(), offset), std::min(n, _size - offset)} : self_type{};
   }
-  return static_cast<U *>(_ptr);
-}
 
-template <typename U> U const *
-MemSpan<void const>::as_ptr() const {
-  if (_size != sizeof(U)) {
-    throw std::invalid_argument("MemSpan::as size is not compatible with target type.");
+  inline constexpr auto
+  MemSpan<void>::subspan(size_t offset, size_t n) const -> self_type
+  {
+    return offset <= _size ? self_type{detail::ptr_add(this->data(), offset), std::min(n, _size - offset)} : self_type{};
   }
-  return static_cast<U const *>(_ptr);
-}
 
-/// Deduction guides
-template<typename T, size_t N> MemSpan(std::array<T,N> &) -> MemSpan<T>;
-template<typename T, size_t N> MemSpan(std::array<T,N> const &) -> MemSpan<T const>;
-template<size_t N> MemSpan(char (&)[N]) -> MemSpan<char>;
-template<size_t N> MemSpan(char const (&)[N]) -> MemSpan<char const>;
-template<typename T> MemSpan(std::vector<T> &) -> MemSpan<T>;
-template<typename T> MemSpan(std::vector<T> const&) -> MemSpan<T const>;
-MemSpan(std::string_view const&) -> MemSpan<char const>;
-MemSpan(std::string &) -> MemSpan<char>;
-MemSpan(std::string const&) -> MemSpan<char const>;
+  template <typename T> constexpr auto MemSpan<T>::restrict(size_t n) -> self_type &
+  {
+    _count = std::min(_count, n);
+    return *this;
+  }
 
-namespace detail {
-struct malloc_liberator {
-  void operator()(void * ptr) { ::free(ptr); }
-};
-} // namespace detail.
+  template <typename T>
+  auto
+  MemSpan<void const>::align() const -> self_type
+  {
+    return this->align(alignof(T), sizeof(T));
+  }
 
-/// A variant of @c unique_ptr that handles memory from @c malloc.
-template<typename T> using unique_malloc = std::unique_ptr<T, detail::malloc_liberator>;
-}} // namespace swoc::SWOC_VERSION_NS
+  template <typename T>
+  auto
+  MemSpan<void>::align() const -> self_type
+  {
+    return this->align(alignof(T), sizeof(T));
+  }
+
+  inline auto
+  MemSpan<void const>::align(size_t alignment) const -> self_type
+  {
+    auto p       = uintptr_t(_ptr);
+    auto padding = p & (alignment - 1);
+    size_t size  = 0;
+    if (_size > padding) { // if there's not enough to pad, result is zero size.
+      size = _size - padding;
+    }
+    return {reinterpret_cast<void *>(p + padding), size};
+  }
+
+  inline auto
+  MemSpan<void>::align(size_t alignment) const -> self_type
+  {
+    auto &&[ptr, size] = super_type::align(alignment);
+    return {ptr, size};
+  }
+
+  inline auto
+  MemSpan<void const>::align(size_t alignment, size_t obj_size) const -> self_type
+  {
+    auto p       = uintptr_t(_ptr);
+    auto padding = p & (alignment - 1);
+    size_t size  = 0;
+    if (_size > padding) { // if there's not enough to pad, result is zero size.
+      size = ((_size - padding) / obj_size) * obj_size;
+    }
+    return {reinterpret_cast<void *>(p + padding), size};
+  }
+
+  inline auto
+  MemSpan<void>::align(size_t alignment, size_t obj_size) const -> self_type
+  {
+    auto &&[ptr, n] = super_type::align(alignment, obj_size);
+    return {ptr, n};
+  }
+
+  template <typename U>
+  MemSpan<U>
+  MemSpan<void const>::rebind() const
+  {
+    static_assert(std::is_const_v<U>, "Cannot rebind MemSpan<const void> to non-const type.");
+    return {static_cast<U *>(_ptr), detail::is_span_compatible<value_type, U>::count(_size)};
+  }
+
+  template <typename U>
+  MemSpan<U>
+  MemSpan<void>::rebind() const
+  {
+    return {static_cast<U *>(_ptr), detail::is_span_compatible<value_type, U>::count(_size)};
+  }
+
+  // Specialize so that @c void -> @c void rebinding compiles and works as expected.
+  template <>
+  inline auto
+  MemSpan<void const>::rebind() const -> self_type
+  {
+    return *this;
+  }
+
+  template <>
+  inline auto
+  MemSpan<void>::rebind() const -> self_type
+  {
+    return *this;
+  }
+
+  template <>
+  inline auto
+  MemSpan<void>::rebind() const -> MemSpan<void const>
+  {
+    return {_ptr, _size};
+  }
+
+  template <typename U>
+  U *
+  MemSpan<void>::as_ptr() const
+  {
+    if (_size != sizeof(U)) {
+      throw std::invalid_argument("MemSpan::as size is not compatible with target type.");
+    }
+    return static_cast<U *>(_ptr);
+  }
+
+  template <typename U>
+  U const *
+  MemSpan<void const>::as_ptr() const
+  {
+    if (_size != sizeof(U)) {
+      throw std::invalid_argument("MemSpan::as size is not compatible with target type.");
+    }
+    return static_cast<U const *>(_ptr);
+  }
+
+  /// Deduction guides
+  template <typename T, size_t N> MemSpan(std::array<T, N> &) -> MemSpan<T>;
+  template <typename T, size_t N> MemSpan(std::array<T, N> const &) -> MemSpan<T const>;
+  template <size_t N> MemSpan(char (&)[N]) -> MemSpan<char>;
+  template <size_t N> MemSpan(char const (&)[N]) -> MemSpan<char const>;
+  template <typename T> MemSpan(std::vector<T> &) -> MemSpan<T>;
+  template <typename T> MemSpan(std::vector<T> const &) -> MemSpan<T const>;
+  MemSpan(std::string_view const &) -> MemSpan<char const>;
+  MemSpan(std::string &) -> MemSpan<char>;
+  MemSpan(std::string const &) -> MemSpan<char const>;
+
+  namespace detail
+  {
+    struct malloc_liberator {
+      void
+      operator()(void *ptr)
+      {
+        ::free(ptr);
+      }
+    };
+  } // namespace detail.
+
+  /// A variant of @c unique_ptr that handles memory from @c malloc.
+  template <typename T> using unique_malloc = std::unique_ptr<T, detail::malloc_liberator>;
+} // namespace SWOC_VERSION_NS
+} // namespace swoc
 
 /// @cond NO_DOXYGEN
 // STL tuple support - this allows the @c MemSpan to be used as a tuple of a pointer
 // and size.
-namespace std {
-template <size_t IDX, typename R> class tuple_element<IDX, swoc::MemSpan<R>> {
+namespace std
+{
+template <size_t IDX, typename R> class tuple_element<IDX, swoc::MemSpan<R>>
+{
   static_assert("swoc::MemSpan tuple index out of range");
 };
 
-template <typename R> class tuple_element<0, swoc::MemSpan<R>> {
+template <typename R> class tuple_element<0, swoc::MemSpan<R>>
+{
 public:
   using type = R *;
 };
 
-template <typename R> class tuple_element<1, swoc::MemSpan<R>> {
+template <typename R> class tuple_element<1, swoc::MemSpan<R>>
+{
 public:
   using type = size_t;
 };
 
-template <typename R> class tuple_size<swoc::MemSpan<R>> : public std::integral_constant<size_t, 2> {};
+template <typename R> class tuple_size<swoc::MemSpan<R>> : public std::integral_constant<size_t, 2>
+{
+};
 
 } // namespace std
 

--- a/code/include/swoc/RBTree.h
+++ b/code/include/swoc/RBTree.h
@@ -9,221 +9,237 @@
 #include "swoc/swoc_version.h"
 #include "swoc/IntrusiveDList.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS { namespace detail {
-/** A node in a red/black tree.
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  namespace detail
+  {
+    /** A node in a red/black tree.
 
-    This class provides only the basic tree operations. The container must provide the search and
-    decision logic. This enables this class to be a base class for templated nodes with much less
-    code duplication.
+        This class provides only the basic tree operations. The container must provide the search and
+        decision logic. This enables this class to be a base class for templated nodes with much less
+        code duplication.
 
-    @internal The primary point of a custom implementation is to hook on rotation events which
-    are used to update additional tree data. This provides a significant performance boost
-    for range based uses of this class.
-*/
-struct RBNode {
-  using self_type = RBNode; ///< self reference type
+        @internal The primary point of a custom implementation is to hook on rotation events which
+        are used to update additional tree data. This provides a significant performance boost
+        for range based uses of this class.
+    */
+    struct RBNode {
+      using self_type = RBNode; ///< self reference type
 
-  /// Node colors
-  enum class Color {
-    RED,
-    BLACK,
-  };
+      /// Node colors
+      enum class Color {
+        RED,
+        BLACK,
+      };
 
-  /// Directional constants
-  enum class Direction {
-    NONE,
-    LEFT,
-    RIGHT,
-  };
+      /// Directional constants
+      enum class Direction {
+        NONE,
+        LEFT,
+        RIGHT,
+      };
 
-  /// Default constructor.
-  RBNode() = default;
+      /// Default constructor.
+      RBNode() = default;
 
-  /// Force virtual destructor.
-  virtual ~RBNode() {}
+      /// Force virtual destructor.
+      virtual ~RBNode() {}
 
-  /** Get the child in direction @a dir.
-   *
-   * @param d Child direction.
-   * @return A pointer to the child node, or @c nullptr if no child in that direction.
-   */
-  self_type *child_at(Direction d) const;
+      /** Get the child in direction @a dir.
+       *
+       * @param d Child direction.
+       * @return A pointer to the child node, or @c nullptr if no child in that direction.
+       */
+      self_type *child_at(Direction d) const;
 
-  /** Get the direction of a child node @a n.
-   *
-   * @param n Child node.
-   * @return Direction of the child if @a n is a child, @c Direction::NONE if not.
-   */
-  Direction direction_of(self_type *const &n) const;
+      /** Get the direction of a child node @a n.
+       *
+       * @param n Child node.
+       * @return Direction of the child if @a n is a child, @c Direction::NONE if not.
+       */
+      Direction direction_of(self_type *const &n) const;
 
-  /// @return The color of the node.
-  Color color() const;
+      /// @return The color of the node.
+      Color color() const;
 
-  /// @return The left most descendant of @a this, or @a null ptr if no left child.
-  self_type *left_most_descendant() const;
+      /// @return The left most descendant of @a this, or @a null ptr if no left child.
+      self_type *left_most_descendant() const;
 
-  /** Reverse a direction
-      @return @c LEFT if @a d is @c RIGHT, @c RIGHT if @a d is @c LEFT,
-      @c NONE otherwise.
-  */
-  Direction flip(Direction d);
+      /** Reverse a direction
+          @return @c LEFT if @a d is @c RIGHT, @c RIGHT if @a d is @c LEFT,
+          @c NONE otherwise.
+      */
+      Direction flip(Direction d);
 
-  /** Perform internal validation checks.
-      @return 0 on failure, black height of the tree on success.
-  */
-  int validate();
+      /** Perform internal validation checks.
+          @return 0 on failure, black height of the tree on success.
+      */
+      int validate();
 
-  /** Rotate the subtree rooted at this node in the direction @a dir.
-   *
-   * @param dir Direction of rotatoin.
-   * @return The root node after rotation.
-   *
-   * @a this node is rotated in to the position of its @a dir child and the child in the other
-   * direction becomes the new root node for the subtree. This operation is a no-op if there
-   * is no other child.
-   *
-   * If @a this node has a parent then that parent's child pointer is updated as needed.
-   */
-  self_type *rotate(Direction dir);
+      /** Rotate the subtree rooted at this node in the direction @a dir.
+       *
+       * @param dir Direction of rotatoin.
+       * @return The root node after rotation.
+       *
+       * @a this node is rotated in to the position of its @a dir child and the child in the other
+       * direction becomes the new root node for the subtree. This operation is a no-op if there
+       * is no other child.
+       *
+       * If @a this node has a parent then that parent's child pointer is updated as needed.
+       */
+      self_type *rotate(Direction dir);
 
-  /** Set the @a dir child of @a this node to @a child.
-   *
-   * @param child Node to set as the child.
-   * @param dir Direction of the child location.
-   * @return @a child
-   *
-   * The internal pointers in both @a this and @a child are updated as needed. It is an error
-   * to call this if the specified child is already set.
-   */
-  self_type *set_child(self_type *child, Direction dir);
+      /** Set the @a dir child of @a this node to @a child.
+       *
+       * @param child Node to set as the child.
+       * @param dir Direction of the child location.
+       * @return @a child
+       *
+       * The internal pointers in both @a this and @a child are updated as needed. It is an error
+       * to call this if the specified child is already set.
+       */
+      self_type *set_child(self_type *child, Direction dir);
 
-  /** Remove this node from the tree.
-      The tree is rebalanced after removal.
-      @return The new root node.
-  */
-  self_type *remove();
+      /** Remove this node from the tree.
+          The tree is rebalanced after removal.
+          @return The new root node.
+      */
+      self_type *remove();
 
-  /** Remove the @a dir child.
-   *
-   * @param dir Direction of child to remove.
-   *
-   * The pointers in @a this and the child are updated as needed. It is not an error if there
-   * is no child in the direction @a dir.
-   */
-  void clear_child(Direction dir);
+      /** Remove the @a dir child.
+       *
+       * @param dir Direction of child to remove.
+       *
+       * The pointers in @a this and the child are updated as needed. It is not an error if there
+       * is no child in the direction @a dir.
+       */
+      void clear_child(Direction dir);
 
-  /** @name Subclass hook methods */
-  //@{
-  /** Structural change notification.
+      /** @name Subclass hook methods */
+      //@{
+      /** Structural change notification.
 
-      This method is called if the structure of the subtree rooted at this node was changed. This
-      makes it possible to keep subtree information nodes synchronized with the state of the tree
-      efficiently.
+          This method is called if the structure of the subtree rooted at this node was changed. This
+          makes it possible to keep subtree information nodes synchronized with the state of the tree
+          efficiently.
 
-      This is intended a hook. The base method is empty so that subclasses are not required to
-      override.
+          This is intended a hook. The base method is empty so that subclasses are not required to
+          override.
 
-      @internal This is the primary reason for this class.
-  */
-  virtual void
-  structure_fixup() {}
+          @internal This is the primary reason for this class.
+      */
+      virtual void
+      structure_fixup()
+      {
+      }
 
-  /** Called from @c validate to perform any additional validation checks.
-      Clients should chain this if they wish to perform additional checks.
-      @return @c true if the validation is successful, @c false otherwise.
-  */
-  virtual bool structure_validate();
-  //@}
+      /** Called from @c validate to perform any additional validation checks.
+          Clients should chain this if they wish to perform additional checks.
+          @return @c true if the validation is successful, @c false otherwise.
+      */
+      virtual bool structure_validate();
+      //@}
 
-  /** Replace @a this node with @a n.
-   *
-   * @param n Replacement node.
-   *
-   * Invariant: this is a non-order modifying replacement.
-   */
-  void replace_with(self_type *n);
+      /** Replace @a this node with @a n.
+       *
+       * @param n Replacement node.
+       *
+       * Invariant: this is a non-order modifying replacement.
+       */
+      void replace_with(self_type *n);
 
-  //! Rebalance the tree starting at this node
-  /** The tree is rebalanced so that all of the invariants are
-      true. The (potentially new) root of the tree is returned.
+      //! Rebalance the tree starting at this node
+      /** The tree is rebalanced so that all of the invariants are
+          true. The (potentially new) root of the tree is returned.
 
-      @return The root node of the tree after the rebalance.
-  */
-  self_type *rebalance_after_insert();
+          @return The root node of the tree after the rebalance.
+      */
+      self_type *rebalance_after_insert();
 
-  /** Rebalance the tree after a deletion.
-      Called on the lowest modified node.
-      @return The new root of the tree.
-  */
-  /** Rebalance the tree root at @a this node after a removal.
-   *
-   * @param c The color of the removed node.
-   * @param d The direction of the removed node from @a this.
-   * @return The new root node.
-   *
-   * Invariant: @a this is the parent of the removed node.
-   */
-  self_type *rebalance_after_remove(Color c, Direction dir);
+      /** Rebalance the tree after a deletion.
+          Called on the lowest modified node.
+          @return The new root of the tree.
+      */
+      /** Rebalance the tree root at @a this node after a removal.
+       *
+       * @param c The color of the removed node.
+       * @param d The direction of the removed node from @a this.
+       * @return The new root node.
+       *
+       * Invariant: @a this is the parent of the removed node.
+       */
+      self_type *rebalance_after_remove(Color c, Direction dir);
 
-  /** Invoke @c structure_fixup on @a this node and its parents to the root.
-   *
-   * @return @a The root node.
-   *
-   * @note This is used by the base class to inform subclasses of structure changes, starting
-   * from a leaf node up to the root node.
-   */
-  self_type *ripple_structure_fixup();
+      /** Invoke @c structure_fixup on @a this node and its parents to the root.
+       *
+       * @return @a The root node.
+       *
+       * @note This is used by the base class to inform subclasses of structure changes, starting
+       * from a leaf node up to the root node.
+       */
+      self_type *ripple_structure_fixup();
 
-  Color _color{Color::RED};    ///< node color
-  self_type *_parent{nullptr}; ///< parent node (needed for rotations)
-  self_type *_left{nullptr};   ///< left child
-  self_type *_right{nullptr};  ///< right child
-  self_type *_next{nullptr};   ///< Next node.
-  self_type *_prev{nullptr};   ///< Previous node.
+      Color _color{Color::RED};    ///< node color
+      self_type *_parent{nullptr}; ///< parent node (needed for rotations)
+      self_type *_left{nullptr};   ///< left child
+      self_type *_right{nullptr};  ///< right child
+      self_type *_next{nullptr};   ///< Next node.
+      self_type *_prev{nullptr};   ///< Previous node.
 
-  /// Support for @c IntrusiveDList
-  struct Linkage {
-    /// @return Reference to internal pointer to the next element.
-    static self_type *&
-    next_ptr(self_type *t) {
-      return swoc::ptr_ref_cast<self_type>(t->_next);
+      /// Support for @c IntrusiveDList
+      struct Linkage {
+        /// @return Reference to internal pointer to the next element.
+        static self_type *&
+        next_ptr(self_type *t)
+        {
+          return swoc::ptr_ref_cast<self_type>(t->_next);
+        }
+        /// @return Reference to the internal pointer to the previoius element.
+        static self_type *&
+        prev_ptr(self_type *t)
+        {
+          return swoc::ptr_ref_cast<self_type>(t->_prev);
+        }
+      };
+    };
+
+    // --- Implementation ---
+
+    inline auto
+    RBNode::direction_of(self_type *const &n) const -> Direction
+    {
+      return (n == _left) ? Direction::LEFT : (n == _right) ? Direction::RIGHT : Direction::NONE;
     }
-    /// @return Reference to the internal pointer to the previoius element.
-    static self_type *&
-    prev_ptr(self_type *t) {
-      return swoc::ptr_ref_cast<self_type>(t->_prev);
+
+    inline RBNode::Color
+    RBNode::color() const
+    {
+      return _color;
     }
-  };
-};
 
-// --- Implementation ---
+    inline RBNode::Direction
+    RBNode::flip(RBNode::Direction d)
+    {
+      return Direction::LEFT == d ? Direction::RIGHT : Direction::RIGHT == d ? Direction::LEFT : Direction::NONE;
+    }
 
-inline auto
-RBNode::direction_of(self_type *const &n) const -> Direction {
-  return (n == _left) ? Direction::LEFT : (n == _right) ? Direction::RIGHT : Direction::NONE;
-}
+    inline void
+    RBNode::clear_child(RBNode::Direction dir)
+    {
+      if (Direction::LEFT == dir)
+        _left = nullptr;
+      else if (Direction::RIGHT == dir)
+        _right = nullptr;
+    }
 
-inline RBNode::Color
-RBNode::color() const {
-  return _color;
-}
+    inline bool
+    RBNode::structure_validate()
+    {
+      return true;
+    }
 
-inline RBNode::Direction
-RBNode::flip(RBNode::Direction d) {
-  return Direction::LEFT == d ? Direction::RIGHT : Direction::RIGHT == d ? Direction::LEFT : Direction::NONE;
-}
-
-inline void
-RBNode::clear_child(RBNode::Direction dir) {
-  if (Direction::LEFT == dir)
-    _left = nullptr;
-  else if (Direction::RIGHT == dir)
-    _right = nullptr;
-}
-
-inline bool
-RBNode::structure_validate() {
-  return true;
-}
-
-}}} // namespace swoc::SWOC_VERSION_NS::detail
+  } // namespace detail
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/include/swoc/Scalar.h
+++ b/code/include/swoc/Scalar.h
@@ -18,1040 +18,1152 @@
 #include "swoc/swoc_version.h"
 #include "swoc/swoc_meta.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
 
-namespace tag {
-/// A generic tag for @c Scalar types, used as the default.
-struct generic;
-} // namespace tag
+  namespace tag
+  {
+    /// A generic tag for @c Scalar types, used as the default.
+    struct generic;
+  } // namespace tag
 
-template <intmax_t N, typename C, typename T> class Scalar;
+  template <intmax_t N, typename C, typename T> class Scalar;
 
-namespace detail {
-/// @cond INTERNAL_DETAIL
+  namespace detail
+  {
+    /// @cond INTERNAL_DETAIL
 
-// @internal - although these conversion methods look bulky, in practice they compile down to
-// very small amounts of code due to the conditions being compile time constant - the non-taken
-// clauses are dead code and eliminated by the compiler.
+    // @internal - although these conversion methods look bulky, in practice they compile down to
+    // very small amounts of code due to the conditions being compile time constant - the non-taken
+    // clauses are dead code and eliminated by the compiler.
 
-// The general case where neither N nor S are a multiple of the other seems a bit long but this
-// minimizes the risk of integer overflow.  I need to validate that under -O2 the compiler will
-// only do 1 division to get both the quotient and remainder for (n/N) and (n%N). In cases where
-// N,S are powers of 2 I have verified recent GNU compilers will optimize to bit operations.
+    // The general case where neither N nor S are a multiple of the other seems a bit long but this
+    // minimizes the risk of integer overflow.  I need to validate that under -O2 the compiler will
+    // only do 1 division to get both the quotient and remainder for (n/N) and (n%N). In cases where
+    // N,S are powers of 2 I have verified recent GNU compilers will optimize to bit operations.
 
-// Convert a count @a c that is scale @a S to scale @c N
-template <intmax_t N, intmax_t S, typename C>
-C
-scale_conversion_round_up(C c) {
-  using R = std::ratio<N, S>;
-  if constexpr (N == S) {
-    return c;
-  } else if constexpr (R::den == 1) {
-    return c / R::num + (0 != c % R::num); // N is a multiple of S.
-  } else if constexpr (R::num == 1) {
-    return c * R::den; // S is a multiple of N.
+    // Convert a count @a c that is scale @a S to scale @c N
+    template <intmax_t N, intmax_t S, typename C>
+    C
+    scale_conversion_round_up(C c)
+    {
+      using R = std::ratio<N, S>;
+      if constexpr (N == S) {
+        return c;
+      } else if constexpr (R::den == 1) {
+        return c / R::num + (0 != c % R::num); // N is a multiple of S.
+      } else if constexpr (R::num == 1) {
+        return c * R::den; // S is a multiple of N.
+      }
+      return (c / R::num) * R::den + ((c % R::num) * R::den) / R::num + (0 != (c % R::num));
+    }
+
+    // Convert a count @a c that is scale @a S to scale @c N
+    template <intmax_t N, intmax_t S, typename C>
+    C
+    scale_conversion_round_down(C c)
+    {
+      using R = std::ratio<N, S>;
+      if constexpr (N == S) {
+        return c;
+      } else if constexpr (R::den == 1) {
+        return c / R::num; // N = k S
+      } else if constexpr (R::num == 1) {
+        return c * R::den; // S = k N
+      }
+      return (c / R::num) * R::den + ((c % R::num) * R::den) / R::num;
+    }
+
+    /* Helper classes for @c Scalar
+
+       These wrap values to capture extra information for @c Scalar methods. This includes whether to
+       round up or down when converting and, when the wrapped data is also a @c Scalar, the scale.
+
+       These are not intended for direct use but by the @c round_up and @c round_down free functions
+       which capture the information about the argument and construct an instance of one of these
+       classes to pass it on to a @c Scalar method.
+
+       Scale conversions between @c Scalar instances are handled in these classes via the templated
+       methods @c scale_conversion_round_up and @c scale_conversion_round_down.
+
+       Conversions between scales and types for the scalar helpers is done inside the helper classes
+       and a user type conversion operator exists so the helper can be converted by the compiler to
+       the correct type. For the units base conversion this is done in @c Scalar because the
+       generality of the needed conversion is too broad to be easily used. It can be done but there is
+       some ugliness due to the fact that in some cases two user conversions are needed, which is
+       difficult to deal with. I have tried it both ways and overall this seems a cleaner
+       implementation.
+
+       Much of this is driven by the fact that the assignment operator, in some cases, can not be
+       templated and therefore to have a nice interface for assignment this split is needed.
+
+       Note - the key point is the actual conversion is not done when the wrapper instance is created
+       but when the wrapper instance is assigned. That is what enables the conversion to be done in
+       the context of the destination, which is not otherwise possible.
+     */
+
+    // Unit value, to be rounded up.
+    template <typename C> struct scalar_unit_round_up_t {
+      C _n;
+
+      template <intmax_t N, typename I>
+      constexpr I
+      scale() const
+      {
+        return static_cast<I>(_n / N + (0 != (_n % N)));
+      }
+    };
+
+    // Unit value, to be rounded down.
+    template <typename C> struct scalar_unit_round_down_t {
+      C _n;
+
+      template <intmax_t N, typename I>
+      constexpr I
+      scale() const
+      {
+        return static_cast<I>(_n / N);
+      }
+    };
+
+    // Scalar value, to be rounded up.
+    template <intmax_t N, typename C, typename T> struct scalar_round_up_t {
+      C _n;
+
+      template <intmax_t S, typename I>
+      constexpr
+      operator Scalar<S, I, T>() const
+      {
+        return Scalar<S, I, T>(scale_conversion_round_up<S, N>(_n));
+      }
+    };
+
+    // Scalar value, to be rounded down.
+    template <intmax_t N, typename C, typename T> struct scalar_round_down_t {
+      C _n;
+
+      template <intmax_t S, typename I>
+      constexpr
+      operator Scalar<S, I, T>() const
+      {
+        return Scalar<S, I, T>(scale_conversion_round_down<S, N>(_n));
+      }
+    };
+
+    /// @endcond
+  } // namespace detail
+
+  /** A class to hold scaled values.
+
+      Instances of this class have a @a count and a @a scale. The "value" of the instance is @a
+      count * @a scale.  The scale is stored in the compiler in the class symbol table and so only
+      the count is a run time value. An instance with a large scale can be assigned to an instance
+      with a smaller scale and the conversion is done automatically. Conversions from a smaller to
+      larger scale must be explicit using @c round_up and @c round_down. This prevents
+      inadvertent changes in value. Because the scales are not the same these conversions can be
+      lossy and the two conversions determine whether, in such a case, the result should be rounded
+      up or down to the nearest scale value.
+
+      @a N sets the scale. @a C is the type used to hold the count, which is in units of @a N.
+
+      @a T is a "tag" type which is used only to distinguish the base metric for the scale. Scalar
+      types that have different tags are not interoperable although they can be converted manually by
+      converting to units and then explicitly constructing a new Scalar instance. This is by design.
+      This can be ignored - if not specified then it defaults to a "generic" tag. The type can be (and
+      usually is) defined in name only).
+
+      @note This is modeled somewhat on @c std::chrono and serves a similar function for different
+      and simpler cases (where the ratio is always an integer, never a fraction).
+
+      @see round_up
+      @see round_down
+   */
+  template <intmax_t N, typename C = int, typename T = tag::generic> class Scalar
+  {
+    using self_type = Scalar; ///< Self reference type.
+
+  public:
+    /// Scaling factor - make it external accessible.
+    constexpr static intmax_t SCALE = N;
+    using Counter                   = C; ///< Type used to hold the count.
+    using Tag                       = T; ///< Tag for the scalar.
+
+    static_assert(N > 0, "The scaling factor (1st template argument) must be a positive integer");
+    static_assert(std::is_integral<C>::value, "The counter type (2nd template argument) must be an integral type");
+
+    constexpr Scalar(); ///< Default constructor.
+
+    /// Construct to have value that is @a n scaled units.
+    explicit constexpr Scalar(Counter n);
+
+    /// Copy constructor.
+    constexpr Scalar(self_type const &that); /// Copy constructor.
+
+    /// Copy constructor for same scale.
+    template <typename I> constexpr Scalar(Scalar<N, I, T> const &that);
+
+    /// Direct conversion constructor.
+    /// @note Requires that @c S be an integer multiple of @c SCALE.
+    template <intmax_t S, typename I> constexpr Scalar(Scalar<S, I, T> const &that);
+
+    /// @cond INTERNAL_DETAIL
+    // Assignment from internal rounding structures.
+    // Conversion constructor.
+    constexpr Scalar(detail::scalar_round_up_t<N, C, T> const &v);
+
+    // Conversion constructor.
+    constexpr Scalar(detail::scalar_round_down_t<N, C, T> const &that);
+
+    // Conversion constructor.
+    template <typename I> constexpr Scalar(detail::scalar_unit_round_up_t<I> v);
+
+    // Conversion constructor.
+    template <typename I> constexpr Scalar(detail::scalar_unit_round_down_t<I> v);
+    /// @endcond
+
+    /** Assign value from @a that.
+     *
+     * @tparam S Scale.
+     * @tparam I Integral type.
+     * @param that Source value.
+     * @return @a this.
+     *
+     * @note Requires the scale of @a that be an integer multiple of the scale of @a this. If this
+     * isn't the case then the @c round_up or @c round_down must be used to indicate the rounding
+     * direction.
+     */
+    template <intmax_t S, typename I> self_type &operator=(Scalar<S, I, T> const &that);
+
+    /// Self type assignment.
+    self_type &operator=(self_type const &that);
+
+    /// @cond INTERNAL_DETAIL
+    /** Internal method to assign a unit value to be rounded up to the internal @c SCALE.
+     *
+     * @tparam I The underlying scale type.
+     * @param n The value to be scaled.
+     * @return @a this
+     */
+    template <typename I> self_type &operator=(detail::scalar_unit_round_up_t<I> n);
+
+    /** Internal method to assign a unit value to be rounded down to the internal @c SCALE.
+     *
+     * @tparam I The underlying scale type.
+     * @param n The value to be scaled.
+     * @return @a this
+     */
+    template <typename I> self_type &operator=(detail::scalar_unit_round_down_t<I> n);
+
+    /** Internal method to assign a differently scaled SCALAR to be rounded up.
+     *
+     * @param v The embedding of the value to be scaled.
+     * @return @a this
+     *
+     * The template parameters of @a v carry the static information needed to correctly scale
+     * it to the local scale.
+     */
+    self_type &operator=(detail::scalar_round_up_t<N, C, T> v);
+
+    /** Internal method to assign a differently scaled SCALAR to be rounded down.
+     *
+     * @param v The embedding of the value to be scaled.
+     * @return @a this
+     *
+     * The template parameters of @a v carry the static information needed to correctly scale
+     * it to the local scale.
+     */
+    self_type &operator=(detail::scalar_round_down_t<N, C, T> v);
+    /// @endcond
+
+    /** Set the scaled count to @a n.
+     *
+     * @param n The number of scale units.
+     * @return @a this
+     *
+     * This sets the count to be @a n, making the effective value @c SCALE*n. This is frequently useful
+     * for parsing, when the input is also in scaled units (e.g., the number of megabytes to use for
+     * a file).
+     */
+    self_type &assign(Counter n);
+
+    /// The value @a that is scaled appropriately.
+    /// @note Requires the scale of @a that be an integer multiple of the scale of @a this. If this
+    /// isn't the case then the @c round_up or @c round_down must be used to indicate the rounding
+    /// direction.
+    template <intmax_t S, typename I> self_type &assign(Scalar<S, I, T> const &that);
+
+    /// @cond INTERNAL_DETAIL
+    template <typename I> self_type &assign(detail::scalar_unit_round_up_t<I> n);
+
+    template <typename I> self_type &assign(detail::scalar_unit_round_down_t<I> n);
+
+    self_type &assign(detail::scalar_round_up_t<N, C, T> v);
+
+    self_type &assign(detail::scalar_round_down_t<N, C, T> v);
+    /// @endcond
+
+    /// The number of scale units.
+    constexpr Counter count() const;
+
+    /// The scaled value.
+    constexpr Counter value() const;
+
+    /// User conversion to scaled value.
+    constexpr operator Counter() const;
+
+    /// Addition operator.
+    /// The value is scaled from @a that to @a this.
+    /// @note Requires the scale of @a that be an integer multiple of the scale of @a this. If this isn't the case then
+    /// the @c scale_up or @c scale_down casts must be used to indicate the rounding direction.
+    self_type &operator+=(self_type const &that);
+
+    /** Cross scale addition.
+     *
+     * @tparam S Source scale.
+     * @tparam I Source raw type.
+     * @param that Value.
+     * @return @a this
+     *
+     * @a that is scaled as needed to be added to @a this.
+     */
+    template <intmax_t S, typename I> self_type &operator+=(Scalar<S, I, T> const &that);
+
+    /// @cond INTERNAL_DETAIL
+    template <typename I> self_type &operator+=(detail::scalar_unit_round_up_t<I> n);
+
+    template <typename I> self_type &operator+=(detail::scalar_unit_round_down_t<I> n);
+
+    self_type &operator+=(detail::scalar_round_up_t<N, C, T> v);
+
+    self_type &operator+=(detail::scalar_round_down_t<N, C, T> v);
+    /// @endcond
+
+    /// Increment - increase count by 1.
+    self_type &operator++();
+
+    /// Increment - increase count by 1.
+    self_type operator++(int);
+
+    /// Decrement - decrease count by 1.
+    self_type &operator--();
+
+    /// Decrement - decrease count by 1.
+    self_type operator--(int);
+
+    /// Increment by @a n.
+    self_type &inc(Counter n);
+
+    /// Decrement by @a n.
+    self_type &dec(Counter n);
+
+    /// Subtraction operator.
+    /// The value is scaled from @a that to @a this.
+    /// @note Requires the scale of @a that be an integer multiple of the scale of @a this. If this isn't the case then
+    /// the @c scale_up or @c scale_down casts must be used to indicate the rounding direction.
+    self_type &operator-=(self_type const &that);
+
+    /** Subtraction.
+     *
+     * @tparam S Scale.
+     * @tparam I Raw type.
+     * @param that Value to subtract.
+     * @return @a this
+     *
+     * The value of @a that is subtracted from the value of @a this.
+     */
+    template <intmax_t S, typename I> self_type &operator-=(Scalar<S, I, T> const &that);
+
+    /// @cond INTERNAL_DETAIL
+    template <typename I> self_type &operator-=(detail::scalar_unit_round_up_t<I> n);
+
+    template <typename I> self_type &operator-=(detail::scalar_unit_round_down_t<I> n);
+
+    self_type &operator-=(detail::scalar_round_up_t<N, C, T> v);
+
+    self_type &operator-=(detail::scalar_round_down_t<N, C, T> v);
+    /// @endcond
+
+    /// Multiplication - multiple the count by @a n.
+    self_type &operator*=(C n);
+
+    /// Division - divide (rounding down) the count by @a n.
+    self_type &operator/=(C n);
+
+    /// Utility overload of the function operator to create instances at the same scale.
+    self_type operator()(Counter n) const;
+
+    /// Return a value at the same scale with a count increased by @a n.
+    self_type plus(Counter n) const;
+
+    /// Return a value at the same scale with a count decreased by @a n.
+    self_type minus(Counter n) const;
+
+    /// Run time access to the scale (template arg @a N).
+    static constexpr intmax_t scale();
+
+  protected:
+    Counter _n; ///< Number of scale units.
+  };
+
+  /// @cond Scalar_INTERNAL
+  // Avoid issues with doxygen matching externally defined methods.
+  template <intmax_t N, typename C, typename T> constexpr Scalar<N, C, T>::Scalar() : _n() {}
+
+  template <intmax_t N, typename C, typename T> constexpr Scalar<N, C, T>::Scalar(Counter n) : _n(n) {}
+
+  template <intmax_t N, typename C, typename T> constexpr Scalar<N, C, T>::Scalar(self_type const &that) : _n(that._n) {}
+
+  template <intmax_t N, typename C, typename T>
+  template <typename I>
+  constexpr Scalar<N, C, T>::Scalar(Scalar<N, I, T> const &that) : _n(static_cast<C>(that.count()))
+  {
   }
-  return (c / R::num) * R::den + ((c % R::num) * R::den) / R::num + (0 != (c % R::num));
-}
 
-// Convert a count @a c that is scale @a S to scale @c N
-template <intmax_t N, intmax_t S, typename C>
-C
-scale_conversion_round_down(C c) {
-  using R = std::ratio<N, S>;
-  if constexpr (N == S) {
-    return c;
-  } else if constexpr (R::den == 1) {
-    return c / R::num; // N = k S
-  } else if constexpr (R::num == 1) {
-    return c * R::den; // S = k N
+  template <intmax_t N, typename C, typename T>
+  template <intmax_t S, typename I>
+  constexpr Scalar<N, C, T>::Scalar(Scalar<S, I, T> const &that) : _n(std::ratio<S, N>::num * that.count())
+  {
+    static_assert(std::ratio<S, N>::den == 1,
+                  "Construction not permitted - target scale is not an integral multiple of source scale.");
   }
-  return (c / R::num) * R::den + ((c % R::num) * R::den) / R::num;
-}
 
-/* Helper classes for @c Scalar
-
-   These wrap values to capture extra information for @c Scalar methods. This includes whether to
-   round up or down when converting and, when the wrapped data is also a @c Scalar, the scale.
-
-   These are not intended for direct use but by the @c round_up and @c round_down free functions
-   which capture the information about the argument and construct an instance of one of these
-   classes to pass it on to a @c Scalar method.
-
-   Scale conversions between @c Scalar instances are handled in these classes via the templated
-   methods @c scale_conversion_round_up and @c scale_conversion_round_down.
-
-   Conversions between scales and types for the scalar helpers is done inside the helper classes
-   and a user type conversion operator exists so the helper can be converted by the compiler to
-   the correct type. For the units base conversion this is done in @c Scalar because the
-   generality of the needed conversion is too broad to be easily used. It can be done but there is
-   some ugliness due to the fact that in some cases two user conversions are needed, which is
-   difficult to deal with. I have tried it both ways and overall this seems a cleaner
-   implementation.
-
-   Much of this is driven by the fact that the assignment operator, in some cases, can not be
-   templated and therefore to have a nice interface for assignment this split is needed.
-
-   Note - the key point is the actual conversion is not done when the wrapper instance is created
-   but when the wrapper instance is assigned. That is what enables the conversion to be done in
-   the context of the destination, which is not otherwise possible.
- */
-
-// Unit value, to be rounded up.
-template <typename C> struct scalar_unit_round_up_t {
-  C _n;
-
-  template <intmax_t N, typename I>
-  constexpr I
-  scale() const {
-    return static_cast<I>(_n / N + (0 != (_n % N)));
+  template <intmax_t N, typename C, typename T>
+  constexpr Scalar<N, C, T>::Scalar(detail::scalar_round_up_t<N, C, T> const &v) : _n(v._n)
+  {
   }
-};
 
-// Unit value, to be rounded down.
-template <typename C> struct scalar_unit_round_down_t {
-  C _n;
-
-  template <intmax_t N, typename I>
-  constexpr I
-  scale() const {
-    return static_cast<I>(_n / N);
+  template <intmax_t N, typename C, typename T>
+  constexpr Scalar<N, C, T>::Scalar(detail::scalar_round_down_t<N, C, T> const &v) : _n(v._n)
+  {
   }
-};
 
-// Scalar value, to be rounded up.
-template <intmax_t N, typename C, typename T> struct scalar_round_up_t {
-  C _n;
-
-  template <intmax_t S, typename I> constexpr operator Scalar<S, I, T>() const {
-    return Scalar<S, I, T>(scale_conversion_round_up<S, N>(_n));
+  template <intmax_t N, typename C, typename T>
+  template <typename I>
+  constexpr Scalar<N, C, T>::Scalar(detail::scalar_unit_round_up_t<I> v) : _n(v.template scale<N, C>())
+  {
   }
-};
 
-// Scalar value, to be rounded down.
-template <intmax_t N, typename C, typename T> struct scalar_round_down_t {
-  C _n;
-
-  template <intmax_t S, typename I> constexpr operator Scalar<S, I, T>() const {
-    return Scalar<S, I, T>(scale_conversion_round_down<S, N>(_n));
+  template <intmax_t N, typename C, typename T>
+  template <typename I>
+  constexpr Scalar<N, C, T>::Scalar(detail::scalar_unit_round_down_t<I> v) : _n(v.template scale<N, C>())
+  {
   }
-};
 
-/// @endcond
-} // namespace detail
+  template <intmax_t N, typename C, typename T>
+  constexpr auto
+  Scalar<N, C, T>::count() const -> Counter
+  {
+    return _n;
+  }
 
-/** A class to hold scaled values.
+  template <intmax_t N, typename C, typename T>
+  constexpr C
+  Scalar<N, C, T>::value() const
+  {
+    return _n * SCALE;
+  }
 
-    Instances of this class have a @a count and a @a scale. The "value" of the instance is @a
-    count * @a scale.  The scale is stored in the compiler in the class symbol table and so only
-    the count is a run time value. An instance with a large scale can be assigned to an instance
-    with a smaller scale and the conversion is done automatically. Conversions from a smaller to
-    larger scale must be explicit using @c round_up and @c round_down. This prevents
-    inadvertent changes in value. Because the scales are not the same these conversions can be
-    lossy and the two conversions determine whether, in such a case, the result should be rounded
-    up or down to the nearest scale value.
+  template <intmax_t N, typename C, typename T> constexpr Scalar<N, C, T>::operator Counter() const
+  {
+    return _n * SCALE;
+  }
 
-    @a N sets the scale. @a C is the type used to hold the count, which is in units of @a N.
+  template <intmax_t N, typename C, typename T>
+  inline auto
+  Scalar<N, C, T>::assign(Counter n) -> self_type &
+  {
+    _n = n;
+    return *this;
+  }
 
-    @a T is a "tag" type which is used only to distinguish the base metric for the scale. Scalar
-    types that have different tags are not interoperable although they can be converted manually by
-    converting to units and then explicitly constructing a new Scalar instance. This is by design.
-    This can be ignored - if not specified then it defaults to a "generic" tag. The type can be (and
-    usually is) defined in name only).
+  template <intmax_t N, typename C, typename T>
+  inline auto
+  Scalar<N, C, T>::operator=(self_type const &that) -> self_type &
+  {
+    _n = that._n;
+    return *this;
+  }
 
-    @note This is modeled somewhat on @c std::chrono and serves a similar function for different
-    and simpler cases (where the ratio is always an integer, never a fraction).
+  template <intmax_t N, typename C, typename T>
+  inline auto
+  Scalar<N, C, T>::operator=(detail::scalar_round_up_t<N, C, T> v) -> self_type &
+  {
+    _n = v._n;
+    return *this;
+  }
 
-    @see round_up
-    @see round_down
- */
-template <intmax_t N, typename C = int, typename T = tag::generic> class Scalar {
-  using self_type = Scalar; ///< Self reference type.
+  template <intmax_t N, typename C, typename T>
+  inline auto
+  Scalar<N, C, T>::assign(detail::scalar_round_up_t<N, C, T> v) -> self_type &
+  {
+    _n = v._n;
+    return *this;
+  }
 
-public:
-  /// Scaling factor - make it external accessible.
-  constexpr static intmax_t SCALE = N;
-  using Counter                   = C; ///< Type used to hold the count.
-  using Tag                       = T; ///< Tag for the scalar.
+  template <intmax_t N, typename C, typename T>
+  inline auto
+  Scalar<N, C, T>::operator=(detail::scalar_round_down_t<N, C, T> v) -> self_type &
+  {
+    _n = v._n;
+    return *this;
+  }
 
-  static_assert(N > 0, "The scaling factor (1st template argument) must be a positive integer");
-  static_assert(std::is_integral<C>::value, "The counter type (2nd template argument) must be an integral type");
+  template <intmax_t N, typename C, typename T>
+  inline auto
+  Scalar<N, C, T>::assign(detail::scalar_round_down_t<N, C, T> v) -> self_type &
+  {
+    _n = v._n;
+    return *this;
+  }
 
-  constexpr Scalar(); ///< Default constructor.
+  template <intmax_t N, typename C, typename T>
+  template <typename I>
+  inline auto
+  Scalar<N, C, T>::operator=(detail::scalar_unit_round_up_t<I> v) -> self_type &
+  {
+    _n = v.template scale<N, C>();
+    return *this;
+  }
 
-  /// Construct to have value that is @a n scaled units.
-  explicit constexpr Scalar(Counter n);
+  template <intmax_t N, typename C, typename T>
+  template <typename I>
+  inline auto
+  Scalar<N, C, T>::assign(detail::scalar_unit_round_up_t<I> v) -> self_type &
+  {
+    _n = v.template scale<N, C>();
+    return *this;
+  }
 
-  /// Copy constructor.
-  constexpr Scalar(self_type const &that); /// Copy constructor.
+  template <intmax_t N, typename C, typename T>
+  template <typename I>
+  inline auto
+  Scalar<N, C, T>::operator=(detail::scalar_unit_round_down_t<I> v) -> self_type &
+  {
+    _n = v.template scale<N, C>();
+    return *this;
+  }
 
-  /// Copy constructor for same scale.
-  template <typename I> constexpr Scalar(Scalar<N, I, T> const &that);
+  template <intmax_t N, typename C, typename T>
+  template <typename I>
+  inline auto
+  Scalar<N, C, T>::assign(detail::scalar_unit_round_down_t<I> v) -> self_type &
+  {
+    _n = v.template scale<N, C>();
+    return *this;
+  }
 
-  /// Direct conversion constructor.
-  /// @note Requires that @c S be an integer multiple of @c SCALE.
-  template <intmax_t S, typename I> constexpr Scalar(Scalar<S, I, T> const &that);
+  template <intmax_t N, typename C, typename T>
+  template <intmax_t S, typename I>
+  auto
+  Scalar<N, C, T>::operator=(Scalar<S, I, T> const &that) -> self_type &
+  {
+    using R = std::ratio<S, N>;
+    static_assert(R::den == 1, "Assignment not permitted - target scale is not an integral multiple of source scale.");
+    _n = that.count() * R::num;
+    return *this;
+  }
+
+  template <intmax_t N, typename C, typename T>
+  template <intmax_t S, typename I>
+  auto
+  Scalar<N, C, T>::assign(Scalar<S, I, T> const &that) -> self_type &
+  {
+    using R = std::ratio<S, N>;
+    static_assert(R::den == 1, "Assignment not permitted - target scale is not an integral multiple of source scale.");
+    _n = that.count() * R::num;
+    return *this;
+  }
+
+  template <intmax_t N, typename C, typename T>
+  constexpr inline intmax_t
+  Scalar<N, C, T>::scale()
+  {
+    return SCALE;
+  }
+
+  /// @endcond Scalar_INTERNAL
+
+  // --- Functions ---
+
+  /** Prepare units @a n to be assigned to a @c Scalar, rounding up as needed.
+   *
+   * @tparam C The type of the value.
+   * @param n The value.
+   * @return An unspecified type suitable to be assigned to a @c Scalar.
+   */
+  template <typename C>
+  constexpr detail::scalar_unit_round_up_t<C>
+  round_up(C n)
+  {
+    return {n};
+  }
+
+  /** Prepare a @c Scalar instance to be assigned to another @c Scalar, rounding up as needed.
+   *
+   * @tparam N @c Scalar scale value.
+   * @tparam C @c Scalar internal storage type.
+   * @tparam T @c Scalar tag.
+   * @param v The @c Scalar value.
+   * @return
+   */
+  template <intmax_t N, typename C, typename T>
+  constexpr detail::scalar_round_up_t<N, C, T>
+  round_up(Scalar<N, C, T> v)
+  {
+    return {v.count()};
+  }
+
+  /** Prepare units @a n to be assigned to a @c Scalar, rounding down as needed.
+   *
+   * @tparam C The type of the value.
+   * @param n The value.
+   * @return An unspecified type suitable to be assigned to a @c Scalar.
+   */
+  template <typename C>
+  constexpr detail::scalar_unit_round_down_t<C>
+  round_down(C n)
+  {
+    return {n};
+  }
+
+  /** Prepare a @c Scalar instance to be assigned to another @c Scalar, rounding down as needed.
+   *
+   * @tparam N @c Scalar scale value.
+   * @tparam C @c Scalar internal storage type.
+   * @tparam T @c Scalar tag.
+   * @param v The @c Scalar value.
+   * @return
+   */
+  template <intmax_t N, typename C, typename T>
+  constexpr detail::scalar_round_down_t<N, C, T>
+  round_down(Scalar<N, C, T> v)
+  {
+    return {v.count()};
+  }
+
+  // --- Compare operators
+  // These optimize nicely because if R::num or R::den is 1 the compiler will drop it.
+
+  template <intmax_t N, typename C1, intmax_t S, typename I, typename T>
+  bool
+  operator<(Scalar<N, C1, T> const &lhs, Scalar<S, I, T> const &rhs)
+  {
+    using R = std::ratio<N, S>;
+    return lhs.count() * R::num < rhs.count() * R::den;
+  }
+
+  template <intmax_t N, typename C1, intmax_t S, typename I, typename T>
+  bool
+  operator==(Scalar<N, C1, T> const &lhs, Scalar<S, I, T> const &rhs)
+  {
+    using R = std::ratio<N, S>;
+    return lhs.count() * R::num == rhs.count() * R::den;
+  }
+
+  template <intmax_t N, typename C1, intmax_t S, typename I, typename T>
+  bool
+  operator<=(Scalar<N, C1, T> const &lhs, Scalar<S, I, T> const &rhs)
+  {
+    using R = std::ratio<N, S>;
+    return lhs.count() * R::num <= rhs.count() * R::den;
+  }
+
+  // Derived compares.
+  template <intmax_t N, typename C, intmax_t S, typename I, typename T>
+  bool
+  operator>(Scalar<N, C, T> const &lhs, Scalar<S, I, T> const &rhs)
+  {
+    return rhs < lhs;
+  }
+
+  template <intmax_t N, typename C, intmax_t S, typename I, typename T>
+  bool
+  operator>=(Scalar<N, C, T> const &lhs, Scalar<S, I, T> const &rhs)
+  {
+    return rhs <= lhs;
+  }
+
+  // Arithmetic operators
+  template <intmax_t N, typename C, typename T>
+  auto
+  Scalar<N, C, T>::operator+=(self_type const &that) -> self_type &
+  {
+    _n += that._n;
+    return *this;
+  }
+
+  template <intmax_t N, typename C, typename T>
+  template <intmax_t S, typename I>
+  auto
+  Scalar<N, C, T>::operator+=(Scalar<S, I, T> const &that) -> self_type &
+  {
+    using R = std::ratio<S, N>;
+    static_assert(R::den == 1, "Addition not permitted - target scale is not an integral multiple of source scale.");
+    _n += that.count() * R::num;
+    return *this;
+  }
 
   /// @cond INTERNAL_DETAIL
-  // Assignment from internal rounding structures.
-  // Conversion constructor.
-  constexpr Scalar(detail::scalar_round_up_t<N, C, T> const &v);
+  template <intmax_t N, typename C, typename T>
+  template <typename I>
+  auto
+  Scalar<N, C, T>::operator+=(detail::scalar_unit_round_up_t<I> v) -> self_type &
+  {
+    _n += v.template scale<N, C>();
+    return *this;
+  }
 
-  // Conversion constructor.
-  constexpr Scalar(detail::scalar_round_down_t<N, C, T> const &that);
+  template <intmax_t N, typename C, typename T>
+  template <typename I>
+  auto
+  Scalar<N, C, T>::operator+=(detail::scalar_unit_round_down_t<I> v) -> self_type &
+  {
+    _n += v.template scale<N, C>();
+    return *this;
+  }
 
-  // Conversion constructor.
-  template <typename I> constexpr Scalar(detail::scalar_unit_round_up_t<I> v);
+  template <intmax_t N, typename C, typename T>
+  auto
+  Scalar<N, C, T>::operator+=(detail::scalar_round_up_t<N, C, T> v) -> self_type &
+  {
+    _n += v._n;
+    return *this;
+  }
 
-  // Conversion constructor.
-  template <typename I> constexpr Scalar(detail::scalar_unit_round_down_t<I> v);
+  template <intmax_t N, typename C, typename T>
+  auto
+  Scalar<N, C, T>::operator+=(detail::scalar_round_down_t<N, C, T> v) -> self_type &
+  {
+    _n += v._n;
+    return *this;
+  }
+
   /// @endcond
 
-  /** Assign value from @a that.
-   *
-   * @tparam S Scale.
-   * @tparam I Integral type.
-   * @param that Source value.
-   * @return @a this.
-   *
-   * @note Requires the scale of @a that be an integer multiple of the scale of @a this. If this
-   * isn't the case then the @c round_up or @c round_down must be used to indicate the rounding
-   * direction.
-   */
-  template <intmax_t S, typename I> self_type &operator=(Scalar<S, I, T> const &that);
+  template <intmax_t N, typename C, intmax_t S, typename I, typename T>
+  auto
+  operator+(Scalar<N, C, T> lhs, Scalar<S, I, T> const &rhs) -> typename std::common_type<Scalar<N, C, T>, Scalar<S, I, T>>::type
+  {
+    return typename std::common_type<Scalar<N, C, T>, Scalar<S, I, T>>::type(lhs) += rhs;
+  }
 
-  /// Self type assignment.
-  self_type &operator=(self_type const &that);
+  /** Add a two scalars of the same type.
+   * @return A scalar of the same type holding the sum.
+   */
+  template <intmax_t N, typename C, typename T>
+  Scalar<N, C, T>
+  operator+(Scalar<N, C, T> const &lhs, Scalar<N, C, T> const &rhs)
+  {
+    return Scalar<N, C, T>(lhs) += rhs;
+  }
 
   /// @cond INTERNAL_DETAIL
-  /** Internal method to assign a unit value to be rounded up to the internal @c SCALE.
-   *
-   * @tparam I The underlying scale type.
-   * @param n The value to be scaled.
-   * @return @a this
-   */
-  template <typename I> self_type &operator=(detail::scalar_unit_round_up_t<I> n);
+  // These handle adding a wrapper and a scalar.
+  template <intmax_t N, typename C, typename T, typename I>
+  Scalar<N, C, T>
+  operator+(detail::scalar_unit_round_up_t<I> lhs, Scalar<N, C, T> const &rhs)
+  {
+    return Scalar<N, C, T>(rhs) += lhs;
+  }
 
-  /** Internal method to assign a unit value to be rounded down to the internal @c SCALE.
-   *
-   * @tparam I The underlying scale type.
-   * @param n The value to be scaled.
-   * @return @a this
-   */
-  template <typename I> self_type &operator=(detail::scalar_unit_round_down_t<I> n);
+  template <intmax_t N, typename C, typename T, typename I>
+  Scalar<N, C, T>
+  operator+(Scalar<N, C, T> const &lhs, detail::scalar_unit_round_up_t<I> rhs)
+  {
+    return Scalar<N, C, T>(lhs) += rhs;
+  }
 
-  /** Internal method to assign a differently scaled SCALAR to be rounded up.
-   *
-   * @param v The embedding of the value to be scaled.
-   * @return @a this
-   *
-   * The template parameters of @a v carry the static information needed to correctly scale
-   * it to the local scale.
-   */
-  self_type &operator=(detail::scalar_round_up_t<N, C, T> v);
+  template <intmax_t N, typename C, typename T, typename I>
+  Scalar<N, C, T>
+  operator+(detail::scalar_unit_round_down_t<I> lhs, Scalar<N, C, T> const &rhs)
+  {
+    return Scalar<N, C, T>(rhs) += lhs;
+  }
 
-  /** Internal method to assign a differently scaled SCALAR to be rounded down.
-   *
-   * @param v The embedding of the value to be scaled.
-   * @return @a this
-   *
-   * The template parameters of @a v carry the static information needed to correctly scale
-   * it to the local scale.
-   */
-  self_type &operator=(detail::scalar_round_down_t<N, C, T> v);
+  template <intmax_t N, typename C, typename T, typename I>
+  Scalar<N, C, T>
+  operator+(Scalar<N, C, T> const &lhs, detail::scalar_unit_round_down_t<I> rhs)
+  {
+    return Scalar<N, C, T>(lhs) += rhs;
+  }
+
+  template <intmax_t N, typename C, typename T>
+  Scalar<N, C, T>
+  operator+(detail::scalar_round_up_t<N, C, T> lhs, Scalar<N, C, T> const &rhs)
+  {
+    return Scalar<N, C, T>(rhs) += lhs._n;
+  }
+
+  template <intmax_t N, typename C, typename T>
+  Scalar<N, C, T>
+  operator+(Scalar<N, C, T> const &lhs, detail::scalar_round_up_t<N, C, T> rhs)
+  {
+    return Scalar<N, C, T>(lhs) += rhs._n;
+  }
+
+  template <intmax_t N, typename C, typename T>
+  Scalar<N, C, T>
+  operator+(detail::scalar_round_down_t<N, C, T> lhs, Scalar<N, C, T> const &rhs)
+  {
+    return Scalar<N, C, T>(rhs) += lhs._n;
+  }
+
+  template <intmax_t N, typename C, typename T>
+  Scalar<N, C, T>
+  operator+(Scalar<N, C, T> const &lhs, detail::scalar_round_down_t<N, C, T> rhs)
+  {
+    return Scalar<N, C, T>(lhs) += rhs._n;
+  }
   /// @endcond
 
-  /** Set the scaled count to @a n.
-   *
-   * @param n The number of scale units.
-   * @return @a this
-   *
-   * This sets the count to be @a n, making the effective value @c SCALE*n. This is frequently useful
-   * for parsing, when the input is also in scaled units (e.g., the number of megabytes to use for
-   * a file).
-   */
-  self_type &assign(Counter n);
+  template <intmax_t N, typename C, typename T>
+  auto
+  Scalar<N, C, T>::operator-=(self_type const &that) -> self_type &
+  {
+    _n -= that._n;
+    return *this;
+  }
 
-  /// The value @a that is scaled appropriately.
-  /// @note Requires the scale of @a that be an integer multiple of the scale of @a this. If this
-  /// isn't the case then the @c round_up or @c round_down must be used to indicate the rounding
-  /// direction.
-  template <intmax_t S, typename I> self_type &assign(Scalar<S, I, T> const &that);
+  template <intmax_t N, typename C, typename T>
+  template <intmax_t S, typename I>
+  auto
+  Scalar<N, C, T>::operator-=(Scalar<S, I, T> const &that) -> self_type &
+  {
+    using R = std::ratio<S, N>;
+    static_assert(R::den == 1, "Subtraction not permitted - target scale is not an integral multiple of source scale.");
+    _n -= that.count() * R::num;
+    return *this;
+  }
 
   /// @cond INTERNAL_DETAIL
-  template <typename I> self_type &assign(detail::scalar_unit_round_up_t<I> n);
 
-  template <typename I> self_type &assign(detail::scalar_unit_round_down_t<I> n);
+  template <intmax_t N, typename C, typename T>
+  template <typename I>
+  auto
+  Scalar<N, C, T>::operator-=(detail::scalar_unit_round_up_t<I> v) -> self_type &
+  {
+    _n -= v.template scale<N, C>();
+    return *this;
+  }
 
-  self_type &assign(detail::scalar_round_up_t<N, C, T> v);
+  template <intmax_t N, typename C, typename T>
+  template <typename I>
+  auto
+  Scalar<N, C, T>::operator-=(detail::scalar_unit_round_down_t<I> v) -> self_type &
+  {
+    _n -= v.template scale<N, C>();
+    return *this;
+  }
 
-  self_type &assign(detail::scalar_round_down_t<N, C, T> v);
+  template <intmax_t N, typename C, typename T>
+  auto
+  Scalar<N, C, T>::operator-=(detail::scalar_round_up_t<N, C, T> v) -> self_type &
+  {
+    _n -= v._n;
+    return *this;
+  }
+
+  template <intmax_t N, typename C, typename T>
+  auto
+  Scalar<N, C, T>::operator-=(detail::scalar_round_down_t<N, C, T> v) -> self_type &
+  {
+    _n -= v._n;
+    return *this;
+  }
+
   /// @endcond
 
-  /// The number of scale units.
-  constexpr Counter count() const;
+  template <intmax_t N, typename C, intmax_t S, typename I, typename T>
+  auto
+  operator-(Scalar<N, C, T> lhs, Scalar<S, I, T> const &rhs) -> typename std::common_type<Scalar<N, C, T>, Scalar<S, I, T>>::type
+  {
+    return typename std::common_type<Scalar<N, C, T>, Scalar<S, I, T>>::type(lhs) -= rhs;
+  }
 
-  /// The scaled value.
-  constexpr Counter value() const;
-
-  /// User conversion to scaled value.
-  constexpr operator Counter() const;
-
-  /// Addition operator.
-  /// The value is scaled from @a that to @a this.
-  /// @note Requires the scale of @a that be an integer multiple of the scale of @a this. If this isn't the case then
-  /// the @c scale_up or @c scale_down casts must be used to indicate the rounding direction.
-  self_type &operator+=(self_type const &that);
-
-  /** Cross scale addition.
-   *
-   * @tparam S Source scale.
-   * @tparam I Source raw type.
-   * @param that Value.
-   * @return @a this
-   *
-   * @a that is scaled as needed to be added to @a this.
+  /** Subtract scalars.
+   * @return A scalar of the same type holding the difference @a lhs - @a rhs
    */
-  template <intmax_t S, typename I> self_type &operator+=(Scalar<S, I, T> const &that);
+  template <intmax_t N, typename C, typename T>
+  Scalar<N, C, T>
+  operator-(Scalar<N, C, T> const &lhs, Scalar<N, C, T> const &rhs)
+  {
+    return Scalar<N, C, T>(lhs) -= rhs;
+  }
 
   /// @cond INTERNAL_DETAIL
-  template <typename I> self_type &operator+=(detail::scalar_unit_round_up_t<I> n);
+  // Handle subtraction for intermediate wrappers.
+  template <intmax_t N, typename C, typename T, typename I>
+  Scalar<N, C, T>
+  operator-(detail::scalar_unit_round_up_t<I> lhs, Scalar<N, C, T> const &rhs)
+  {
+    return Scalar<N, C, T>(lhs.template scale<N, C>()) -= rhs;
+  }
 
-  template <typename I> self_type &operator+=(detail::scalar_unit_round_down_t<I> n);
+  template <intmax_t N, typename C, typename T, typename I>
+  Scalar<N, C, T>
+  operator-(Scalar<N, C, T> const &lhs, detail::scalar_unit_round_up_t<I> rhs)
+  {
+    return Scalar<N, C, T>(lhs) -= rhs;
+  }
 
-  self_type &operator+=(detail::scalar_round_up_t<N, C, T> v);
+  template <intmax_t N, typename C, typename T, typename I>
+  Scalar<N, C, T>
+  operator-(detail::scalar_unit_round_down_t<I> lhs, Scalar<N, C, T> const &rhs)
+  {
+    return Scalar<N, C, T>(lhs.template scale<N, C>()) -= rhs;
+  }
 
-  self_type &operator+=(detail::scalar_round_down_t<N, C, T> v);
+  template <intmax_t N, typename C, typename T, typename I>
+  Scalar<N, C, T>
+  operator-(Scalar<N, C, T> const &lhs, detail::scalar_unit_round_down_t<I> rhs)
+  {
+    return Scalar<N, C, T>(lhs) -= rhs;
+  }
+
+  template <intmax_t N, typename C, typename T>
+  Scalar<N, C, T>
+  operator-(detail::scalar_round_up_t<N, C, T> lhs, Scalar<N, C, T> const &rhs)
+  {
+    return Scalar<N, C, T>(lhs._n) -= rhs;
+  }
+
+  template <intmax_t N, typename C, typename T>
+  Scalar<N, C, T>
+  operator-(Scalar<N, C, T> const &lhs, detail::scalar_round_up_t<N, C, T> rhs)
+  {
+    return Scalar<N, C, T>(lhs) -= rhs._n;
+  }
+
+  template <intmax_t N, typename C, typename T>
+  Scalar<N, C, T>
+  operator-(detail::scalar_round_down_t<N, C, T> lhs, Scalar<N, C, T> const &rhs)
+  {
+    return Scalar<N, C, T>(lhs._n) -= rhs;
+  }
+
+  template <intmax_t N, typename C, typename T>
+  Scalar<N, C, T>
+  operator-(Scalar<N, C, T> const &lhs, detail::scalar_round_down_t<N, C, T> rhs)
+  {
+    return Scalar<N, C, T>(lhs) -= rhs._n;
+  }
   /// @endcond
 
-  /// Increment - increase count by 1.
-  self_type &operator++();
+  template <intmax_t N, typename C, typename T>
+  auto
+  Scalar<N, C, T>::operator++() -> self_type &
+  {
+    ++_n;
+    return *this;
+  }
 
-  /// Increment - increase count by 1.
-  self_type operator++(int);
+  template <intmax_t N, typename C, typename T>
+  auto
+  Scalar<N, C, T>::operator++(int) -> self_type
+  {
+    self_type zret(*this);
+    ++_n;
+    return zret;
+  }
 
-  /// Decrement - decrease count by 1.
-  self_type &operator--();
+  template <intmax_t N, typename C, typename T>
+  auto
+  Scalar<N, C, T>::operator--() -> self_type &
+  {
+    --_n;
+    return *this;
+  }
 
-  /// Decrement - decrease count by 1.
-  self_type operator--(int);
+  template <intmax_t N, typename C, typename T>
+  auto
+  Scalar<N, C, T>::operator--(int) -> self_type
+  {
+    self_type zret(*this);
+    --_n;
+    return zret;
+  }
 
-  /// Increment by @a n.
-  self_type &inc(Counter n);
+  template <intmax_t N, typename C, typename T>
+  auto
+  Scalar<N, C, T>::inc(Counter n) -> self_type &
+  {
+    _n += n;
+    return *this;
+  }
 
-  /// Decrement by @a n.
-  self_type &dec(Counter n);
+  template <intmax_t N, typename C, typename T>
+  auto
+  Scalar<N, C, T>::dec(Counter n) -> self_type &
+  {
+    _n -= n;
+    return *this;
+  }
 
-  /// Subtraction operator.
-  /// The value is scaled from @a that to @a this.
-  /// @note Requires the scale of @a that be an integer multiple of the scale of @a this. If this isn't the case then
-  /// the @c scale_up or @c scale_down casts must be used to indicate the rounding direction.
-  self_type &operator-=(self_type const &that);
+  template <intmax_t N, typename C, typename T>
+  auto
+  Scalar<N, C, T>::operator*=(C n) -> self_type &
+  {
+    _n *= n;
+    return *this;
+  }
 
-  /** Subtraction.
+  template <intmax_t N, typename C, typename T>
+  Scalar<N, C, T>
+  operator*(Scalar<N, C, T> const &lhs, C n)
+  {
+    return Scalar<N, C, T>(lhs) *= n;
+  }
+
+  template <intmax_t N, typename C, typename T>
+  Scalar<N, C, T>
+  operator*(C n, Scalar<N, C, T> const &rhs)
+  {
+    return Scalar<N, C, T>(rhs) *= n;
+  }
+
+  template <intmax_t N, typename C, typename T>
+  Scalar<N, C, T>
+  operator*(Scalar<N, C, T> const &lhs, int n)
+  {
+    return Scalar<N, C, T>(lhs) *= n;
+  }
+
+  template <intmax_t N, typename C, typename T>
+  Scalar<N, C, T>
+  operator*(int n, Scalar<N, C, T> const &rhs)
+  {
+    return Scalar<N, C, T>(rhs) *= n;
+  }
+
+  template <intmax_t N>
+  Scalar<N, int>
+  operator*(Scalar<N, int> const &lhs, int n)
+  {
+    return Scalar<N, int>(lhs) *= n;
+  }
+
+  template <intmax_t N>
+  Scalar<N, int>
+  operator*(int n, Scalar<N, int> const &rhs)
+  {
+    return Scalar<N, int>(rhs) *= n;
+  }
+
+  template <intmax_t N, typename C, typename T>
+  auto
+  Scalar<N, C, T>::operator/=(C n) -> self_type &
+  {
+    _n /= n;
+    return *this;
+  }
+
+  template <intmax_t N, typename C, intmax_t S, typename I, typename T>
+  auto
+  operator/(Scalar<N, C, T> lhs, Scalar<S, I, T> rhs) -> typename std::common_type<C, I>::type
+  {
+    using R = std::ratio<N, S>;
+    return (lhs.count() * R::num) / (rhs.count() * R::den);
+  }
+
+  template <intmax_t N, typename C, typename T, typename I>
+  Scalar<N, C, T>
+  operator/(Scalar<N, C, T> lhs, I n)
+  {
+    static_assert(std::is_integral<I>::value, "Scalar divsion only support integral types.");
+    return Scalar<N, C, T>(lhs) /= n;
+  }
+
+  template <intmax_t N, typename C, typename T>
+  auto
+  Scalar<N, C, T>::operator()(Counter n) const -> self_type
+  {
+    return self_type{n};
+  }
+
+  template <intmax_t N, typename C, typename T>
+  auto
+  Scalar<N, C, T>::plus(Counter n) const -> self_type
+  {
+    return {_n + n};
+  }
+
+  template <intmax_t N, typename C, typename T>
+  auto
+  Scalar<N, C, T>::minus(Counter n) const -> self_type
+  {
+    return {_n - n};
+  }
+
+  /** Explicitly round @c value up to a multiple of @a N.
    *
-   * @tparam S Scale.
-   * @tparam I Raw type.
-   * @param that Value to subtract.
-   * @return @a this
+   * @tparam N [explicit] Rounding unit.
+   * @tparam C [deduced] Base type of @a value.
+   * @param value Value to round.
+   * @return The smallest multiple of @a N that is at least as large as @a value.
    *
-   * The value of @a that is subtracted from the value of @a this.
+   * @code
+   * int r = swoc::round_up<10>(119); // r becomes 120.
+   * int r = swoc::round_up<10>(120); // r becomes 120.
+   * int r = swoc::round_up<10>(121); // r becomes 130.
+   * @endcode
    */
-  template <intmax_t S, typename I> self_type &operator-=(Scalar<S, I, T> const &that);
-
-  /// @cond INTERNAL_DETAIL
-  template <typename I> self_type &operator-=(detail::scalar_unit_round_up_t<I> n);
-
-  template <typename I> self_type &operator-=(detail::scalar_unit_round_down_t<I> n);
-
-  self_type &operator-=(detail::scalar_round_up_t<N, C, T> v);
-
-  self_type &operator-=(detail::scalar_round_down_t<N, C, T> v);
-  /// @endcond
-
-  /// Multiplication - multiple the count by @a n.
-  self_type &operator*=(C n);
-
-  /// Division - divide (rounding down) the count by @a n.
-  self_type &operator/=(C n);
-
-  /// Utility overload of the function operator to create instances at the same scale.
-  self_type operator()(Counter n) const;
-
-  /// Return a value at the same scale with a count increased by @a n.
-  self_type plus(Counter n) const;
-
-  /// Return a value at the same scale with a count decreased by @a n.
-  self_type minus(Counter n) const;
-
-  /// Run time access to the scale (template arg @a N).
-  static constexpr intmax_t scale();
-
-protected:
-  Counter _n; ///< Number of scale units.
-};
-
-/// @cond Scalar_INTERNAL
-// Avoid issues with doxygen matching externally defined methods.
-template <intmax_t N, typename C, typename T> constexpr Scalar<N, C, T>::Scalar() : _n() {}
-
-template <intmax_t N, typename C, typename T> constexpr Scalar<N, C, T>::Scalar(Counter n) : _n(n) {}
-
-template <intmax_t N, typename C, typename T> constexpr Scalar<N, C, T>::Scalar(self_type const &that) : _n(that._n) {}
-
-template <intmax_t N, typename C, typename T>
-template <typename I>
-constexpr Scalar<N, C, T>::Scalar(Scalar<N, I, T> const &that) : _n(static_cast<C>(that.count())) {}
-
-template <intmax_t N, typename C, typename T>
-template <intmax_t S, typename I>
-constexpr Scalar<N, C, T>::Scalar(Scalar<S, I, T> const &that) : _n(std::ratio<S, N>::num * that.count()) {
-  static_assert(std::ratio<S, N>::den == 1,
-                "Construction not permitted - target scale is not an integral multiple of source scale.");
-}
-
-template <intmax_t N, typename C, typename T>
-constexpr Scalar<N, C, T>::Scalar(detail::scalar_round_up_t<N, C, T> const &v) : _n(v._n) {}
-
-template <intmax_t N, typename C, typename T>
-constexpr Scalar<N, C, T>::Scalar(detail::scalar_round_down_t<N, C, T> const &v) : _n(v._n) {}
-
-template <intmax_t N, typename C, typename T>
-template <typename I>
-constexpr Scalar<N, C, T>::Scalar(detail::scalar_unit_round_up_t<I> v) : _n(v.template scale<N, C>()) {}
-
-template <intmax_t N, typename C, typename T>
-template <typename I>
-constexpr Scalar<N, C, T>::Scalar(detail::scalar_unit_round_down_t<I> v) : _n(v.template scale<N, C>()) {}
-
-template <intmax_t N, typename C, typename T>
-constexpr auto
-Scalar<N, C, T>::count() const -> Counter {
-  return _n;
-}
-
-template <intmax_t N, typename C, typename T>
-constexpr C
-Scalar<N, C, T>::value() const {
-  return _n * SCALE;
-}
-
-template <intmax_t N, typename C, typename T> constexpr Scalar<N, C, T>::operator Counter() const {
-  return _n * SCALE;
-}
-
-template <intmax_t N, typename C, typename T>
-inline auto
-Scalar<N, C, T>::assign(Counter n) -> self_type & {
-  _n = n;
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-inline auto
-Scalar<N, C, T>::operator=(self_type const &that) -> self_type & {
-  _n = that._n;
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-inline auto
-Scalar<N, C, T>::operator=(detail::scalar_round_up_t<N, C, T> v) -> self_type &{
-  _n = v._n;
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-inline auto
-Scalar<N, C, T>::assign(detail::scalar_round_up_t<N, C, T> v) -> self_type & {
-  _n = v._n;
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-inline auto
-Scalar<N, C, T>::operator=(detail::scalar_round_down_t<N, C, T> v) -> self_type & {
-  _n = v._n;
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-inline auto
-Scalar<N, C, T>::assign(detail::scalar_round_down_t<N, C, T> v) -> self_type & {
-  _n = v._n;
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-template <typename I>
-inline auto
-Scalar<N, C, T>::operator=(detail::scalar_unit_round_up_t<I> v) -> self_type & {
-  _n = v.template scale<N, C>();
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-template <typename I>
-inline auto
-Scalar<N, C, T>::assign(detail::scalar_unit_round_up_t<I> v) -> self_type & {
-  _n = v.template scale<N, C>();
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-template <typename I>
-inline auto
-Scalar<N, C, T>::operator=(detail::scalar_unit_round_down_t<I> v) -> self_type & {
-  _n = v.template scale<N, C>();
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-template <typename I>
-inline auto
-Scalar<N, C, T>::assign(detail::scalar_unit_round_down_t<I> v) -> self_type & {
-  _n = v.template scale<N, C>();
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-template <intmax_t S, typename I>
-auto
-Scalar<N, C, T>::operator=(Scalar<S, I, T> const &that) -> self_type & {
-  using R = std::ratio<S, N>;
-  static_assert(R::den == 1, "Assignment not permitted - target scale is not an integral multiple of source scale.");
-  _n = that.count() * R::num;
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-template <intmax_t S, typename I>
-auto
-Scalar<N, C, T>::assign(Scalar<S, I, T> const &that) -> self_type & {
-  using R = std::ratio<S, N>;
-  static_assert(R::den == 1, "Assignment not permitted - target scale is not an integral multiple of source scale.");
-  _n = that.count() * R::num;
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-constexpr inline intmax_t
-Scalar<N, C, T>::scale() {
-  return SCALE;
-}
-
-/// @endcond Scalar_INTERNAL
-
-// --- Functions ---
-
-/** Prepare units @a n to be assigned to a @c Scalar, rounding up as needed.
- *
- * @tparam C The type of the value.
- * @param n The value.
- * @return An unspecified type suitable to be assigned to a @c Scalar.
- */
-template <typename C>
-constexpr detail::scalar_unit_round_up_t<C>
-round_up(C n) {
-  return {n};
-}
-
-/** Prepare a @c Scalar instance to be assigned to another @c Scalar, rounding up as needed.
- *
- * @tparam N @c Scalar scale value.
- * @tparam C @c Scalar internal storage type.
- * @tparam T @c Scalar tag.
- * @param v The @c Scalar value.
- * @return
- */
-template <intmax_t N, typename C, typename T>
-constexpr detail::scalar_round_up_t<N, C, T>
-round_up(Scalar<N, C, T> v) {
-  return {v.count()};
-}
-
-/** Prepare units @a n to be assigned to a @c Scalar, rounding down as needed.
- *
- * @tparam C The type of the value.
- * @param n The value.
- * @return An unspecified type suitable to be assigned to a @c Scalar.
- */
-template <typename C>
-constexpr detail::scalar_unit_round_down_t<C>
-round_down(C n) {
-  return {n};
-}
-
-/** Prepare a @c Scalar instance to be assigned to another @c Scalar, rounding down as needed.
- *
- * @tparam N @c Scalar scale value.
- * @tparam C @c Scalar internal storage type.
- * @tparam T @c Scalar tag.
- * @param v The @c Scalar value.
- * @return
- */
-template <intmax_t N, typename C, typename T>
-constexpr detail::scalar_round_down_t<N, C, T>
-round_down(Scalar<N, C, T> v) {
-  return {v.count()};
-}
-
-// --- Compare operators
-// These optimize nicely because if R::num or R::den is 1 the compiler will drop it.
-
-template <intmax_t N, typename C1, intmax_t S, typename I, typename T>
-bool
-operator<(Scalar<N, C1, T> const &lhs, Scalar<S, I, T> const &rhs) {
-  using R = std::ratio<N, S>;
-  return lhs.count() * R::num < rhs.count() * R::den;
-}
-
-template <intmax_t N, typename C1, intmax_t S, typename I, typename T>
-bool
-operator==(Scalar<N, C1, T> const &lhs, Scalar<S, I, T> const &rhs) {
-  using R = std::ratio<N, S>;
-  return lhs.count() * R::num == rhs.count() * R::den;
-}
-
-template <intmax_t N, typename C1, intmax_t S, typename I, typename T>
-bool
-operator<=(Scalar<N, C1, T> const &lhs, Scalar<S, I, T> const &rhs) {
-  using R = std::ratio<N, S>;
-  return lhs.count() * R::num <= rhs.count() * R::den;
-}
-
-// Derived compares.
-template <intmax_t N, typename C, intmax_t S, typename I, typename T>
-bool
-operator>(Scalar<N, C, T> const &lhs, Scalar<S, I, T> const &rhs) {
-  return rhs < lhs;
-}
-
-template <intmax_t N, typename C, intmax_t S, typename I, typename T>
-bool
-operator>=(Scalar<N, C, T> const &lhs, Scalar<S, I, T> const &rhs) {
-  return rhs <= lhs;
-}
-
-// Arithmetic operators
-template <intmax_t N, typename C, typename T>
-auto
-Scalar<N, C, T>::operator+=(self_type const &that) -> self_type & {
-  _n += that._n;
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-template <intmax_t S, typename I>
-auto
-Scalar<N, C, T>::operator+=(Scalar<S, I, T> const &that) -> self_type & {
-  using R = std::ratio<S, N>;
-  static_assert(R::den == 1, "Addition not permitted - target scale is not an integral multiple of source scale.");
-  _n += that.count() * R::num;
-  return *this;
-}
-
-/// @cond INTERNAL_DETAIL
-template <intmax_t N, typename C, typename T>
-template <typename I>
-auto
-Scalar<N, C, T>::operator+=(detail::scalar_unit_round_up_t<I> v) -> self_type & {
-  _n += v.template scale<N, C>();
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-template <typename I>
-auto
-Scalar<N, C, T>::operator+=(detail::scalar_unit_round_down_t<I> v) -> self_type & {
-  _n += v.template scale<N, C>();
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-auto
-Scalar<N, C, T>::operator+=(detail::scalar_round_up_t<N, C, T> v) -> self_type & {
-  _n += v._n;
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-auto
-Scalar<N, C, T>::operator+=(detail::scalar_round_down_t<N, C, T> v) -> self_type & {
-  _n += v._n;
-  return *this;
-}
-
-/// @endcond
-
-template <intmax_t N, typename C, intmax_t S, typename I, typename T>
-auto
-operator+(Scalar<N, C, T> lhs, Scalar<S, I, T> const &rhs) -> typename std::common_type<Scalar<N, C, T>, Scalar<S, I, T>>::type {
-  return typename std::common_type<Scalar<N, C, T>, Scalar<S, I, T>>::type(lhs) += rhs;
-}
-
-/** Add a two scalars of the same type.
- * @return A scalar of the same type holding the sum.
- */
-template <intmax_t N, typename C, typename T>
-Scalar<N, C, T>
-operator+(Scalar<N, C, T> const &lhs, Scalar<N, C, T> const &rhs) {
-  return Scalar<N, C, T>(lhs) += rhs;
-}
-
-/// @cond INTERNAL_DETAIL
-// These handle adding a wrapper and a scalar.
-template <intmax_t N, typename C, typename T, typename I>
-Scalar<N, C, T>
-operator+(detail::scalar_unit_round_up_t<I> lhs, Scalar<N, C, T> const &rhs) {
-  return Scalar<N, C, T>(rhs) += lhs;
-}
-
-template <intmax_t N, typename C, typename T, typename I>
-Scalar<N, C, T>
-operator+(Scalar<N, C, T> const &lhs, detail::scalar_unit_round_up_t<I> rhs) {
-  return Scalar<N, C, T>(lhs) += rhs;
-}
-
-template <intmax_t N, typename C, typename T, typename I>
-Scalar<N, C, T>
-operator+(detail::scalar_unit_round_down_t<I> lhs, Scalar<N, C, T> const &rhs) {
-  return Scalar<N, C, T>(rhs) += lhs;
-}
-
-template <intmax_t N, typename C, typename T, typename I>
-Scalar<N, C, T>
-operator+(Scalar<N, C, T> const &lhs, detail::scalar_unit_round_down_t<I> rhs) {
-  return Scalar<N, C, T>(lhs) += rhs;
-}
-
-template <intmax_t N, typename C, typename T>
-Scalar<N, C, T>
-operator+(detail::scalar_round_up_t<N, C, T> lhs, Scalar<N, C, T> const &rhs) {
-  return Scalar<N, C, T>(rhs) += lhs._n;
-}
-
-template <intmax_t N, typename C, typename T>
-Scalar<N, C, T>
-operator+(Scalar<N, C, T> const &lhs, detail::scalar_round_up_t<N, C, T> rhs) {
-  return Scalar<N, C, T>(lhs) += rhs._n;
-}
-
-template <intmax_t N, typename C, typename T>
-Scalar<N, C, T>
-operator+(detail::scalar_round_down_t<N, C, T> lhs, Scalar<N, C, T> const &rhs) {
-  return Scalar<N, C, T>(rhs) += lhs._n;
-}
-
-template <intmax_t N, typename C, typename T>
-Scalar<N, C, T>
-operator+(Scalar<N, C, T> const &lhs, detail::scalar_round_down_t<N, C, T> rhs) {
-  return Scalar<N, C, T>(lhs) += rhs._n;
-}
-/// @endcond
-
-template <intmax_t N, typename C, typename T>
-auto
-Scalar<N, C, T>::operator-=(self_type const &that) -> self_type & {
-  _n -= that._n;
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-template <intmax_t S, typename I>
-auto
-Scalar<N, C, T>::operator-=(Scalar<S, I, T> const &that) -> self_type & {
-  using R = std::ratio<S, N>;
-  static_assert(R::den == 1, "Subtraction not permitted - target scale is not an integral multiple of source scale.");
-  _n -= that.count() * R::num;
-  return *this;
-}
-
-/// @cond INTERNAL_DETAIL
-
-template <intmax_t N, typename C, typename T>
-template <typename I>
-auto
-Scalar<N, C, T>::operator-=(detail::scalar_unit_round_up_t<I> v) -> self_type & {
-  _n -= v.template scale<N, C>();
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-template <typename I>
-auto
-Scalar<N, C, T>::operator-=(detail::scalar_unit_round_down_t<I> v) -> self_type & {
-  _n -= v.template scale<N, C>();
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-auto
-Scalar<N, C, T>::operator-=(detail::scalar_round_up_t<N, C, T> v) -> self_type & {
-  _n -= v._n;
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-auto
-Scalar<N, C, T>::operator-=(detail::scalar_round_down_t<N, C, T> v) -> self_type & {
-  _n -= v._n;
-  return *this;
-}
-
-/// @endcond
-
-template <intmax_t N, typename C, intmax_t S, typename I, typename T>
-auto
-operator-(Scalar<N, C, T> lhs, Scalar<S, I, T> const &rhs) -> typename std::common_type<Scalar<N, C, T>, Scalar<S, I, T>>::type {
-  return typename std::common_type<Scalar<N, C, T>, Scalar<S, I, T>>::type(lhs) -= rhs;
-}
-
-/** Subtract scalars.
- * @return A scalar of the same type holding the difference @a lhs - @a rhs
- */
-template <intmax_t N, typename C, typename T>
-Scalar<N, C, T>
-operator-(Scalar<N, C, T> const &lhs, Scalar<N, C, T> const &rhs) {
-  return Scalar<N, C, T>(lhs) -= rhs;
-}
-
-/// @cond INTERNAL_DETAIL
-// Handle subtraction for intermediate wrappers.
-template <intmax_t N, typename C, typename T, typename I>
-Scalar<N, C, T>
-operator-(detail::scalar_unit_round_up_t<I> lhs, Scalar<N, C, T> const &rhs) {
-  return Scalar<N, C, T>(lhs.template scale<N, C>()) -= rhs;
-}
-
-template <intmax_t N, typename C, typename T, typename I>
-Scalar<N, C, T>
-operator-(Scalar<N, C, T> const &lhs, detail::scalar_unit_round_up_t<I> rhs) {
-  return Scalar<N, C, T>(lhs) -= rhs;
-}
-
-template <intmax_t N, typename C, typename T, typename I>
-Scalar<N, C, T>
-operator-(detail::scalar_unit_round_down_t<I> lhs, Scalar<N, C, T> const &rhs) {
-  return Scalar<N, C, T>(lhs.template scale<N, C>()) -= rhs;
-}
-
-template <intmax_t N, typename C, typename T, typename I>
-Scalar<N, C, T>
-operator-(Scalar<N, C, T> const &lhs, detail::scalar_unit_round_down_t<I> rhs) {
-  return Scalar<N, C, T>(lhs) -= rhs;
-}
-
-template <intmax_t N, typename C, typename T>
-Scalar<N, C, T>
-operator-(detail::scalar_round_up_t<N, C, T> lhs, Scalar<N, C, T> const &rhs) {
-  return Scalar<N, C, T>(lhs._n) -= rhs;
-}
-
-template <intmax_t N, typename C, typename T>
-Scalar<N, C, T>
-operator-(Scalar<N, C, T> const &lhs, detail::scalar_round_up_t<N, C, T> rhs) {
-  return Scalar<N, C, T>(lhs) -= rhs._n;
-}
-
-template <intmax_t N, typename C, typename T>
-Scalar<N, C, T>
-operator-(detail::scalar_round_down_t<N, C, T> lhs, Scalar<N, C, T> const &rhs) {
-  return Scalar<N, C, T>(lhs._n) -= rhs;
-}
-
-template <intmax_t N, typename C, typename T>
-Scalar<N, C, T>
-operator-(Scalar<N, C, T> const &lhs, detail::scalar_round_down_t<N, C, T> rhs) {
-  return Scalar<N, C, T>(lhs) -= rhs._n;
-}
-/// @endcond
-
-template <intmax_t N, typename C, typename T>
-auto
-Scalar<N, C, T>::operator++() -> self_type & {
-  ++_n;
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-auto
-Scalar<N, C, T>::operator++(int) -> self_type {
-  self_type zret(*this);
-  ++_n;
-  return zret;
-}
-
-template <intmax_t N, typename C, typename T>
-auto
-Scalar<N, C, T>::operator--() -> self_type & {
-  --_n;
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-auto
-Scalar<N, C, T>::operator--(int) -> self_type {
-  self_type zret(*this);
-  --_n;
-  return zret;
-}
-
-template <intmax_t N, typename C, typename T>
-auto
-Scalar<N, C, T>::inc(Counter n) -> self_type & {
-  _n += n;
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-auto
-Scalar<N, C, T>::dec(Counter n) -> self_type & {
-  _n -= n;
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-auto
-Scalar<N, C, T>::operator*=(C n) -> self_type & {
-  _n *= n;
-  return *this;
-}
-
-template <intmax_t N, typename C, typename T>
-Scalar<N, C, T>
-operator*(Scalar<N, C, T> const &lhs, C n) {
-  return Scalar<N, C, T>(lhs) *= n;
-}
-
-template <intmax_t N, typename C, typename T>
-Scalar<N, C, T>
-operator*(C n, Scalar<N, C, T> const &rhs) {
-  return Scalar<N, C, T>(rhs) *= n;
-}
-
-template <intmax_t N, typename C, typename T>
-Scalar<N, C, T>
-operator*(Scalar<N, C, T> const &lhs, int n) {
-  return Scalar<N, C, T>(lhs) *= n;
-}
-
-template <intmax_t N, typename C, typename T>
-Scalar<N, C, T>
-operator*(int n, Scalar<N, C, T> const &rhs) {
-  return Scalar<N, C, T>(rhs) *= n;
-}
-
-template <intmax_t N>
-Scalar<N, int>
-operator*(Scalar<N, int> const &lhs, int n) {
-  return Scalar<N, int>(lhs) *= n;
-}
-
-template <intmax_t N>
-Scalar<N, int>
-operator*(int n, Scalar<N, int> const &rhs) {
-  return Scalar<N, int>(rhs) *= n;
-}
-
-template <intmax_t N, typename C, typename T>
-auto
-Scalar<N, C, T>::operator/=(C n) -> self_type & {
-  _n /= n;
-  return *this;
-}
-
-template <intmax_t N, typename C, intmax_t S, typename I, typename T>
-auto
-operator/(Scalar<N, C, T> lhs, Scalar<S, I, T> rhs) -> typename std::common_type<C, I>::type {
-  using R = std::ratio<N, S>;
-  return (lhs.count() * R::num) / (rhs.count() * R::den);
-}
-
-template <intmax_t N, typename C, typename T, typename I>
-Scalar<N, C, T>
-operator/(Scalar<N, C, T> lhs, I n) {
-  static_assert(std::is_integral<I>::value, "Scalar divsion only support integral types.");
-  return Scalar<N, C, T>(lhs) /= n;
-}
-
-template <intmax_t N, typename C, typename T>
-auto
-Scalar<N, C, T>::operator()(Counter n) const -> self_type {
-  return self_type{n};
-}
-
-template <intmax_t N, typename C, typename T>
-auto
-Scalar<N, C, T>::plus(Counter n) const -> self_type {
-  return {_n + n};
-}
-
-template <intmax_t N, typename C, typename T>
-auto
-Scalar<N, C, T>::minus(Counter n) const -> self_type {
-  return {_n - n};
-}
-
-/** Explicitly round @c value up to a multiple of @a N.
- *
- * @tparam N [explicit] Rounding unit.
- * @tparam C [deduced] Base type of @a value.
- * @param value Value to round.
- * @return The smallest multiple of @a N that is at least as large as @a value.
- *
- * @code
- * int r = swoc::round_up<10>(119); // r becomes 120.
- * int r = swoc::round_up<10>(120); // r becomes 120.
- * int r = swoc::round_up<10>(121); // r becomes 130.
- * @endcode
- */
-template <intmax_t N, typename C>
-C
-round_up(C value) {
-  return N * detail::scale_conversion_round_up<N, 1>(value);
-}
-
-/** Explicitly round @a value to a multiple of @a N.
- *
- * @tparam N [explicit] Rounding unit.
- * @tparam C [deduced] Base type of @a value.
- * @param value Value to round.
- * @return The largest multiple of @a N that is not greater than @a value.
- *
- * @code
- * int r = swoc::round_down<10>(119); // r becomes 110.
- * int r = swoc::round_down<10>(120); // r becomes 120.
- * int r = swoc::round_down<10>(121); // r becomes 120.
- * @endcode
- */
-template <intmax_t N, typename C>
-C
-round_down(C value) {
-  return N * detail::scale_conversion_round_down<N, 1>(value);
-}
-
-namespace detail {
-template <typename T>
-auto
-tag_label(std::ostream &, const meta::CaseTag<0> &) -> void {}
-
-template <typename T>
-auto
-tag_label(std::ostream &w, const meta::CaseTag<1> &) -> decltype(T::label, meta::TypeFunc<void>()) {
-  w << T::label;
-}
-
-template <typename T>
-inline std::ostream &
-tag_label(std::ostream &w) {
-  tag_label<T>(w, meta::CaseArg);
-  return w;
-}
-} // namespace detail
-}} // namespace swoc::SWOC_VERSION_NS
-
-namespace std {
+  template <intmax_t N, typename C>
+  C
+  round_up(C value)
+  {
+    return N * detail::scale_conversion_round_up<N, 1>(value);
+  }
+
+  /** Explicitly round @a value to a multiple of @a N.
+   *
+   * @tparam N [explicit] Rounding unit.
+   * @tparam C [deduced] Base type of @a value.
+   * @param value Value to round.
+   * @return The largest multiple of @a N that is not greater than @a value.
+   *
+   * @code
+   * int r = swoc::round_down<10>(119); // r becomes 110.
+   * int r = swoc::round_down<10>(120); // r becomes 120.
+   * int r = swoc::round_down<10>(121); // r becomes 120.
+   * @endcode
+   */
+  template <intmax_t N, typename C>
+  C
+  round_down(C value)
+  {
+    return N * detail::scale_conversion_round_down<N, 1>(value);
+  }
+
+  namespace detail
+  {
+    template <typename T>
+    auto
+    tag_label(std::ostream &, const meta::CaseTag<0> &) -> void
+    {
+    }
+
+    template <typename T>
+    auto
+    tag_label(std::ostream &w, const meta::CaseTag<1> &) -> decltype(T::label, meta::TypeFunc<void>())
+    {
+      w << T::label;
+    }
+
+    template <typename T>
+    inline std::ostream &
+    tag_label(std::ostream &w)
+    {
+      tag_label<T>(w, meta::CaseArg);
+      return w;
+    }
+  } // namespace detail
+} // namespace SWOC_VERSION_NS
+} // namespace swoc
+
+namespace std
+{
 /// Compute common type of two scalars.
 /// This is in `std` to overload the base definition. This yields a type that has the common type of
 /// the counter type and a scale that is the GCF of the input scales.
@@ -1063,7 +1175,8 @@ struct common_type<swoc::Scalar<N, C, T>, swoc::Scalar<S, I, T>> {
 
 template <intmax_t N, typename C, typename T>
 ostream &
-operator<<(ostream &s, swoc::Scalar<N, C, T> const &x) {
+operator<<(ostream &s, swoc::Scalar<N, C, T> const &x)
+{
   s << x.value();
   return swoc::detail::tag_label<T>(s);
 }

--- a/code/include/swoc/TextView.h
+++ b/code/include/swoc/TextView.h
@@ -28,1999 +28,2147 @@
 // assign, the error message is too vague for me to be sure - it doesn't even provide the location of
 // the method invocation. I've been using g++ 12 for development and I don't see that error.
 #if __GNUC__ == 11
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
 
-class TextView;
+  class TextView;
 
-/** A read only view of a contiguous piece of memory.
+  /** A read only view of a contiguous piece of memory.
 
-    A @c TextView does not own the memory to which it refers, it is simply a view of part of some
-    (presumably) larger memory object. The purpose is to allow working in a read only way a specific
-    part of the memory. A classic example for ATS is working with HTTP header fields and values
-    which need to be accessed independently but preferably without copying. A @c TextView supports
-    this style.
+      A @c TextView does not own the memory to which it refers, it is simply a view of part of some
+      (presumably) larger memory object. The purpose is to allow working in a read only way a specific
+      part of the memory. A classic example for ATS is working with HTTP header fields and values
+      which need to be accessed independently but preferably without copying. A @c TextView supports
+      this style.
 
-    @note To simplify the interface there is no constructor taking only a character pointer.
-    Constructors require either a literal string or an explicit length. This avoid ambiguities which
-    are much more annoying that explicitly calling @c strlen on a character pointer.
+      @note To simplify the interface there is no constructor taking only a character pointer.
+      Constructors require either a literal string or an explicit length. This avoid ambiguities which
+      are much more annoying that explicitly calling @c strlen on a character pointer.
 
-    @internal For construction, assignment operator, and @c assign method, there are a lot of overloads
-    because users would like to be able to use the same sort of arguments for all of these. This includes
-    - self / parent type
-    - @c std::string
-    - literal string
-    - C-string pointer
-    - pointer and count
-    - begin/end style pointers.
-    - character containers that have the STL standard @c size and @c data methods.
- */
-class TextView : public std::string_view {
-  using self_type  = TextView;         ///< Self reference type.
-  using super_type = std::string_view; ///< Parent type.
-
-public:
-  /// Default constructor (empty buffer).
-  constexpr TextView() noexcept = default;
-
-  /// Construct from a @c std::string_view or @c TextView
-  /// @note This provides an user defined conversion from @c std::string_view to @c TextView. The
-  /// reverse conversion is implicit in @c TextView being a subclass of @c std::string_view.
-  constexpr TextView(super_type const &that) noexcept;
-
-  /** Construct from pointer and size.
-   *
-   * @param ptr Pointer to first character.
-   * @param n Number of characters.
-   *
-   * If @a n is @c npos then @c ptr is presumed to be a C string and checked for length. If @c ptr
-   * is @c nullptr the length is 0. Otherwise @c strlen is used to calculate the length.
+      @internal For construction, assignment operator, and @c assign method, there are a lot of overloads
+      because users would like to be able to use the same sort of arguments for all of these. This includes
+      - self / parent type
+      - @c std::string
+      - literal string
+      - C-string pointer
+      - pointer and count
+      - begin/end style pointers.
+      - character containers that have the STL standard @c size and @c data methods.
    */
-  constexpr TextView(char const *ptr, size_t n) noexcept;
+  class TextView : public std::string_view
+  {
+    using self_type  = TextView;         ///< Self reference type.
+    using super_type = std::string_view; ///< Parent type.
 
-  /** Construct from pointer and size.
-   *
-   * @param ptr Pointer to first character.
-   * @param n Number of characters.
-   */
-  constexpr TextView(char const *ptr, unsigned n) noexcept;
+  public:
+    /// Default constructor (empty buffer).
+    constexpr TextView() noexcept = default;
 
-  /** Construct from pointer and size.
-   *
-   * @param ptr Pointer to first character.
-   * @param n Number of characters.
-   *
-   * If @a n is negative then @c ptr is presumed to be a C string and checked for length. If @c ptr
-   * is @c nullptr the length is 0. Otherwise @c strlen is used to calculate the length.
-   */
-  constexpr TextView(char const *ptr, ssize_t n) noexcept;
+    /// Construct from a @c std::string_view or @c TextView
+    /// @note This provides an user defined conversion from @c std::string_view to @c TextView. The
+    /// reverse conversion is implicit in @c TextView being a subclass of @c std::string_view.
+    constexpr TextView(super_type const &that) noexcept;
 
-  /** Construct from pointer and size.
-   *
-   * @param ptr Pointer to first character.
-   * @param n Number of characters.
-   *
-   * If @a n is negative then @c ptr is presumed to be a C string and checked for length. If @c ptr
-   * is @c nullptr the length is 0. Otherwise @c strlen is used to calculate the length.
-   */
-  constexpr TextView(char const *ptr, int n) noexcept;
+    /** Construct from pointer and size.
+     *
+     * @param ptr Pointer to first character.
+     * @param n Number of characters.
+     *
+     * If @a n is @c npos then @c ptr is presumed to be a C string and checked for length. If @c ptr
+     * is @c nullptr the length is 0. Otherwise @c strlen is used to calculate the length.
+     */
+    constexpr TextView(char const *ptr, size_t n) noexcept;
 
-  /** Construct from a half open range [first, last).
-   *
-   * @param first Start of half open range.
-   * @param last End of half open range.
-   *
-   * The character at @a first will be in the view, but the character at @a last will not.
-   *
-   * @note @c explicit to avoid interpreting a string initializer list as a view.
-   *
-   * @internal For the love of Turing, WHY DID YOU DO THIS?
-   *
-   * Well, estemed reader, because the C++ standard doesn't have a better way to support overloads
-   * that handle character pointers and literal strings differently. If the parameters were simply
-   * <tt>(char const *, char const *)</tt> then a cosntruct like <tt>{ "really", "broken" }</tt> can
-   * be interpreted as a @c TextView because the elements implicitly convert to <tt>char const
-   * *</tt>. This makes no sense and creates some @b very annoying ambiguities for lists of strings
-   * if there are exactly two in the list. See @c Lexicon for an example.
-   *
-   * The template itself does the check to make sure it's a character @b pointer and not an array. Arrays
-   * are handled by a different constructor so this only disables constructing from two char arrays
-   * which IMHO makes no sense and should be forbidden.
-   */
-  template < typename T > explicit TextView(T first, std::enable_if_t<!std::is_array_v<T> && std::is_pointer_v<T> && std::is_convertible_v<T, char const *>, T> last) noexcept : super_type(first, last - first) {}
+    /** Construct from pointer and size.
+     *
+     * @param ptr Pointer to first character.
+     * @param n Number of characters.
+     */
+    constexpr TextView(char const *ptr, unsigned n) noexcept;
 
-  /** Construct from any character container following STL standards.
-   *
-   * @tparam C Container type.
-   * @param c container
-   *
-   * The container type must have the methods @c data and @c size which must return values convertible
-   * to @c char @c const @c * and @c size_t respectively.
-   */
-  template < typename C
-    , typename = std::enable_if_t<
-        std::is_convertible_v<decltype(std::declval<C>().data()), char const*> &&
-        std::is_convertible_v<decltype(std::declval<C>().size()), size_t>
-        , void
-      >
-  > constexpr TextView(C const& c);
+    /** Construct from pointer and size.
+     *
+     * @param ptr Pointer to first character.
+     * @param n Number of characters.
+     *
+     * If @a n is negative then @c ptr is presumed to be a C string and checked for length. If @c ptr
+     * is @c nullptr the length is 0. Otherwise @c strlen is used to calculate the length.
+     */
+    constexpr TextView(char const *ptr, ssize_t n) noexcept;
 
-  /** Construct from literal string or array.
+    /** Construct from pointer and size.
+     *
+     * @param ptr Pointer to first character.
+     * @param n Number of characters.
+     *
+     * If @a n is negative then @c ptr is presumed to be a C string and checked for length. If @c ptr
+     * is @c nullptr the length is 0. Otherwise @c strlen is used to calculate the length.
+     */
+    constexpr TextView(char const *ptr, int n) noexcept;
 
-      All elements of the array are included in the view unless the last element is nul, in which case it is elided.
-      If this is inappropriate then a constructor with an explicit size should be used.
+    /** Construct from a half open range [first, last).
+     *
+     * @param first Start of half open range.
+     * @param last End of half open range.
+     *
+     * The character at @a first will be in the view, but the character at @a last will not.
+     *
+     * @note @c explicit to avoid interpreting a string initializer list as a view.
+     *
+     * @internal For the love of Turing, WHY DID YOU DO THIS?
+     *
+     * Well, estemed reader, because the C++ standard doesn't have a better way to support overloads
+     * that handle character pointers and literal strings differently. If the parameters were simply
+     * <tt>(char const *, char const *)</tt> then a cosntruct like <tt>{ "really", "broken" }</tt> can
+     * be interpreted as a @c TextView because the elements implicitly convert to <tt>char const
+     * *</tt>. This makes no sense and creates some @b very annoying ambiguities for lists of strings
+     * if there are exactly two in the list. See @c Lexicon for an example.
+     *
+     * The template itself does the check to make sure it's a character @b pointer and not an array. Arrays
+     * are handled by a different constructor so this only disables constructing from two char arrays
+     * which IMHO makes no sense and should be forbidden.
+     */
+    template <typename T>
+    explicit TextView(
+      T first,
+      std::enable_if_t<!std::is_array_v<T> && std::is_pointer_v<T> && std::is_convertible_v<T, char const *>, T> last) noexcept
+      : super_type(first, last - first)
+    {
+    }
 
-      @code
-        TextView a("A literal string");
-      @endcode
-      The last character in @a a will be 'g'.
-   */
-  template <size_t N> constexpr TextView(const char (&s)[N]) noexcept;
+    /** Construct from any character container following STL standards.
+     *
+     * @tparam C Container type.
+     * @param c container
+     *
+     * The container type must have the methods @c data and @c size which must return values convertible
+     * to @c char @c const @c * and @c size_t respectively.
+     */
+    template <typename C, typename = std::enable_if_t<std::is_convertible_v<decltype(std::declval<C>().data()), char const *> &&
+                                                        std::is_convertible_v<decltype(std::declval<C>().size()), size_t>,
+                                                      void>>
+    constexpr TextView(C const &c);
 
-  /** Construct from a C-string.
-   *
-   * @param src A pointer to a C-string.
-   *
-   * The view does not include the terminating nul.
-   *
-   * @internal @a src a reference because it is otherwise ambiguous with the literal constructor.
-   */
-  TextView(char * & src) : super_type(src, src ? strlen(src) : 0) {}
+    /** Construct from literal string or array.
 
-  /** Construct from a const C-string.
-   *
-   * @param src Pointer to a const C-string.
-   *
-   * The view does not include the terminating nul.
-   *
-   * @internal @a src a reference because it is otherwise ambiguous with the literal constructor.
-   */
-  TextView(char const * & src) : super_type(src, src ? strlen(src) : 0) {}
+        All elements of the array are included in the view unless the last element is nul, in which case it is elided.
+        If this is inappropriate then a constructor with an explicit size should be used.
 
-  /** Construct from nullptr.
-      This implicitly makes the length 0.
+        @code
+          TextView a("A literal string");
+        @endcode
+        The last character in @a a will be 'g'.
+     */
+    template <size_t N> constexpr TextView(const char (&s)[N]) noexcept;
+
+    /** Construct from a C-string.
+     *
+     * @param src A pointer to a C-string.
+     *
+     * The view does not include the terminating nul.
+     *
+     * @internal @a src a reference because it is otherwise ambiguous with the literal constructor.
+     */
+    TextView(char *&src) : super_type(src, src ? strlen(src) : 0) {}
+
+    /** Construct from a const C-string.
+     *
+     * @param src Pointer to a const C-string.
+     *
+     * The view does not include the terminating nul.
+     *
+     * @internal @a src a reference because it is otherwise ambiguous with the literal constructor.
+     */
+    TextView(char const *&src) : super_type(src, src ? strlen(src) : 0) {}
+
+    /** Construct from nullptr.
+        This implicitly makes the length 0.
+    */
+    constexpr TextView(std::nullptr_t) noexcept;
+
+    /// Construct from @c std::string, referencing the entire string contents.
+    /// @internal This can't be @c constexpr because this uses methods in @c std::string that may
+    /// not be @c constexpr.
+    TextView(std::string const &str) noexcept;
+
+    /// Assign a super class instance, @c std::string_view  to @a this.
+    self_type &operator=(super_type const &that);
+
+    /// Assign a constant array to @a this.
+    /// @note If the last character of @a s is a nul byte, it is not included in the view.
+    template <size_t N> self_type &operator=(const char (&s)[N]);
+
+    /// Assign from C-string @a s.
+    self_type &operator=(char *&s);
+    /// Assign from C-string @a s.
+    self_type &operator=(char const *&s);
+
+    /// Assign from a @c std::string.
+    self_type &operator=(const std::string &s);
+
+    /** Assign a view of the @a c_str
+     *
+     * @param c_str Pointer to C string.
+     * @return @a this
+     *
+     * @note @c c_str must be a null terminated string. The null byte is not included in the view.
+     */
+    self_type &assign(char *&c_str);
+
+    /** Assign a view of the @a c_str
+     *
+     * @param c_str Pointer to C string.
+     * @return @a this
+     *
+     * @note @c c_str must be a null terminated string. The null byte is not included in the view.
+     */
+    self_type &assign(char const *&c_str);
+
+    /** Assign from a pointer and size.
+     *
+     * @param ptr Pointer to first character of the view.
+     * @param n Length of the view.
+     * @return @a this
+     *
+     * if @a n is @a npos then @c strlen is used determine the size of the view.
+     */
+    self_type &assign(char const *ptr, size_t n);
+
+    /** Assign the half open view [ @a b , @a e ) to @a this
+     *
+     * @param b First character in the view.
+     * @param e One character after the last character in the view.
+     * @return @a this
+     */
+    self_type &assign(char const *b, char const *e);
+
+    /// Explicitly set the view from a @c std::string
+    self_type &assign(std::string const &s);
+
+    /** Assign literal string or array.
+
+     * All elements of the array are included in the view unless the last element is nul, in which case it is elided.
+     * If this is inappropriate then a constructor with an explicit size should be used.
+     *
+     * @code
+     *   tv.assign("A literal string");
+     * @endcode
+     * The last character in @a tv will be 'g'.
+    */
+    template <size_t N> self_type &assign(const char (&s)[N]) noexcept;
+
+    /** Assign from any character container following STL standards.
+     *
+     * @tparam C Container type.
+     * @param c container
+     *
+     * The container type must have the methods @c data and @c size which must return values convertible
+     * to @c char @c const @c * and @c size_t respectively.
+     */
+    template <typename C, typename = std::enable_if_t<std::is_convertible_v<decltype(std::declval<C>().data()), char const *> &&
+                                                        std::is_convertible_v<decltype(std::declval<C>().size()), size_t>,
+                                                      void>>
+    constexpr self_type &
+    assign(C const &c)
+    {
+      return this->assign(c.data(), c.size());
+    }
+
+    /** Dereference operator.
+
+        @note This allows the view to be used as if it were a character iterator to a null terminated
+        string which is handy for several other STL interfaces.
+
+        @return The first byte in the view, or a nul character if the view is empty.
+    */
+    /// @return The first byte in the view.
+    constexpr char operator*() const;
+
+    /** Discard the first byte of the view.
+     *
+     *  @return @a this.
+     */
+    self_type &operator++();
+
+    /** Discard the first byte of the view.
+     *
+     * @return The view before discarding the byte.
+     */
+    self_type operator++(int);
+
+    /** Discard the first @a n bytes of the view.
+     *
+     *  Equivalent to @c remove_prefix(n).
+     *  @return @a this
+     */
+    self_type &operator+=(size_t n);
+
+    /// Check for empty view.
+    /// @return @c true if the view has a nullptr @b or zero size.
+    constexpr bool operator!() const noexcept;
+
+    /// Check for non-empty view.
+    /// @return @c true if the view refers to a non-empty range of bytes.
+    explicit constexpr operator bool() const noexcept;
+
+    /// Clear the view (become an empty view).
+    self_type &clear();
+
+    /// Get the offset of the first character for which @a pred is @c true.
+    template <typename F> size_t find_if(F const &pred) const;
+    /// Get the offset of the last character for which @a pred is @c true.
+    template <typename F> size_t rfind_if(F const &pred) const;
+
+    /** Remove bytes that match @a c from the start of the view.
+     *
+     * @return @a this
+     */
+    self_type &ltrim(char c);
+
+    /** Remove bytes from the start of the view that are in @a delimiters.
+     *
+     * @return @a this
+     */
+    self_type &ltrim(std::string_view const &delimiters);
+
+    /** Remove bytes from the start of the view that are in @a delimiters.
+     *
+     * @internal This is needed to avoid collisions with the templated predicate style.
+     *
+     * @return @c *this
+     */
+    self_type &ltrim(const char *delimiters);
+
+    /** Remove bytes from the start of the view for which @a pred is @c true.
+        @a pred must be a functor taking a @c char argument and returning @c bool.
+        @return @c *this
+    */
+    template <typename F> self_type &ltrim_if(F const &pred);
+
+    /** Remove bytes that match @a c from the end of the view.
+     *
+     * @return @a this
+     */
+    self_type &rtrim(char c);
+
+    /** Remove bytes from the end of the view that are in @a delimiters.
+     * @return @a this
+     */
+    self_type &rtrim(std::string_view const &delimiters);
+
+    /** Remove bytes from the end of the view for which @a pred is @c true.
+     *
+     * @a pred must be a functor taking a @c char argument and returning @c bool.
+     *
+     * @return @c *this
+     */
+    template <typename F> self_type &rtrim_if(F const &pred);
+
+    /** Remove bytes that match @a c from the start and end of this view.
+     *
+     * @return @a this
+     */
+    self_type &trim(char c);
+
+    /** Remove bytes from the start and end of the view that are in @a delimiters.
+     * @return @a this
+     */
+    self_type &trim(std::string_view const &delimiters);
+
+    /** Remove bytes from the start and end of the view that are in @a delimiters.
+        @internal This is needed to avoid collisions with the templated predicate style.
+        @return @c *this
+    */
+    self_type &trim(const char *delimiters);
+
+    /** Remove bytes from the start and end of the view for which @a pred is @c true.
+        @a pred must be a functor taking a @c char argument and returning @c bool.
+        @return @c *this
+    */
+    template <typename F> self_type &trim_if(F const &pred);
+
+    /** Get a view of the first @a n bytes.
+     *
+     * @param n Number of chars in the prefix.
+     * @return A view of the first @a n characters in @a this, bounded by the size of @a this.
+     */
+    constexpr self_type prefix(size_t n) const noexcept;
+
+    /** Get a view of a prefix bounded by @a c.
+     *
+     * @param c Delimiter character.
+     * @return A view of the prefix bounded by @a c, or all of @a this if @a c is not found.
+     * @note The character @a c is not included in the returned view.
+     */
+    self_type prefix_at(char c) const;
+
+    /** Get a view of a prefix bounded by a character in @a delimiters.
+     *
+     * @param delimiters A set of characters.
+     *
+     * @return A view of the prefix bounded by any character in @a delimiters, or empty if none are
+     * found.
+     *
+     * @note The delimiter character is not included in the returned view.
+     */
+    self_type prefix_at(std::string_view const &delimiters) const;
+
+    /** Get a view of a prefix bounded by a character predicate @a pred.
+     *
+     * @a pred must be a functor which takes a @c char argument and returns @c bool. Each character in
+     * @a this is tested by @a pred and the prefix is delimited by the first character for which @a
+     * pred is @c true.
+     *
+     * @param pred A character predicate.
+     *
+     * @return A view of the prefix bounded by @a pred or empty if @a pred is not @c true for any
+     * characer.
+     *
+     * @note The deliminting character is not included in the returned view.
+     */
+    template <typename F> self_type prefix_if(F const &pred) const;
+
+    /** Remove bytes from the start of the view.
+     *
+     * @param n Number of bytes to remove.
+     * @return @a this.
+     */
+    self_type &remove_prefix(size_t n);
+
+    /** Remove bytes from the end of the view.
+     *
+     * @param n Number of bytes to remove.
+     * @return @a this.
+     */
+    self_type &remove_suffix(size_t n);
+
+    /** Remove the leading characters of @a this up to and including @a c.
+     *
+     * @param c Delimiter character.
+     * @return @a this.
+     * @note The first occurrence of character @a c is removed along with all preceding characters, or
+     * the view is cleared if @a c is not found.
+     */
+    self_type &remove_prefix_at(char c);
+
+    /** Remove the leading characters of @a this up to and including the first character matching @a delimiters.
+     *
+     * @param delimiters Characters to match.
+     * @return @a this.
+     * @note The first occurrence of any character in @a delimiters is removed along with all preceding
+     * characters, or the view is cleared if none are found.
+     */
+    self_type &remove_prefix_at(std::string_view const &delimiters);
+
+    /** Remove the leading characters up to and including the character selected by @a pred.
+     *
+     * @tparam F Predicate function type.
+     * @param pred The predicate instance.
+     * @return @a this.
+     *
+     * Characters are removed until @a pred returns @c true. The matching character is also removed.
+     */
+    template <typename F> self_type &remove_prefix_if(F const &pred);
+
+    /** Remove and return a prefix of size @a n.
+     *
+     * @param n Size of the prefix.
+     * @return The first @a n bytes of @a this if @a n is in @a this, otherwise an empty view.
+     *
+     * The prefix is removed and returned if the requested prefix is no larger than @a this,
+     * otherwise @a this is not modified.
+     *
+     * @note The character at offset @a n is discarded if @a this is modified.
+     *
+     * @see @c take_prefix
+     */
+    self_type split_prefix(size_t n);
+
+    /** Remove and return a prefix bounded by the first occurrence of @a c.
+     *
+     * @param c The character to match.
+     * @return The prefix bounded by @a c if @a c is found, an empty view if not.
+     *
+     * The prefix is removed and returned if @a c is found, otherwise @a this is not modified.
+     *
+     * @note The delimiter character is discarded if @a this is modified.
+     *
+     * @see @c take_prefix
+     */
+    self_type split_prefix_at(char c);
+
+    /** Remove and return a prefix bounded by the first occurrence of any of @a delimiters.
+     *
+     * @param delimiters The characters to match.
+     * @return The prefix bounded by a delimiter if one is found, otherwise an empty view.
+     *
+     * The prefix is removed and returned if a @a delimiter is found, otherwise @a this is not modified.
+     *
+     * @note The matching character is discarded if @a this is modified.
+     *
+     * @see @c take_prefix_at
+     */
+    self_type split_prefix_at(std::string_view const &delimiters);
+
+    /** Remove and return a prefix bounded by the first character that satisfies @a pred.
+     *
+     * @tparam F Predicate functor type.
+     * @param pred A function taking @c char and returning @c bool.
+     * @return The prefix bounded by the first character satisfying @a pred.
+     *
+     * The prefix is removed and returned if a character satisfying @a pred is found, otherwise
+     * @a this is not modified.
+     *
+     * @note The matching character is discarded if @a this is modified.
+     *
+     * @see @c take_prefix_if
+     */
+    template <typename F> self_type split_prefix_if(F const &pred);
+
+    /** Remove and return the first @a n characters.
+     *
+     * @param n Size of the return prefix.
+     * @return The first @a n bytes of @a this if @a n is in @a this, otherwise all of @a this.
+     *
+     * The prefix is removed and returned if the requested prefix is no larger than @a this,
+     * otherwise all of @a this is removed and returned.
+     *
+     * @note The character at offset @a n is discarded if @a n is within the bounds of @a this.
+     *
+     * @see @c split_prefix
+     */
+    self_type take_prefix(size_t n);
+
+    /** Remove and return a prefix bounded by the first occurrence of @a c.
+     *
+     * @param c The character to match.
+     * @return The prefix bounded by @a c if @a c is found, all of @a this if not.
+     *
+     * The prefix is removed and returned if @a c is found, otherwise all of @a this is removed and
+     * returned.
+     *
+     * @note The character at offset @a n is discarded if found.
+     *
+     * @see @c split_prefix_at
+     */
+    self_type take_prefix_at(char c);
+
+    /** Remove and return a prefix bounded by the first occurrence of any of @a delimiters.
+     *
+     * @param delimiters The characters to match.
+     * @return The prefix bounded by a delimiter if one is found, otherwise all of @a this.
+     *
+     * The prefix is removed and returned if a @a delimiter is found, otherwise all of @a this is
+     * removed and returned.
+     *
+     * @note The matching character is discarded if found.
+     *
+     * @see @c split_prefix_at
+     */
+    self_type take_prefix_at(std::string_view const &delimiters);
+
+    /** Remove and return a prefix bounded by the first character that satisfies @a pred.
+     *
+     * @tparam F Predicate functor type.
+     * @param pred A function taking @c char and returning @c bool.
+     * @return The prefix bounded by the first character satisfying @a pred, or all of @a this if none
+     * is found.
+     *
+     * The prefix is removed and returned if a character satisfying @a pred is found, otherwise
+     * all of @a this is removed and returned.
+     *
+     * @note The matching character is discarded if found.
+     *
+     * @see @c split_prefix_if
+     */
+    template <typename F> self_type take_prefix_if(F const &pred);
+
+    /** Remove and return a prefix of characters satisfying @a pred
+     *
+     * @tparam F Predicate functor type.
+     * @param pred A function taking @c char and returning @c bool.
+     * @return The prefix of characters that satisfy @a pred.
+     *
+     * The returned prefix is removed from @a this. That prefix may be empty if the first character
+     * does not satisfy @a pred.
+     *
+     * @note This is very similar to @c ltrim_if but returns the removed text instead of the modified
+     * view.
+     */
+    template <typename F> self_type clip_prefix_of(F const &pred);
+
+    /** Get a view of the last @a n bytes.
+     *
+     * @param n Number of chars in the suffix.
+     * @return A view of the last @a n characters in @a this, bounded by the size of @a this.
+     */
+    constexpr self_type suffix(size_t n) const noexcept;
+
+    /** Get a view of a suffix bounded by @a c.
+     *
+     * @param c Delimiter character.
+     * @return A view of the suffix bounded by @a c, or all of @a this if @a c is not found.
+     * @note The character @a c is not included in the returned view.
+     */
+    self_type suffix_at(char c) const;
+
+    /** Get a view of a suffix bounded by a character in @a delimiters.
+     *
+     * @param delimiters A set of characters.
+     *
+     * @return A view of the suffix bounded by any character in @a delimiters, or mepty if none are
+     * found.
+     *
+     * @note The delimiter character is not included in the returned view.
+     */
+    self_type suffix_at(std::string_view const &delimiters) const;
+
+    /** Get a view of a suffix bounded by a character predicate @a pred.
+     *
+     * @a pred must be a functor which takes a @c char argument and returns @c bool. Each character in
+     * @a this is tested by @a pred and the suffix is delimited by the last character for which @a
+     * pred is @c true.
+     *
+     * @param pred A character predicate.
+     *
+     * @return A view of the suffix bounded by @a pred or empty if @a pred is not @c true for any
+     * character.
+     *
+     * @note The delimiting character is not included in the returned view.
+     */
+    template <typename F> self_type suffix_if(F const &pred) const;
+
+    /** Remove the trailing characters of @a this up to and including @a c.
+     *
+     * @param c Delimiter character.
+     * @return @a this.
+     *
+     * @note The last occurrence of character @a c is removed along with all succeeding characters, or
+     * the view is cleared if @a c is not found.
+     */
+    self_type &remove_suffix_at(char c);
+
+    /** Remove the trailing characters of @a this up to and including the last character matching @a delimiters.
+     *
+     * @param delimiters Characters to match.
+     * @return @a this.
+     * @note The first occurrence of any character in @a delimiters is removed along with all preceding
+     * characters, or the view is cleared if none are found.
+     */
+    self_type &remove_suffix_at(std::string_view const &delimiters);
+
+    /** Remove the trailing characters up to and including the character selected by @a pred.
+     *
+     * @tparam F Predicate function type.
+     * @param pred The predicate instance.
+     * @return @a this.
+     *
+     * If predicate is never true the view is cleared.
+     */
+    template <typename F> self_type &remove_suffix_if(F const &pred);
+
+    /** Remove and return a suffix of size @a n.
+     *
+     * @param n Size of the suffix.
+     * @return The first @a n bytes of @a this if @a n is in @a this, otherwise an empty view.
+     *
+     * The prefix is removed and returned if the requested suffix is no larger than @a this,
+     * otherwise @a this is not modified.
+     *
+     * @note The character at offset @a n is discarded if @a this is modified.
+     *
+     * @see @c take_suffix
+     */
+    self_type split_suffix(size_t n);
+
+    /** Remove and return a suffix bounded by the last occurrence of @a c.
+     *
+     * @param c The character to match.
+     * @return The suffix bounded by @a c if @a c is found, an empty view if not.
+     *
+     * The suffix is removed and returned if @a c is found, otherwise @a this is not modified.
+     *
+     * @note The character at offset @a n is discarded if @a this is modified.
+     *
+     * @see @c take_suffix_at
+     */
+    self_type split_suffix_at(char c);
+
+    /** Remove and return a suffix bounded by the last occurrence of any of @a delimiters.
+     *
+     * @param delimiters The characters to match.
+     * @return The suffix bounded by a delimiter if found, an empty view if none found.
+     *
+     * The suffix is removed and returned if delimiter is found, otherwise @a this is not modified.
+     *
+     * @note The delimiter character is discarded if @a this is modified.
+     *
+     * @see @c take_suffix_at
+     */
+    self_type split_suffix_at(std::string_view const &delimiters);
+
+    /** Remove and return a suffix bounded by the last character that satisfies @a pred.
+     *
+     * @tparam F Predicate functor type.
+     * @param pred A function taking @c char and returning @c bool.
+     * @return The suffix bounded by the first character satisfying @a pred if found, otherwise @a this
+     * is not modified.
+     *
+     * The prefix is removed and returned if a character satisfying @a pred if found, otherwise
+     * @a this is not modified.
+     *
+     * @note The matching character is discarded if @a this is modified.
+     *
+     * @see @c take_suffix_if
+     */
+    template <typename F> self_type split_suffix_if(F const &pred);
+
+    /** Remove and return a suffix of size @a n.
+     *
+     * @param n Size of the suffix.
+     * @return The first @a n bytes of @a this if @a n is in @a this, otherwise all of @a this.
+     *
+     * The returned suffix is removed from @a this, along with the character at offset @a n if present.
+     *
+     * @see @c split_suffix
+     */
+    self_type take_suffix(size_t n);
+
+    /** Remove and return a suffix bounded by the last occurrence of @a c.
+     *
+     * @param c The character to match.
+     * @return The suffix bounded by @a c if @a c is found, all of @a this if not.
+     *
+     * The returned suffix is removed from @a this, along with the delimiter character if found.
+     *
+     * @see @c split_suffix_at
+     */
+    self_type take_suffix_at(char c);
+
+    /** Remove and return a suffix bounded by the last occurrence of any of @a delimiters.
+     *
+     * @param delimiters The characters to match.
+     * @return The suffix bounded by a delimiter if @a c is found, all of @a this if not.
+     *
+     * The returned suffix is removed from @a this, along with the delimiter character if found.
+     *
+     * @see @c split_suffix_at
+     */
+    self_type take_suffix_at(std::string_view const &delimiters);
+
+    /** Remove and return a suffix bounded by the last character that satisfies @a pred.
+     *
+     * @tparam F Predicate functor type.
+     * @param pred A function taking @c char and returning @c bool.
+     * @return The suffix bounded by the first character satisfying @a pred if found, otherwise all of @a this.
+     *
+     * @note The matching character is discarded if found.
+     *
+     * @see @c split_suffix_if
+     */
+    template <typename F> self_type take_suffix_if(F const &pred);
+
+    /** Remove and return a suffix of characters satisfying @a pred
+     *
+     * @tparam F Predicate functor type.
+     * @param pred A function taking @c char and returning @c bool.
+     * @return The suffix of characters that satisfy @a pred.
+     *
+     * The returned suffix is removed from @a this. That suffix may be empty if the last character
+     * does not satisfy @a pred.
+     *
+     * @note This is very similar to @c rtrim_if but returns the removed text instead of the modified
+     * view.
+     */
+    template <typename F> self_type clip_suffix_of(F const &pred);
+
+    /** Get a view of part of this view.
+     *
+     * @param pos Offset of first byte in the new view.
+     * @param count Number of bytes in the view.
+     * @return The view starting at @a pos for @a count bytes.
+     *
+     * The returned view is clipped by @a this - that is, it will not extend beyond the original view.
+     * @a count is reduced such that it covers only data in @a this.
+     *
+     * @note This is provided primarily for co-variance, i.e. the returned view is a @c TextView
+     * instead of a @c std::string_view.
+     */
+    constexpr self_type substr(size_type pos = 0, size_type count = npos) const noexcept;
+
+    /** Check if the view begins with a specific @a prefix.
+     *
+     * @param prefix String to check against @a this.
+     * @return @c true if <tt>this->prefix(prefix.size()) == prefix</tt>, @c false otherwise.
+     * @internal C++20 preview.
+     */
+    bool starts_with(std::string_view const &prefix) const noexcept;
+
+    /** Check if the view begins with a specific @a prefix.
+     *
+     * @param prefix String to check against @a this.
+     * @return @c true if <tt>this->prefix(prefix.size()) == prefix</tt>, @c false otherwise.
+     * @internal C++20 preview.
+     */
+    bool starts_with(char const *prefix) const;
+
+    /** Check if the view begins with the character @c c.
+     *
+     * @param c Character to check.
+     * @return @c true if the string is non-empty and the first character is @c c.
+     * @internal C++20 preview.
+     */
+    bool starts_with(char c) const noexcept;
+
+    /** Check if the view begins with a specific @a prefix, ignoring case.
+     *
+     * @param prefix String to check against @a this.
+     * @return @c true if <tt>this->prefix(prefix.size()) == prefix</tt> without regard to case, @c false otherwise.
+     * @internal C++20 preview.
+     */
+    bool starts_with_nocase(std::string_view const &prefix) const noexcept;
+
+    /** Check if the view begins with a specific @a prefix.
+     *
+     * @param prefix String to check against @a this.
+     * @return @c true if <tt>this->prefix(prefix.size()) == prefix</tt>, @c false otherwise.
+     * @internal C++20 preview.
+     */
+    bool starts_with_nocase(char const *prefix) const;
+
+    /** Check if the view begins with the character @c c, ignoring case.
+     *
+     * @param c Character to check.
+     * @return @c true if the string is non-empty and the first character is @c c.
+     * @internal C++20 preview.
+     */
+    bool starts_with_nocase(char c) const noexcept;
+
+    /** Check if the view ends with a specific @a suffix.
+     *
+     * @param suffix String to check against @a this.
+     * @return @c true if <tt>this->suffix(suffix.size()) == suffix</tt>, @c false otherwise.
+     * @internal C++20 preview.
+     */
+    bool ends_with(std::string_view const &suffix) const noexcept;
+
+    /** Check if the view ends with a specific @a suffix.
+     *
+     * @param suffix String to check against @a this.
+     * @return @c true if <tt>this->suffix(suffix.size()) == suffix</tt>, @c false otherwise.
+     * @internal C++20 preview.
+     */
+    bool ends_with(char const *suffix) const;
+
+    /** Check the view ends with the character @c c.
+     *
+     * @param c Character to check.
+     * @return @c true if the string is non-empty and the last character is @c c.
+     * @internal C++20 preview.
+     */
+    bool ends_with(char c) const noexcept;
+
+    /** Check if the view starts with a specific @a suffix, ignoring case.
+     *
+     * @param suffix String to check against @a this.
+     * @return @c true if <tt>this->suffix(suffix.size()) == suffix</tt> without regard to case, @c false otherwise.
+     * @internal C++20 preview.
+     */
+    bool ends_with_nocase(std::string_view const &suffix) const noexcept;
+
+    /** Check if the view starts with a specific @a suffix, ignoring case.
+     *
+     * @param suffix String to check against @a this.
+     * @return @c true if <tt>this->suffix(suffix.size()) == suffix</tt> without regard to case, @c false otherwise.
+     * @internal C++20 preview.
+     */
+    bool ends_with_nocase(char const *suffix) const;
+
+    /** Check the view ends with the character @c c, ignoring case.
+     *
+     * @param c Character to check.
+     * @return @c true if the string is non-empty and the last character is @c c.
+     * @internal C++20 preview.
+     */
+    bool ends_with_nocase(char c) const noexcept;
+
+    // Functors for using this class in STL containers.
+    /// Ordering functor, lexicographic comparison.
+    struct LessThan {
+      /// @return Case sensitive ordering.
+      bool
+      operator()(self_type const &lhs, self_type const &rhs) const noexcept
+      {
+        return -1 == strcmp(lhs, rhs);
+      }
+    };
+
+    /// Ordering functor, case ignoring lexicographic comparison.
+    struct LessThanNoCase {
+      /// @return Case insensitive ordering.
+      bool
+      operator()(self_type const &lhs, self_type const &rhs) const noexcept
+      {
+        return -1 == strcasecmp(lhs, rhs);
+      }
+    };
+
+    /// Support for containers that need case insensitive comparisons between views.
+    struct CaselessEqual {
+      /// @return @c true if the view contants are equal when compared without regard to case.
+      bool
+      operator()(self_type const &lhs, self_type const &rhs) const noexcept
+      {
+        return lhs.size() == rhs.size() && 0 == strcasecmp(lhs, rhs);
+      }
+    };
+
+    /** A pointer to the first byte.
+     *
+     * @return Address of the first byte of the view.
+     *
+     * @internal This fixes an error in @c std::string_view where this method is declared to return
+     * a template parameter instead of the correct @c value_type. The effect is @c string_view::data
+     * is not considered by the compiler to return <tt>char const *</tt> which makes meta-programming
+     * painful.
+     */
+    constexpr value_type const *data() const noexcept;
+
+    /** A pointer to past the last byte.
+     *
+     * @return Address of the first byte past the end of the view.
+     *
+     * This is effectively @c std::string_view::end() except it explicit returns a pointer and not
+     * (potentially) an iterator class, to match up with @c data().
+     */
+    constexpr value_type const *data_end() const noexcept;
+
+    /// Specialized stream operator implementation.
+    /// @note Use the standard stream operator unless there is a specific need for this, which is unlikely.
+    /// @return The stream @a os.
+    /// @internal Needed because @c std::ostream::write must be used and
+    /// so alignment / fill have to be explicitly handled.
+    template <typename Stream> Stream &stream_write(Stream &os, const TextView &b) const;
+
+    /// @cond OVERLOAD
+    // These methods are all overloads of other methods, defined in order to make the API more
+    // convenient to use. Mostly these overload @c int for @c size_t so naked numbers work as expected.
+    constexpr self_type prefix(int n) const noexcept;
+    self_type take_suffix(int n);
+    self_type split_prefix(int n);
+    constexpr self_type suffix(int n) const noexcept;
+    self_type split_suffix(int n);
+    /// @endcond
+
+  protected:
+    /// Initialize a bit mask to mark which characters are in this view.
+    static void init_delimiter_set(std::string_view const &delimiters, std::bitset<256> &set);
+  };
+
+  /// Internal table of digit values for characters.
+  /// This is -1 for characters that are not valid digits.
+  extern const int8_t svtoi_convert[256];
+
+  /** Convert the text in @c TextView @a src to a signed numeric value.
+
+      If @a parsed is non-null then the part of the string actually parsed is placed there.
+      @a base sets the conversion base. If not set base 10 is used with two special cases:
+
+      - If the number starts with a literal '0' then it is treated as base 8.
+      - If the number starts with the literal characters '0x' or '0X' then it is treated as base 16.
+
+      If @a base is explicitly set then any leading radix indicator is not supported.
   */
-  constexpr TextView(std::nullptr_t) noexcept;
+  intmax_t svtoi(TextView src, TextView *parsed = nullptr, int base = 0);
 
-  /// Construct from @c std::string, referencing the entire string contents.
-  /// @internal This can't be @c constexpr because this uses methods in @c std::string that may
-  /// not be @c constexpr.
-  TextView(std::string const &str) noexcept;
+  /** Convert the text in @c TextView @a src to an unsigned numeric value.
 
-  /// Assign a super class instance, @c std::string_view  to @a this.
-  self_type &operator=(super_type const &that);
+      If @a parsed is non-null then the part of the string actually parsed is placed there.
+      @a base sets the conversion base. If not set base 10 is used with two special cases:
 
-  /// Assign a constant array to @a this.
-  /// @note If the last character of @a s is a nul byte, it is not included in the view.
-  template <size_t N> self_type &operator=(const char (&s)[N]);
+      - If the number starts with a literal '0' then it is treated as base 8.
+      - If the number starts with the literal characters '0x' or '0X' then it is treated as base 16.
 
-  /// Assign from C-string @a s.
-  self_type &operator=(char *&s);
-  /// Assign from C-string @a s.
-  self_type &operator=(char const * & s);
-
-  /// Assign from a @c std::string.
-  self_type &operator=(const std::string &s);
-
-  /** Assign a view of the @a c_str
-   *
-   * @param c_str Pointer to C string.
-   * @return @a this
-   *
-   * @note @c c_str must be a null terminated string. The null byte is not included in the view.
-   */
-  self_type &assign(char * & c_str);
-
-  /** Assign a view of the @a c_str
-   *
-   * @param c_str Pointer to C string.
-   * @return @a this
-   *
-   * @note @c c_str must be a null terminated string. The null byte is not included in the view.
-   */
-  self_type &assign(char const * & c_str);
-
-  /** Assign from a pointer and size.
-   *
-   * @param ptr Pointer to first character of the view.
-   * @param n Length of the view.
-   * @return @a this
-   *
-   * if @a n is @a npos then @c strlen is used determine the size of the view.
-   */
-  self_type &assign(char const *ptr, size_t n);
-
-  /** Assign the half open view [ @a b , @a e ) to @a this
-   *
-   * @param b First character in the view.
-   * @param e One character after the last character in the view.
-   * @return @a this
-   */
-  self_type &assign(char const *b, char const *e);
-
-  /// Explicitly set the view from a @c std::string
-  self_type &assign(std::string const &s);
-
-  /** Assign literal string or array.
-
-   * All elements of the array are included in the view unless the last element is nul, in which case it is elided.
-   * If this is inappropriate then a constructor with an explicit size should be used.
-   *
-   * @code
-   *   tv.assign("A literal string");
-   * @endcode
-   * The last character in @a tv will be 'g'.
+      If @a base is explicitly set then any leading radix indicator is not supported.
   */
-  template <size_t N> self_type & assign(const char (&s)[N]) noexcept;
+  uintmax_t svtou(TextView src, TextView *parsed = nullptr, int base = 0);
 
-  /** Assign from any character container following STL standards.
+  /** Convert the text in @c src to an unsigned numeric value.
    *
-   * @tparam C Container type.
-   * @param c container
+   * @tparam N The radix (must be  1..36)
+   * @param src The source text. Updated during parsing.
+   * @return The converted numeric value.
    *
-   * The container type must have the methods @c data and @c size which must return values convertible
-   * to @c char @c const @c * and @c size_t respectively.
+   * This is a specialized function useful only where conversion performance is critical. It is used
+   * inside @c svtoi and @a svtou for the common cases of 8, 10, and 16, therefore normally this isn't much more
+   * performant in those cases than just @c svtoi. Because of this only positive values are parsed.
+   * If determining the radix from the text or signed value parsing is needed, used @c svtoi.
+   *
+   * @a src is updated in place to indicate what characters were parsed by removing them from the view
+   * Parsing stops on the first invalid digit, so any leading non-digit characters (e.g. whitespace)
+   * must already be removed. For overflow, all valid digits are consumed and the maximum value returned.
    */
-  template < typename C
-            , typename = std::enable_if_t<
-                std::is_convertible_v<decltype(std::declval<C>().data()), char const*> &&
-                std::is_convertible_v<decltype(std::declval<C>().size()), size_t>
-                , void
-              >
-            > constexpr self_type & assign(C const& c) {
-    return this->assign(c.data(), c.size());
+  template <int RADIX>
+  uintmax_t
+  svto_radix(TextView &src)
+  {
+    static_assert(0 < RADIX && RADIX <= 36, "Radix must be in the range 1..36");
+    static constexpr auto MAX            = std::numeric_limits<uintmax_t>::max();
+    static constexpr auto OVERFLOW_LIMIT = MAX / RADIX;
+    uintmax_t zret                       = 0;
+    int8_t v;
+    while (src.size() && (0 <= (v = swoc::svtoi_convert[uint8_t(*src)])) && v < RADIX) {
+      // Tweaked for performance - need to check range after @a RADIX multiply.
+      ++src; // Update view iff the character is parsed.
+      if (zret <= OVERFLOW_LIMIT && uintmax_t(v) <= MAX - (zret *= RADIX)) {
+        zret += v;
+      } else {
+        zret = MAX; // clamp to max - once set will always hit this case for subsequent input.
+      }
+    }
+    return zret;
   }
 
-  /** Dereference operator.
+  /// Convenience overload.
+  /// @see svto_radix(swoc::TextView &src)
+  template <int N>
+  uintmax_t
+  svto_radix(TextView &&src)
+  {
+    return svto_radix<N>(src);
+  }
 
-      @note This allows the view to be used as if it were a character iterator to a null terminated
-      string which is handy for several other STL interfaces.
-
-      @return The first byte in the view, or a nul character if the view is empty.
-  */
-  /// @return The first byte in the view.
-  constexpr char operator*() const;
-
-  /** Discard the first byte of the view.
+  /** Parse @a text as a floating point number.
    *
-   *  @return @a this.
+   * @param text The input text.
+   * @param parsed Parsed text [out]
+   * @return The floating point value, or 0.0 if invalid input.
+   *
+   * If @a parsed is not @a nullptr then the span of characters parsed is put there. This can be
+   * used to check if the parse was scuccesful - on a failed parse, it will be empty.
+   *
+   * @note This should be within 1 epsilon of correct, although it doesn't guarantee picking
+   * the closest epsilon. It's more than sufficient for use in configurations, but possibly
+   * not for high precision work.
    */
-  self_type &operator++();
-
-  /** Discard the first byte of the view.
-   *
-   * @return The view before discarding the byte.
-   */
-  self_type operator++(int);
-
-  /** Discard the first @a n bytes of the view.
-   *
-   *  Equivalent to @c remove_prefix(n).
-   *  @return @a this
-   */
-  self_type &operator+=(size_t n);
-
-  /// Check for empty view.
-  /// @return @c true if the view has a nullptr @b or zero size.
-  constexpr bool operator!() const noexcept;
-
-  /// Check for non-empty view.
-  /// @return @c true if the view refers to a non-empty range of bytes.
-  explicit constexpr operator bool() const noexcept;
-
-  /// Clear the view (become an empty view).
-  self_type &clear();
-
-  /// Get the offset of the first character for which @a pred is @c true.
-  template <typename F> size_t find_if(F const &pred) const;
-  /// Get the offset of the last character for which @a pred is @c true.
-  template <typename F> size_t rfind_if(F const &pred) const;
-
-  /** Remove bytes that match @a c from the start of the view.
-   *
-   * @return @a this
-   */
-  self_type &ltrim(char c);
-
-  /** Remove bytes from the start of the view that are in @a delimiters.
-   *
-   * @return @a this
-   */
-  self_type &ltrim(std::string_view const &delimiters);
-
-  /** Remove bytes from the start of the view that are in @a delimiters.
-   *
-   * @internal This is needed to avoid collisions with the templated predicate style.
-   *
-   * @return @c *this
-   */
-  self_type &ltrim(const char *delimiters);
-
-  /** Remove bytes from the start of the view for which @a pred is @c true.
-      @a pred must be a functor taking a @c char argument and returning @c bool.
-      @return @c *this
-  */
-  template <typename F> self_type &ltrim_if(F const &pred);
-
-  /** Remove bytes that match @a c from the end of the view.
-   *
-   * @return @a this
-   */
-  self_type &rtrim(char c);
-
-  /** Remove bytes from the end of the view that are in @a delimiters.
-   * @return @a this
-   */
-  self_type &rtrim(std::string_view const &delimiters);
-
-  /** Remove bytes from the end of the view for which @a pred is @c true.
-   *
-   * @a pred must be a functor taking a @c char argument and returning @c bool.
-   *
-   * @return @c *this
-   */
-  template <typename F> self_type &rtrim_if(F const &pred);
-
-  /** Remove bytes that match @a c from the start and end of this view.
-   *
-   * @return @a this
-   */
-  self_type &trim(char c);
-
-  /** Remove bytes from the start and end of the view that are in @a delimiters.
-   * @return @a this
-   */
-  self_type &trim(std::string_view const &delimiters);
-
-  /** Remove bytes from the start and end of the view that are in @a delimiters.
-      @internal This is needed to avoid collisions with the templated predicate style.
-      @return @c *this
-  */
-  self_type &trim(const char *delimiters);
-
-  /** Remove bytes from the start and end of the view for which @a pred is @c true.
-      @a pred must be a functor taking a @c char argument and returning @c bool.
-      @return @c *this
-  */
-  template <typename F> self_type &trim_if(F const &pred);
-
-  /** Get a view of the first @a n bytes.
-   *
-   * @param n Number of chars in the prefix.
-   * @return A view of the first @a n characters in @a this, bounded by the size of @a this.
-   */
-  constexpr self_type prefix(size_t n) const noexcept;
-
-  /** Get a view of a prefix bounded by @a c.
-   *
-   * @param c Delimiter character.
-   * @return A view of the prefix bounded by @a c, or all of @a this if @a c is not found.
-   * @note The character @a c is not included in the returned view.
-   */
-  self_type prefix_at(char c) const;
-
-  /** Get a view of a prefix bounded by a character in @a delimiters.
-   *
-   * @param delimiters A set of characters.
-   *
-   * @return A view of the prefix bounded by any character in @a delimiters, or empty if none are
-   * found.
-   *
-   * @note The delimiter character is not included in the returned view.
-   */
-  self_type prefix_at(std::string_view const &delimiters) const;
-
-  /** Get a view of a prefix bounded by a character predicate @a pred.
-   *
-   * @a pred must be a functor which takes a @c char argument and returns @c bool. Each character in
-   * @a this is tested by @a pred and the prefix is delimited by the first character for which @a
-   * pred is @c true.
-   *
-   * @param pred A character predicate.
-   *
-   * @return A view of the prefix bounded by @a pred or empty if @a pred is not @c true for any
-   * characer.
-   *
-   * @note The deliminting character is not included in the returned view.
-   */
-  template <typename F> self_type prefix_if(F const &pred) const;
-
-  /** Remove bytes from the start of the view.
-   *
-   * @param n Number of bytes to remove.
-   * @return @a this.
-   */
-  self_type &remove_prefix(size_t n);
-
-  /** Remove bytes from the end of the view.
-   *
-   * @param n Number of bytes to remove.
-   * @return @a this.
-   */
-  self_type &remove_suffix(size_t n);
-
-  /** Remove the leading characters of @a this up to and including @a c.
-   *
-   * @param c Delimiter character.
-   * @return @a this.
-   * @note The first occurrence of character @a c is removed along with all preceding characters, or
-   * the view is cleared if @a c is not found.
-   */
-  self_type &remove_prefix_at(char c);
-
-  /** Remove the leading characters of @a this up to and including the first character matching @a delimiters.
-   *
-   * @param delimiters Characters to match.
-   * @return @a this.
-   * @note The first occurrence of any character in @a delimiters is removed along with all preceding
-   * characters, or the view is cleared if none are found.
-   */
-  self_type &remove_prefix_at(std::string_view const &delimiters);
-
-  /** Remove the leading characters up to and including the character selected by @a pred.
-   *
-   * @tparam F Predicate function type.
-   * @param pred The predicate instance.
-   * @return @a this.
-   *
-   * Characters are removed until @a pred returns @c true. The matching character is also removed.
-   */
-  template <typename F> self_type &remove_prefix_if(F const &pred);
-
-  /** Remove and return a prefix of size @a n.
-   *
-   * @param n Size of the prefix.
-   * @return The first @a n bytes of @a this if @a n is in @a this, otherwise an empty view.
-   *
-   * The prefix is removed and returned if the requested prefix is no larger than @a this,
-   * otherwise @a this is not modified.
-   *
-   * @note The character at offset @a n is discarded if @a this is modified.
-   *
-   * @see @c take_prefix
-   */
-  self_type split_prefix(size_t n);
-
-  /** Remove and return a prefix bounded by the first occurrence of @a c.
-   *
-   * @param c The character to match.
-   * @return The prefix bounded by @a c if @a c is found, an empty view if not.
-   *
-   * The prefix is removed and returned if @a c is found, otherwise @a this is not modified.
-   *
-   * @note The delimiter character is discarded if @a this is modified.
-   *
-   * @see @c take_prefix
-   */
-  self_type split_prefix_at(char c);
-
-  /** Remove and return a prefix bounded by the first occurrence of any of @a delimiters.
-   *
-   * @param delimiters The characters to match.
-   * @return The prefix bounded by a delimiter if one is found, otherwise an empty view.
-   *
-   * The prefix is removed and returned if a @a delimiter is found, otherwise @a this is not modified.
-   *
-   * @note The matching character is discarded if @a this is modified.
-   *
-   * @see @c take_prefix_at
-   */
-  self_type split_prefix_at(std::string_view const &delimiters);
-
-  /** Remove and return a prefix bounded by the first character that satisfies @a pred.
-   *
-   * @tparam F Predicate functor type.
-   * @param pred A function taking @c char and returning @c bool.
-   * @return The prefix bounded by the first character satisfying @a pred.
-   *
-   * The prefix is removed and returned if a character satisfying @a pred is found, otherwise
-   * @a this is not modified.
-   *
-   * @note The matching character is discarded if @a this is modified.
-   *
-   * @see @c take_prefix_if
-   */
-  template <typename F> self_type split_prefix_if(F const &pred);
-
-  /** Remove and return the first @a n characters.
-   *
-   * @param n Size of the return prefix.
-   * @return The first @a n bytes of @a this if @a n is in @a this, otherwise all of @a this.
-   *
-   * The prefix is removed and returned if the requested prefix is no larger than @a this,
-   * otherwise all of @a this is removed and returned.
-   *
-   * @note The character at offset @a n is discarded if @a n is within the bounds of @a this.
-   *
-   * @see @c split_prefix
-   */
-  self_type take_prefix(size_t n);
-
-  /** Remove and return a prefix bounded by the first occurrence of @a c.
-   *
-   * @param c The character to match.
-   * @return The prefix bounded by @a c if @a c is found, all of @a this if not.
-   *
-   * The prefix is removed and returned if @a c is found, otherwise all of @a this is removed and
-   * returned.
-   *
-   * @note The character at offset @a n is discarded if found.
-   *
-   * @see @c split_prefix_at
-   */
-  self_type take_prefix_at(char c);
-
-  /** Remove and return a prefix bounded by the first occurrence of any of @a delimiters.
-   *
-   * @param delimiters The characters to match.
-   * @return The prefix bounded by a delimiter if one is found, otherwise all of @a this.
-   *
-   * The prefix is removed and returned if a @a delimiter is found, otherwise all of @a this is
-   * removed and returned.
-   *
-   * @note The matching character is discarded if found.
-   *
-   * @see @c split_prefix_at
-   */
-  self_type take_prefix_at(std::string_view const &delimiters);
-
-  /** Remove and return a prefix bounded by the first character that satisfies @a pred.
-   *
-   * @tparam F Predicate functor type.
-   * @param pred A function taking @c char and returning @c bool.
-   * @return The prefix bounded by the first character satisfying @a pred, or all of @a this if none
-   * is found.
-   *
-   * The prefix is removed and returned if a character satisfying @a pred is found, otherwise
-   * all of @a this is removed and returned.
-   *
-   * @note The matching character is discarded if found.
-   *
-   * @see @c split_prefix_if
-   */
-  template <typename F> self_type take_prefix_if(F const &pred);
-
-  /** Remove and return a prefix of characters satisfying @a pred
-   *
-   * @tparam F Predicate functor type.
-   * @param pred A function taking @c char and returning @c bool.
-   * @return The prefix of characters that satisfy @a pred.
-   *
-   * The returned prefix is removed from @a this. That prefix may be empty if the first character
-   * does not satisfy @a pred.
-   *
-   * @note This is very similar to @c ltrim_if but returns the removed text instead of the modified
-   * view.
-   */
-  template <typename F> self_type clip_prefix_of(F const &pred);
-
-  /** Get a view of the last @a n bytes.
-   *
-   * @param n Number of chars in the suffix.
-   * @return A view of the last @a n characters in @a this, bounded by the size of @a this.
-   */
-  constexpr self_type suffix(size_t n) const noexcept;
-
-  /** Get a view of a suffix bounded by @a c.
-   *
-   * @param c Delimiter character.
-   * @return A view of the suffix bounded by @a c, or all of @a this if @a c is not found.
-   * @note The character @a c is not included in the returned view.
-   */
-  self_type suffix_at(char c) const;
-
-  /** Get a view of a suffix bounded by a character in @a delimiters.
-   *
-   * @param delimiters A set of characters.
-   *
-   * @return A view of the suffix bounded by any character in @a delimiters, or mepty if none are
-   * found.
-   *
-   * @note The delimiter character is not included in the returned view.
-   */
-  self_type suffix_at(std::string_view const &delimiters) const;
-
-  /** Get a view of a suffix bounded by a character predicate @a pred.
-   *
-   * @a pred must be a functor which takes a @c char argument and returns @c bool. Each character in
-   * @a this is tested by @a pred and the suffix is delimited by the last character for which @a
-   * pred is @c true.
-   *
-   * @param pred A character predicate.
-   *
-   * @return A view of the suffix bounded by @a pred or empty if @a pred is not @c true for any
-   * character.
-   *
-   * @note The delimiting character is not included in the returned view.
-   */
-  template <typename F> self_type suffix_if(F const &pred) const;
-
-  /** Remove the trailing characters of @a this up to and including @a c.
-   *
-   * @param c Delimiter character.
-   * @return @a this.
-   *
-   * @note The last occurrence of character @a c is removed along with all succeeding characters, or
-   * the view is cleared if @a c is not found.
-   */
-  self_type &remove_suffix_at(char c);
-
-  /** Remove the trailing characters of @a this up to and including the last character matching @a delimiters.
-   *
-   * @param delimiters Characters to match.
-   * @return @a this.
-   * @note The first occurrence of any character in @a delimiters is removed along with all preceding
-   * characters, or the view is cleared if none are found.
-   */
-  self_type &remove_suffix_at(std::string_view const &delimiters);
-
-  /** Remove the trailing characters up to and including the character selected by @a pred.
-   *
-   * @tparam F Predicate function type.
-   * @param pred The predicate instance.
-   * @return @a this.
-   *
-   * If predicate is never true the view is cleared.
-   */
-  template <typename F> self_type &remove_suffix_if(F const &pred);
-
-  /** Remove and return a suffix of size @a n.
-   *
-   * @param n Size of the suffix.
-   * @return The first @a n bytes of @a this if @a n is in @a this, otherwise an empty view.
-   *
-   * The prefix is removed and returned if the requested suffix is no larger than @a this,
-   * otherwise @a this is not modified.
-   *
-   * @note The character at offset @a n is discarded if @a this is modified.
-   *
-   * @see @c take_suffix
-   */
-  self_type split_suffix(size_t n);
-
-  /** Remove and return a suffix bounded by the last occurrence of @a c.
-   *
-   * @param c The character to match.
-   * @return The suffix bounded by @a c if @a c is found, an empty view if not.
-   *
-   * The suffix is removed and returned if @a c is found, otherwise @a this is not modified.
-   *
-   * @note The character at offset @a n is discarded if @a this is modified.
-   *
-   * @see @c take_suffix_at
-   */
-  self_type split_suffix_at(char c);
-
-  /** Remove and return a suffix bounded by the last occurrence of any of @a delimiters.
-   *
-   * @param delimiters The characters to match.
-   * @return The suffix bounded by a delimiter if found, an empty view if none found.
-   *
-   * The suffix is removed and returned if delimiter is found, otherwise @a this is not modified.
-   *
-   * @note The delimiter character is discarded if @a this is modified.
-   *
-   * @see @c take_suffix_at
-   */
-  self_type split_suffix_at(std::string_view const &delimiters);
-
-  /** Remove and return a suffix bounded by the last character that satisfies @a pred.
-   *
-   * @tparam F Predicate functor type.
-   * @param pred A function taking @c char and returning @c bool.
-   * @return The suffix bounded by the first character satisfying @a pred if found, otherwise @a this
-   * is not modified.
-   *
-   * The prefix is removed and returned if a character satisfying @a pred if found, otherwise
-   * @a this is not modified.
-   *
-   * @note The matching character is discarded if @a this is modified.
-   *
-   * @see @c take_suffix_if
-   */
-  template <typename F> self_type split_suffix_if(F const &pred);
-
-  /** Remove and return a suffix of size @a n.
-   *
-   * @param n Size of the suffix.
-   * @return The first @a n bytes of @a this if @a n is in @a this, otherwise all of @a this.
-   *
-   * The returned suffix is removed from @a this, along with the character at offset @a n if present.
-   *
-   * @see @c split_suffix
-   */
-  self_type take_suffix(size_t n);
-
-  /** Remove and return a suffix bounded by the last occurrence of @a c.
-   *
-   * @param c The character to match.
-   * @return The suffix bounded by @a c if @a c is found, all of @a this if not.
-   *
-   * The returned suffix is removed from @a this, along with the delimiter character if found.
-   *
-   * @see @c split_suffix_at
-   */
-  self_type take_suffix_at(char c);
-
-  /** Remove and return a suffix bounded by the last occurrence of any of @a delimiters.
-   *
-   * @param delimiters The characters to match.
-   * @return The suffix bounded by a delimiter if @a c is found, all of @a this if not.
-   *
-   * The returned suffix is removed from @a this, along with the delimiter character if found.
-   *
-   * @see @c split_suffix_at
-   */
-  self_type take_suffix_at(std::string_view const &delimiters);
-
-  /** Remove and return a suffix bounded by the last character that satisfies @a pred.
-   *
-   * @tparam F Predicate functor type.
-   * @param pred A function taking @c char and returning @c bool.
-   * @return The suffix bounded by the first character satisfying @a pred if found, otherwise all of @a this.
-   *
-   * @note The matching character is discarded if found.
-   *
-   * @see @c split_suffix_if
-   */
-  template <typename F> self_type take_suffix_if(F const &pred);
-
-  /** Remove and return a suffix of characters satisfying @a pred
-   *
-   * @tparam F Predicate functor type.
-   * @param pred A function taking @c char and returning @c bool.
-   * @return The suffix of characters that satisfy @a pred.
-   *
-   * The returned suffix is removed from @a this. That suffix may be empty if the last character
-   * does not satisfy @a pred.
-   *
-   * @note This is very similar to @c rtrim_if but returns the removed text instead of the modified
-   * view.
-   */
-  template <typename F> self_type clip_suffix_of(F const &pred);
-
-  /** Get a view of part of this view.
-   *
-   * @param pos Offset of first byte in the new view.
-   * @param count Number of bytes in the view.
-   * @return The view starting at @a pos for @a count bytes.
-   *
-   * The returned view is clipped by @a this - that is, it will not extend beyond the original view.
-   * @a count is reduced such that it covers only data in @a this.
-   *
-   * @note This is provided primarily for co-variance, i.e. the returned view is a @c TextView
-   * instead of a @c std::string_view.
-   */
-  constexpr self_type substr(size_type pos = 0, size_type count = npos) const noexcept;
-
-  /** Check if the view begins with a specific @a prefix.
-   *
-   * @param prefix String to check against @a this.
-   * @return @c true if <tt>this->prefix(prefix.size()) == prefix</tt>, @c false otherwise.
-   * @internal C++20 preview.
-   */
-  bool starts_with(std::string_view const &prefix) const noexcept;
-
-  /** Check if the view begins with a specific @a prefix.
-   *
-   * @param prefix String to check against @a this.
-   * @return @c true if <tt>this->prefix(prefix.size()) == prefix</tt>, @c false otherwise.
-   * @internal C++20 preview.
-   */
-  bool starts_with(char const *prefix) const;
-
-  /** Check if the view begins with the character @c c.
-   *
-   * @param c Character to check.
-   * @return @c true if the string is non-empty and the first character is @c c.
-   * @internal C++20 preview.
-   */
-  bool starts_with(char c) const noexcept;
-
-  /** Check if the view begins with a specific @a prefix, ignoring case.
-   *
-   * @param prefix String to check against @a this.
-   * @return @c true if <tt>this->prefix(prefix.size()) == prefix</tt> without regard to case, @c false otherwise.
-   * @internal C++20 preview.
-   */
-  bool starts_with_nocase(std::string_view const &prefix) const noexcept;
-
-  /** Check if the view begins with a specific @a prefix.
-   *
-   * @param prefix String to check against @a this.
-   * @return @c true if <tt>this->prefix(prefix.size()) == prefix</tt>, @c false otherwise.
-   * @internal C++20 preview.
-   */
-  bool starts_with_nocase(char const *prefix) const;
-
-  /** Check if the view begins with the character @c c, ignoring case.
-   *
-   * @param c Character to check.
-   * @return @c true if the string is non-empty and the first character is @c c.
-   * @internal C++20 preview.
-   */
-  bool starts_with_nocase(char c) const noexcept;
-
-  /** Check if the view ends with a specific @a suffix.
-   *
-   * @param suffix String to check against @a this.
-   * @return @c true if <tt>this->suffix(suffix.size()) == suffix</tt>, @c false otherwise.
-   * @internal C++20 preview.
-   */
-  bool ends_with(std::string_view const &suffix) const noexcept;
-
-  /** Check if the view ends with a specific @a suffix.
-   *
-   * @param suffix String to check against @a this.
-   * @return @c true if <tt>this->suffix(suffix.size()) == suffix</tt>, @c false otherwise.
-   * @internal C++20 preview.
-   */
-  bool ends_with(char const *suffix) const;
-
-  /** Check the view ends with the character @c c.
-   *
-   * @param c Character to check.
-   * @return @c true if the string is non-empty and the last character is @c c.
-   * @internal C++20 preview.
-   */
-  bool ends_with(char c) const noexcept;
-
-  /** Check if the view starts with a specific @a suffix, ignoring case.
-   *
-   * @param suffix String to check against @a this.
-   * @return @c true if <tt>this->suffix(suffix.size()) == suffix</tt> without regard to case, @c false otherwise.
-   * @internal C++20 preview.
-   */
-  bool ends_with_nocase(std::string_view const &suffix) const noexcept;
-
-  /** Check if the view starts with a specific @a suffix, ignoring case.
-   *
-   * @param suffix String to check against @a this.
-   * @return @c true if <tt>this->suffix(suffix.size()) == suffix</tt> without regard to case, @c false otherwise.
-   * @internal C++20 preview.
-   */
-  bool ends_with_nocase(char const *suffix) const;
-
-  /** Check the view ends with the character @c c, ignoring case.
-   *
-   * @param c Character to check.
-   * @return @c true if the string is non-empty and the last character is @c c.
-   * @internal C++20 preview.
-   */
-  bool ends_with_nocase(char c) const noexcept;
-
-  // Functors for using this class in STL containers.
-  /// Ordering functor, lexicographic comparison.
-  struct LessThan {
-    /// @return Case sensitive ordering.
-    bool
-    operator()(self_type const &lhs, self_type const &rhs) const noexcept {
-      return -1 == strcmp(lhs, rhs);
+  double svtod(TextView text, TextView *parsed = nullptr);
+  // ----------------------------------------------------------
+  // Inline implementations.
+  // Note: Why, you may ask, do I use @c TextView::self_type for return type instead of the
+  // simpler plain @c TextView ? Because otherwise Doxygen can't match up the declaration and
+  // definition and the reference documentation is messed up. Sigh.
+
+  // === TextView Implementation ===
+  /// @cond TextView_INTERNAL
+  // Doxygen doesn't match these up well due to various type and template issues.
+  // @internal If there is more than one overload for numeric types, it's easy to get ambiguity. The only
+  // fix, unfortunately, is lots of overloads to cover the ambiguous cases.
+  inline constexpr TextView::TextView(const char *ptr, size_t n) noexcept
+    : super_type(ptr, n == npos ? (ptr ? ::strlen(ptr) : 0) : n)
+  {
+  }
+  inline constexpr TextView::TextView(const char *ptr, unsigned n) noexcept : super_type(ptr, size_t(n)) {}
+  inline constexpr TextView::TextView(const char *ptr, ssize_t n) noexcept
+    : super_type(ptr, n < 0 ? (ptr ? ::strlen(ptr) : 0) : size_t(n))
+  {
+  }
+  inline constexpr TextView::TextView(const char *ptr, int n) noexcept
+    : super_type(ptr, n < 0 ? (ptr ? ::strlen(ptr) : 0) : size_t(n))
+  {
+  }
+  inline constexpr TextView::TextView(std::nullptr_t) noexcept : super_type(nullptr, 0) {}
+  inline TextView::TextView(std::string const &str) noexcept : super_type(str) {}
+  inline constexpr TextView::TextView(super_type const &that) noexcept : super_type(that) {}
+  template <size_t N> constexpr TextView::TextView(const char (&s)[N]) noexcept : super_type(s, s[N - 1] ? N : N - 1) {}
+  template <typename C, typename> constexpr TextView::TextView(C const &c) : super_type(c.data(), c.size()) {}
+
+  inline void
+  TextView::init_delimiter_set(std::string_view const &delimiters, std::bitset<256> &set)
+  {
+    set.reset();
+    for (char c : delimiters)
+      set[static_cast<uint8_t>(c)] = true;
+  }
+
+  inline auto
+  TextView::clear() -> self_type &
+  {
+    new (this) self_type();
+    return *this;
+  }
+
+  inline constexpr char
+  TextView::operator*() const
+  {
+    return this->empty() ? char(0) : *(this->data());
+  }
+
+  inline constexpr bool
+  TextView::operator!() const noexcept
+  {
+    return this->empty();
+  }
+
+  inline constexpr TextView::operator bool() const noexcept
+  {
+    return !this->empty();
+  }
+
+  inline auto
+  TextView::operator++() -> self_type &
+  {
+    this->remove_prefix(1);
+    return *this;
+  }
+
+  inline auto
+  TextView::operator++(int) -> self_type
+  {
+    self_type zret{*this};
+    this->remove_prefix(1);
+    return zret;
+  }
+
+  inline auto
+  TextView::operator+=(size_t n) -> self_type &
+  {
+    this->remove_prefix(n);
+    return *this;
+  }
+
+  template <size_t N>
+  inline auto
+  TextView::operator=(const char (&s)[N]) -> self_type &
+  {
+    return *this = self_type{s, s[N - 1] ? N : N - 1};
+  }
+
+  inline auto
+  TextView::operator=(super_type const &that) -> self_type &
+  {
+    this->super_type::operator=(that);
+    return *this;
+  }
+
+  inline auto
+  TextView::operator=(char *&s) -> self_type &
+  {
+    this->super_type::operator=(s);
+    return *this;
+  }
+
+  inline auto
+  TextView::operator=(char const *&s) -> self_type &
+  {
+    this->super_type::operator=(s);
+    return *this;
+  }
+
+  inline auto
+  TextView::operator=(const std::string &s) -> self_type &
+  {
+    this->super_type::operator=(s);
+    return *this;
+  }
+
+  inline auto
+  TextView::assign(char *&c_str) -> self_type &
+  {
+    return this->assign(c_str, strlen(c_str));
+  }
+
+  inline auto
+  TextView::assign(char const *&c_str) -> self_type &
+  {
+    return this->assign(c_str, strlen(c_str));
+  }
+
+  inline auto
+  TextView::assign(const std::string &s) -> self_type &
+  {
+    *this = super_type(s);
+    return *this;
+  }
+
+  inline TextView &
+  TextView::assign(char const *ptr, size_t n)
+  {
+    *this = super_type(ptr, n == npos ? (ptr ? ::strlen(ptr) : 0) : n);
+    return *this;
+  }
+
+  inline TextView &
+  TextView::assign(char const *b, char const *e)
+  {
+    *this = super_type(b, e - b);
+    return *this;
+  }
+
+  template <size_t N>
+  inline auto
+  TextView::assign(char const (&s)[N]) noexcept -> self_type &
+  {
+    return *this = self_type{s, s[N - 1] ? N : N - 1};
+  }
+
+  inline constexpr auto
+  TextView::prefix(size_t n) const noexcept -> self_type
+  {
+    return {this->data(), std::min(n, this->size())};
+  }
+
+  inline constexpr TextView
+  TextView::prefix(int n) const noexcept
+  {
+    return {this->data(), std::min<size_t>(n, this->size())};
+  }
+
+  inline auto
+  TextView::prefix_at(char c) const -> self_type
+  {
+    self_type zret; // default to empty return.
+    if (auto n = this->find(c); n != npos) {
+      zret.assign(this->data(), n);
     }
+    return zret;
+  }
+
+  inline TextView
+  TextView::prefix_at(std::string_view const &delimiters) const
+  {
+    self_type zret; // default to empty return.
+    if (auto n = this->find_first_of(delimiters); n != npos) {
+      zret.assign(this->data(), n);
+    }
+    return zret;
+  }
+
+  template <typename F>
+  auto
+  TextView::prefix_if(F const &pred) const -> self_type
+  {
+    self_type zret; // default to empty return.
+    if (auto n = this->find_if(pred); n != npos) {
+      zret.assign(this->data(), n);
+    }
+    return zret;
+  }
+
+  inline auto
+  TextView::remove_prefix(size_t n) -> self_type &
+  {
+    this->super_type::remove_prefix(std::min(n, this->size()));
+    return *this;
+  }
+
+  inline TextView &
+  TextView::remove_prefix_at(char c)
+  {
+    if (auto n = this->find(c); n != npos) {
+      this->super_type::remove_prefix(n + 1);
+    }
+    return *this;
+  }
+
+  inline auto
+  TextView::remove_prefix_at(std::string_view const &delimiters) -> self_type &
+  {
+    if (auto n = this->find_first_of(delimiters); n != npos) {
+      this->super_type::remove_prefix(n + 1);
+    }
+    return *this;
+  }
+
+  template <typename F>
+  auto
+  TextView::remove_prefix_if(F const &pred) -> self_type &
+  {
+    if (auto n = this->find_if(pred); n != npos) {
+      this->super_type::remove_prefix(n + 1);
+    }
+    return *this;
+  }
+
+  inline TextView
+  TextView::split_prefix(size_t n)
+  {
+    self_type zret; // default to empty return.
+    if (n < this->size()) {
+      zret = this->prefix(n);
+      this->remove_prefix(std::min(n + 1, this->size()));
+    }
+    return zret;
+  }
+
+  inline TextView
+  TextView::split_prefix(int n)
+  {
+    return this->split_prefix(size_t(n));
+  }
+
+  inline TextView
+  TextView::split_prefix_at(char c)
+  {
+    return this->split_prefix(this->find(c));
+  }
+
+  inline TextView
+  TextView::split_prefix_at(std::string_view const &delimiters)
+  {
+    return this->split_prefix(this->find_first_of(delimiters));
+  }
+
+  template <typename F>
+  TextView::self_type
+  TextView::split_prefix_if(F const &pred)
+  {
+    return this->split_prefix(this->find_if(pred));
+  }
+
+  inline TextView
+  TextView::take_prefix(size_t n)
+  {
+    n              = std::min(n, this->size());
+    self_type zret = this->prefix(n);
+    this->remove_prefix(std::min(n + 1, this->size()));
+    return zret;
+  }
+
+  inline TextView
+  TextView::take_prefix_at(char c)
+  {
+    return this->take_prefix(this->find(c));
+  }
+
+  inline TextView
+  TextView::take_prefix_at(std::string_view const &delimiters)
+  {
+    return this->take_prefix(this->find_first_of(delimiters));
+  }
+
+  template <typename F>
+  auto
+  TextView::take_prefix_if(F const &pred) -> self_type
+  {
+    return this->take_prefix(this->find_if(pred));
+  }
+
+  inline constexpr TextView
+  TextView::suffix(size_t n) const noexcept
+  {
+    n = std::min(n, this->size());
+    return {this->data_end() - n, n};
+  }
+
+  inline constexpr TextView
+  TextView::suffix(int n) const noexcept
+  {
+    return this->suffix(size_t(n));
+  }
+
+  inline TextView
+  TextView::suffix_at(char c) const
+  {
+    self_type zret;
+    if (auto n = this->rfind(c); n != npos) {
+      ++n;
+      zret.assign(this->data() + n, this->size() - n);
+    }
+    return zret;
+  }
+
+  inline TextView
+  TextView::suffix_at(std::string_view const &delimiters) const
+  {
+    self_type zret;
+    if (auto n = this->find_last_of(delimiters); n != npos) {
+      ++n;
+      zret.assign(this->data() + n, this->size() - n);
+    }
+    return zret;
+  }
+
+  template <typename F>
+  auto
+  TextView::suffix_if(F const &pred) const -> self_type
+  {
+    self_type zret;
+    if (auto n = this->rfind_if(pred); n != npos) {
+      ++n;
+      zret.assign(this->data() + n, this->size() - n);
+    }
+    return zret;
+  }
+
+  inline auto
+  TextView::remove_suffix(size_t n) -> self_type &
+  {
+    this->super_type::remove_suffix(std::min(n, this->size()));
+    return *this;
+  }
+
+  inline TextView &
+  TextView::remove_suffix_at(char c)
+  {
+    if (auto n = this->rfind(c); n != npos) {
+      return this->remove_suffix(this->size() - n);
+    }
+    return this->clear();
+  }
+
+  inline TextView &
+  TextView::remove_suffix_at(std::string_view const &delimiters)
+  {
+    if (auto n = this->find_last_of(delimiters); n != npos) {
+      return this->remove_suffix(this->size() - n);
+    }
+    return this->clear();
+  }
+
+  template <typename F>
+  TextView::self_type &
+  TextView::remove_suffix_if(F const &pred)
+  {
+    if (auto n = this->rfind_if(pred); n != npos) {
+      return this->remove_suffix(this->size() - n);
+    }
+    return this->clear();
+  }
+
+  inline TextView
+  TextView::split_suffix(size_t n)
+  {
+    self_type zret;
+    n    = std::min(n, this->size());
+    zret = this->suffix(n);
+    this->remove_suffix(n + 1);
+    return zret;
+  }
+
+  inline auto
+  TextView::split_suffix(int n) -> self_type
+  {
+    return this->split_suffix(size_t(n));
+  }
+
+  inline TextView
+  TextView::split_suffix_at(char c)
+  {
+    auto idx = this->rfind(c);
+    return npos == idx ? self_type{} : this->split_suffix(this->size() - (idx + 1));
+  }
+
+  inline auto
+  TextView::split_suffix_at(std::string_view const &delimiters) -> self_type
+  {
+    auto idx = this->find_last_of(delimiters);
+    return npos == idx ? self_type{} : this->split_suffix(this->size() - (idx + 1));
+  }
+
+  template <typename F>
+  TextView::self_type
+  TextView::split_suffix_if(F const &pred)
+  {
+    return this->split_suffix(this->rfind_if(pred));
+  }
+
+  inline TextView
+  TextView::take_suffix(size_t n)
+  {
+    self_type zret{*this};
+    *this = zret.split_prefix(n);
+    return zret;
+  }
+
+  inline TextView
+  TextView::take_suffix(int n)
+  {
+    return this->take_suffix(size_t(n));
+  }
+
+  inline TextView
+  TextView::take_suffix_at(char c)
+  {
+    return this->take_suffix(this->rfind(c));
+  }
+
+  inline TextView
+  TextView::take_suffix_at(std::string_view const &delimiters)
+  {
+    return this->take_suffix(this->find_last_of(delimiters));
+  }
+
+  template <typename F>
+  TextView::self_type
+  TextView::take_suffix_if(F const &pred)
+  {
+    return this->take_suffix_at(this->rfind_if(pred));
+  }
+
+  template <typename F>
+  inline size_t
+  TextView::find_if(F const &pred) const
+  {
+    for (const char *spot = this->data(), *limit = this->data_end(); spot < limit; ++spot)
+      if (pred(*spot))
+        return spot - this->data();
+    return npos;
+  }
+
+  template <typename F>
+  inline size_t
+  TextView::rfind_if(F const &pred) const
+  {
+    for (const char *spot = this->data_end(), *limit = this->data(); spot > limit;)
+      if (pred(*--spot))
+        return spot - this->data();
+    return npos;
+  }
+
+  inline TextView &
+  TextView::ltrim(char c)
+  {
+    this->remove_prefix(this->find_first_not_of(c));
+    return *this;
+  }
+
+  inline TextView &
+  TextView::rtrim(char c)
+  {
+    auto n = this->find_last_not_of(c);
+    this->remove_suffix(this->size() - (n == npos ? 0 : n + 1));
+    return *this;
+  }
+
+  inline TextView &
+  TextView::trim(char c)
+  {
+    return this->ltrim(c).rtrim(c);
+  }
+
+  inline TextView &
+  TextView::ltrim(std::string_view const &delimiters)
+  {
+    std::bitset<256> valid;
+    this->init_delimiter_set(delimiters, valid);
+    const char *spot;
+    const char *limit;
+
+    for (spot = this->data(), limit = this->data_end(); spot < limit && valid[static_cast<uint8_t>(*spot)]; ++spot)
+      ;
+    this->remove_prefix(spot - this->data());
+
+    return *this;
+  }
+
+  inline TextView &
+  TextView::ltrim(const char *delimiters)
+  {
+    return this->ltrim(std::string_view(delimiters));
+  }
+
+  inline TextView &
+  TextView::rtrim(std::string_view const &delimiters)
+  {
+    std::bitset<256> valid;
+    this->init_delimiter_set(delimiters, valid);
+    const char *spot  = this->data_end();
+    const char *limit = this->data();
+
+    while (limit < spot-- && valid[static_cast<uint8_t>(*spot)])
+      ;
+
+    this->remove_suffix(this->data_end() - (spot + 1));
+    return *this;
+  }
+
+  inline TextView &
+  TextView::trim(std::string_view const &delimiters)
+  {
+    std::bitset<256> valid;
+    this->init_delimiter_set(delimiters, valid);
+    const char *spot;
+    const char *limit;
+
+    // Do this explicitly, so we don't have to initialize the character set twice.
+    for (spot = this->data(), limit = this->data_end(); spot < limit && valid[static_cast<uint8_t>(*spot)]; ++spot)
+      ;
+    this->remove_prefix(spot - this->data());
+
+    spot  = this->data_end();
+    limit = this->data();
+    while (limit < spot-- && valid[static_cast<uint8_t>(*spot)])
+      ;
+    this->remove_suffix(this->data_end() - (spot + 1));
+
+    return *this;
+  }
+
+  inline TextView &
+  TextView::trim(const char *delimiters)
+  {
+    return this->trim(std::string_view(delimiters));
+  }
+
+  template <typename F>
+  TextView::self_type &
+  TextView::ltrim_if(F const &pred)
+  {
+    const char *spot;
+    const char *limit;
+    for (spot = this->data(), limit = this->data_end(); spot < limit && pred(*spot); ++spot)
+      ;
+    this->remove_prefix(spot - this->data());
+    return *this;
+  }
+
+  template <typename F>
+  TextView::self_type &
+  TextView::rtrim_if(F const &pred)
+  {
+    const char *spot  = this->data_end();
+    const char *limit = this->data();
+    while (limit < spot-- && pred(*spot))
+      ;
+    this->remove_suffix(this->data_end() - (spot + 1));
+    return *this;
+  }
+
+  template <typename F>
+  TextView::self_type &
+  TextView::trim_if(F const &pred)
+  {
+    return this->ltrim_if(pred).rtrim_if(pred);
+  }
+
+  constexpr inline auto
+  TextView::data() const noexcept -> value_type const *
+  {
+    return super_type::data();
+  }
+
+  constexpr inline auto
+  TextView::data_end() const noexcept -> value_type const *
+  {
+    return this->data() + this->size();
+  }
+
+  inline constexpr TextView
+  TextView::substr(size_type pos, size_type count) const noexcept
+  {
+    if (pos >= this->size()) {
+      return {};
+    }
+    count = std::min(this->size() - pos, count);
+    return {this->data() + pos, count};
+  }
+
+  inline bool
+  TextView::starts_with(std::string_view const &prefix) const noexcept
+  {
+    return this->size() >= prefix.size() && 0 == ::memcmp(this->data(), prefix.data(), prefix.size());
+  }
+
+  inline bool
+  TextView::starts_with(char const *prefix) const
+  {
+    return this->starts_with(super_type(prefix));
+  }
+  inline bool
+  TextView::starts_with_nocase(char const *prefix) const
+  {
+    return this->starts_with_nocase(super_type{prefix});
+  }
+
+  inline bool
+  TextView::starts_with(char c) const noexcept
+  {
+    return !this->empty() && c == this->front();
+  }
+  inline bool
+  TextView::starts_with_nocase(char c) const noexcept
+  {
+    return !this->empty() && tolower(c) == tolower(this->front());
+  }
+
+  inline bool
+  TextView::starts_with_nocase(std::string_view const &prefix) const noexcept
+  {
+    return this->size() >= prefix.size() && 0 == ::strncasecmp(this->data(), prefix.data(), prefix.size());
+  }
+
+  inline bool
+  TextView::ends_with(std::string_view const &suffix) const noexcept
+  {
+    return this->size() >= suffix.size() && 0 == ::memcmp(this->data_end() - suffix.size(), suffix.data(), suffix.size());
+  }
+
+  inline bool
+  TextView::ends_with_nocase(std::string_view const &suffix) const noexcept
+  {
+    return this->size() >= suffix.size() && 0 == ::strncasecmp(this->data_end() - suffix.size(), suffix.data(), suffix.size());
+  }
+
+  inline bool
+  TextView::ends_with(char const *suffix) const
+  {
+    return this->ends_with(super_type(suffix));
+  }
+
+  inline bool
+  TextView::ends_with_nocase(char const *suffix) const
+  {
+    return this->ends_with_nocase(super_type(suffix));
+  }
+
+  inline bool
+  TextView::ends_with(char c) const noexcept
+  {
+    return !this->empty() && c == this->back();
+  }
+  inline bool
+  TextView::ends_with_nocase(char c) const noexcept
+  {
+    return !this->empty() && tolower(c) == tolower(this->back());
+  }
+
+  template <typename Stream>
+  Stream &
+  TextView::stream_write(Stream &os, const TextView &b) const
+  {
+    // Local function, avoids extra template work.
+    static const auto stream_fill = [](Stream &ostream, size_t n) -> Stream & {
+      static constexpr size_t pad_size = 8;
+      typename Stream::char_type padding[pad_size];
+
+      std::fill_n(padding, pad_size, ostream.fill());
+      for (; n >= pad_size && ostream.good(); n -= pad_size)
+        ostream.write(padding, pad_size);
+      if (n > 0 && ostream.good())
+        ostream.write(padding, n);
+      return ostream;
+    };
+
+    const std::size_t w = os.width();
+    if (w <= b.size()) {
+      os.write(b.data(), b.size());
+    } else {
+      const std::size_t pad_size = w - b.size();
+      const bool align_left      = (os.flags() & Stream::adjustfield) == Stream::left;
+      if (!align_left && os.good())
+        stream_fill(os, pad_size);
+      if (os.good())
+        os.write(b.data(), b.size());
+      if (align_left && os.good())
+        stream_fill(os, pad_size);
+    }
+    return os;
+  }
+
+  template <typename F>
+  TextView::self_type
+  TextView::clip_prefix_of(F const &pred)
+  {
+    size_t idx = 0;
+    for (auto spot = this->data(), limit = spot + this->size(); spot < limit && pred(*spot); ++spot, ++idx)
+      ; // empty
+    TextView token = this->prefix(idx);
+    this->remove_prefix(idx);
+    return token;
+  }
+
+  template <typename F>
+  TextView::self_type
+  TextView::clip_suffix_of(F const &pred)
+  {
+    size_t idx = this->size() - 1;
+    for (auto spot = this->data() + idx, limit = this->data(); spot >= limit && pred(*spot); --spot, --idx)
+      ; // empty
+    TextView token = this->suffix(idx);
+    this->remove_suffix(idx);
+    return token;
+  }
+  /// @endcond TextView_INTERNAL
+
+  // Provide an instantiation for @c std::ostream as it's likely this is the only one ever used.
+  extern template std::ostream &TextView::stream_write(std::ostream &, const TextView &) const;
+
+  /** A transform view.
+   *
+   * @tparam X Transform functor type.
+   * @tparam V Source view type.
+   *
+   * A transform view acts like a view on the original source view @a V with each element transformed by
+   * @a X.
+   *
+   * This is used most commonly with @c std::string_view. For example, if the goal is to handle a
+   * piece of text as if it were lower case without changing the actual text, the following would
+   * make that possible.
+   * @code
+   * std:::string_view source; // original text.
+   * TransformView<int (*)(int) noexcept, std::string_view> xv(&tolower, source);
+   * @endcode
+   *
+   * To avoid having to figure out the exact signature of the transform, the convenience function
+   * @c transform_view_of is provide.
+   * @code
+   * std::string_view source; // original text.
+   * auto xv = transform_view_of(&tolower, source);
+   * @endcode
+   *
+   * This class supports iterators but those should be avoided as use of them makes extra copies of the instance which
+   * may be expensive if the functor is expensive. In cases where the functor is a function pointer or a lambda this isn't
+   * an issue.
+   */
+  template <typename X, typename V> class TransformView
+  {
+    using self_type       = TransformView; ///< Self reference type.
+    using source_iterator = decltype(V{}.begin());
+
+  public:
+    using transform_type    = X; ///< Export transform functor type.
+    using source_view_type  = V; ///< Export source view type.
+    using source_value_type = std::remove_reference_t<decltype(*source_iterator{})>;
+    /// Result type of calling the transform on an element of the source view.
+    using value_type = std::invoke_result_t<transform_type, source_value_type>;
+    /// This class serves as its own iterator.
+    using iterator = self_type;
+
+    /** Construct a transform view using transform @a xf on source view @a v.
+     *
+     * @param xf Transform instance.
+     * @param v Source view.
+     */
+    TransformView(transform_type &&xf, source_view_type const &v);
+
+    /** Construct a transform view using transform @a xf on source view @a v.
+     *
+     * @param xf Transform instance.
+     * @param v Source view.
+     */
+    TransformView(transform_type const &xf, source_view_type const &v);
+
+    /// Copy constructor.
+    TransformView(self_type const &that) = default;
+    /// Move constructor.
+    TransformView(self_type &&that) = default;
+
+    /// Copy assignment.
+    self_type &operator=(self_type const &that) = default;
+    /// Move assignment.
+    self_type &operator=(self_type &&that) = default;
+
+    /// Equality.
+    bool operator==(self_type const &that) const;
+    /// Inequality.
+    bool operator!=(self_type const &that) const;
+
+    /// Get the current element.
+    value_type operator*() const;
+    /// Move to next element.
+    self_type &operator++();
+    /// Move to next element.
+    self_type operator++(int);
+
+    /// Check if view is empty.
+    bool empty() const;
+    /// Check if bool is not empty.
+    explicit operator bool() const;
+
+    /// Iterator to first transformed character.
+    iterator
+    begin() const
+    {
+      return *this;
+    }
+    /// Iterator past last transformed character.
+    iterator
+    end() const
+    {
+      return self_type{_xf, _limit};
+    }
+
+  protected:
+    transform_type _xf;     ///< Per character transform functor.
+    source_iterator _spot;  ///< Current location in the source view.
+    source_iterator _limit; ///< End of source view.
+
+    /// Special constructor for making an empty instance to serve as the @c end iterator.
+    TransformView(transform_type &&xf, source_iterator &&limit) : _xf(xf), _spot(limit), _limit(limit) {}
   };
 
-  /// Ordering functor, case ignoring lexicographic comparison.
-  struct LessThanNoCase {
-    /// @return Case insensitive ordering.
-    bool
-    operator()(self_type const &lhs, self_type const &rhs) const noexcept {
-      return -1 == strcasecmp(lhs, rhs);
-    }
+  template <typename X, typename V>
+  TransformView<X, V>::TransformView(transform_type &&xf, source_view_type const &v) : _xf(xf), _spot(v.begin()), _limit(v.end())
+  {
+  }
+
+  template <typename X, typename V>
+  TransformView<X, V>::TransformView(transform_type const &xf, source_view_type const &v)
+    : _xf(xf), _spot(v.begin()), _limit(v.end())
+  {
+  }
+
+  template <typename X, typename V>
+  auto
+  TransformView<X, V>::operator*() const -> value_type
+  {
+    return _xf(*_spot);
+  }
+
+  template <typename X, typename V>
+  auto
+  TransformView<X, V>::operator++() -> self_type &
+  {
+    ++_spot;
+    return *this;
+  }
+
+  template <typename X, typename V>
+  auto
+  TransformView<X, V>::operator++(int) -> self_type
+  {
+    self_type zret{*this};
+    ++_spot;
+    return zret;
+  }
+
+  template <typename X, typename V>
+  bool
+  TransformView<X, V>::empty() const
+  {
+    return _spot == _limit;
+  }
+
+  template <typename X, typename V> TransformView<X, V>::operator bool() const
+  {
+    return _spot != _limit;
+  }
+
+  template <typename X, typename V>
+  bool
+  TransformView<X, V>::operator==(self_type const &that) const
+  {
+    return _spot == that._spot && _limit == that._limit;
+  }
+
+  template <typename X, typename V>
+  bool
+  TransformView<X, V>::operator!=(self_type const &that) const
+  {
+    return _spot != that._spot || _limit != that._limit;
+  }
+
+  /** Create a transformed view of a source.
+   *
+   * @tparam X The transform functor type.
+   * @tparam V The source type.
+   * @param xf The transform.
+   * @param src The view source.
+   * @return A @c TransformView that applies @a xf to @a src.
+   */
+  template <typename X, typename V>
+  TransformView<X, V>
+  transform_view_of(X const &xf, V const &src)
+  {
+    return TransformView<X, V>(xf, src);
+  }
+
+  /** Identity transform view.
+   *
+   * @tparam V The source type.
+   *
+   * This is a transform that returns the input unmodified. This is convenient when a transform is
+   * required in general but not in all cases.
+   */
+  template <typename V> class TransformView<void, V>
+  {
+    using self_type = TransformView; ///< Self reference type.
+    /// Iterator over source, for internal use.
+    using source_iterator = decltype(V{}.begin());
+
+  public:
+    using source_view_type  = V; ///< Export source view type.
+    using source_value_type = std::remove_reference_t<decltype(*source_iterator{})>;
+    /// Result type of calling the transform on an element of the source view.
+    using value_type = source_value_type;
+    /// This class serves as its own iterator.
+    using iterator = self_type;
+
+    /** Construct identity transform view from @a v.
+     *
+     * @param v Source view.
+     */
+    TransformView(source_view_type const &v) : _spot(v.begin()), _limit(v.end()) {}
+
+    /// Copy constructor.
+    TransformView(self_type const &that) = default;
+    /// Move constructor.
+    TransformView(self_type &&that) = default;
+
+    /// Copy assignment.
+    self_type &operator=(self_type const &that) = default;
+    /// Move assignment.
+    self_type &operator=(self_type &&that) = default;
+
+    /// Equality.
+    bool operator==(self_type const &that) const;
+    /// Inequality.
+    bool operator!=(self_type const &that) const;
+
+    /// Get the current element.
+    value_type operator*() const;
+
+    /// Move to next element.
+    self_type &operator++();
+
+    /// Move to next element.
+    self_type operator++(int);
+
+    /// Check if view is empty.
+    bool empty() const;
+
+    /// Check if bool is not empty.
+    explicit operator bool() const;
+
+    /// Iterator to first transformed character.
+    iterator begin() const;
+    /// Iterator past last transformed character.
+    iterator end() const;
+
+  protected:
+    source_iterator _spot;  ///< Current location.
+    source_iterator _limit; ///< End marker.
+
+    /// Special constructor for making an empty instance to serve as the @c end iterator.
+    explicit TransformView(source_iterator &&limit) : _spot(limit), _limit(limit) {}
   };
 
-  /// Support for containers that need case insensitive comparisons between views.
-  struct CaselessEqual {
-    /// @return @c true if the view contants are equal when compared without regard to case.
-    bool
-    operator()(self_type const& lhs, self_type const& rhs) const noexcept {
-      return lhs.size() == rhs.size() && 0 == strcasecmp(lhs, rhs);
-    }
-  };
+  template <typename V>
+  auto
+  TransformView<void, V>::operator*() const -> value_type
+  {
+    return *_spot;
+  }
 
-  /** A pointer to the first byte.
-   *
-   * @return Address of the first byte of the view.
-   *
-   * @internal This fixes an error in @c std::string_view where this method is declared to return
-   * a template parameter instead of the correct @c value_type. The effect is @c string_view::data
-   * is not considered by the compiler to return <tt>char const *</tt> which makes meta-programming
-   * painful.
-   */
-  constexpr value_type const *data() const noexcept;
+  template <typename V>
+  auto
+  TransformView<void, V>::operator++() -> self_type &
+  {
+    ++_spot;
+    return *this;
+  }
 
-  /** A pointer to past the last byte.
-   *
-   * @return Address of the first byte past the end of the view.
-   *
-   * This is effectively @c std::string_view::end() except it explicit returns a pointer and not
-   * (potentially) an iterator class, to match up with @c data().
-   */
-  constexpr value_type const *data_end() const noexcept;
+  template <typename V>
+  auto
+  TransformView<void, V>::operator++(int) -> self_type
+  {
+    auto zret{*this};
+    ++*this;
+    return zret;
+  }
 
-  /// Specialized stream operator implementation.
-  /// @note Use the standard stream operator unless there is a specific need for this, which is unlikely.
-  /// @return The stream @a os.
-  /// @internal Needed because @c std::ostream::write must be used and
-  /// so alignment / fill have to be explicitly handled.
-  template <typename Stream> Stream &stream_write(Stream &os, const TextView &b) const;
+  template <typename V>
+  bool
+  TransformView<void, V>::operator==(const self_type &that) const
+  {
+    return _spot == that._spot && _limit == that._limit;
+  }
 
-  /// @cond OVERLOAD
-  // These methods are all overloads of other methods, defined in order to make the API more
-  // convenient to use. Mostly these overload @c int for @c size_t so naked numbers work as expected.
-  constexpr self_type prefix(int n) const noexcept;
-  self_type take_suffix(int n);
-  self_type split_prefix(int n);
-  constexpr self_type suffix(int n) const noexcept;
-  self_type split_suffix(int n);
+  template <typename V>
+  bool
+  TransformView<void, V>::operator!=(const self_type &that) const
+  {
+    return _spot != that._spot || _limit != that._limit;
+  }
+
+  template <typename V>
+  bool
+  TransformView<void, V>::empty() const
+  {
+    return _spot == _limit;
+  }
+
+  template <typename V> TransformView<void, V>::operator bool() const
+  {
+    return _spot != _limit;
+  }
+
+  template <typename V>
+  auto
+  TransformView<void, V>::begin() const -> self_type
+  {
+    return *this;
+  }
+
+  template <typename V>
+  auto
+  TransformView<void, V>::end() const -> self_type
+  {
+    return self_type{_limit};
+  }
+
+  /// @cond INTERNAL_DETAIL
+  // Capture @c void transforms and make them identity transforms.
+  template <typename V>
+  TransformView<void, V>
+  transform_view_of(V const &v)
+  {
+    return TransformView<void, V>(v);
+  }
+
   /// @endcond
 
-protected:
-  /// Initialize a bit mask to mark which characters are in this view.
-  static void init_delimiter_set(std::string_view const &delimiters, std::bitset<256> &set);
-};
-
-/// Internal table of digit values for characters.
-/// This is -1 for characters that are not valid digits.
-extern const int8_t svtoi_convert[256];
-
-/** Convert the text in @c TextView @a src to a signed numeric value.
-
-    If @a parsed is non-null then the part of the string actually parsed is placed there.
-    @a base sets the conversion base. If not set base 10 is used with two special cases:
-
-    - If the number starts with a literal '0' then it is treated as base 8.
-    - If the number starts with the literal characters '0x' or '0X' then it is treated as base 16.
-
-    If @a base is explicitly set then any leading radix indicator is not supported.
-*/
-intmax_t svtoi(TextView src, TextView *parsed = nullptr, int base = 0);
-
-/** Convert the text in @c TextView @a src to an unsigned numeric value.
-
-    If @a parsed is non-null then the part of the string actually parsed is placed there.
-    @a base sets the conversion base. If not set base 10 is used with two special cases:
-
-    - If the number starts with a literal '0' then it is treated as base 8.
-    - If the number starts with the literal characters '0x' or '0X' then it is treated as base 16.
-
-    If @a base is explicitly set then any leading radix indicator is not supported.
-*/
-uintmax_t svtou(TextView src, TextView *parsed = nullptr, int base = 0);
-
-/** Convert the text in @c src to an unsigned numeric value.
- *
- * @tparam N The radix (must be  1..36)
- * @param src The source text. Updated during parsing.
- * @return The converted numeric value.
- *
- * This is a specialized function useful only where conversion performance is critical. It is used
- * inside @c svtoi and @a svtou for the common cases of 8, 10, and 16, therefore normally this isn't much more
- * performant in those cases than just @c svtoi. Because of this only positive values are parsed.
- * If determining the radix from the text or signed value parsing is needed, used @c svtoi.
- *
- * @a src is updated in place to indicate what characters were parsed by removing them from the view
- * Parsing stops on the first invalid digit, so any leading non-digit characters (e.g. whitespace)
- * must already be removed. For overflow, all valid digits are consumed and the maximum value returned.
- */
-template <int RADIX>
-uintmax_t
-svto_radix(TextView &src) {
-  static_assert(0 < RADIX && RADIX <= 36, "Radix must be in the range 1..36");
-  static constexpr auto MAX = std::numeric_limits<uintmax_t>::max();
-  static constexpr auto OVERFLOW_LIMIT = MAX / RADIX;
-  uintmax_t zret = 0;
-  int8_t v;
-  while (src.size() && (0 <= (v = swoc::svtoi_convert[uint8_t(*src)])) && v < RADIX) {
-    // Tweaked for performance - need to check range after @a RADIX multiply.
-    ++src; // Update view iff the character is parsed.
-    if (zret <= OVERFLOW_LIMIT && uintmax_t(v) <= MAX - (zret *= RADIX)) {
-      zret += v;
-    } else {
-      zret = MAX; // clamp to max - once set will always hit this case for subsequent input.
+  /** User literals for TextView.
+   *
+   * - _tv : TextView
+   * - _sv : std::string_view
+   */
+  namespace literals
+  {
+    /** Literal constructor for @c std::string_view.
+     *
+     * @param s The source string.
+     * @param n Size of the source string.
+     * @return A @c string_view
+     *
+     * @internal This is provided because the STL one does not support @c constexpr which seems
+     * rather bizarre to me, but there it is. Update: this depends on the version of the compiler,
+     * so hopefully someday this can be removed.
+     */
+    constexpr std::string_view
+    operator"" _sv(const char *s, size_t n)
+    {
+      return {s, n};
     }
-  }
-  return zret;
-}
 
-/// Convenience overload.
-/// @see svto_radix(swoc::TextView &src)
-template <int N>
-uintmax_t
-svto_radix(TextView &&src) {
-  return svto_radix<N>(src);
-}
-
-/** Parse @a text as a floating point number.
- *
- * @param text The input text.
- * @param parsed Parsed text [out]
- * @return The floating point value, or 0.0 if invalid input.
- *
- * If @a parsed is not @a nullptr then the span of characters parsed is put there. This can be
- * used to check if the parse was scuccesful - on a failed parse, it will be empty.
- *
- * @note This should be within 1 epsilon of correct, although it doesn't guarantee picking
- * the closest epsilon. It's more than sufficient for use in configurations, but possibly
- * not for high precision work.
- */
-double svtod(TextView text, TextView *parsed = nullptr);
-// ----------------------------------------------------------
-// Inline implementations.
-// Note: Why, you may ask, do I use @c TextView::self_type for return type instead of the
-// simpler plain @c TextView ? Because otherwise Doxygen can't match up the declaration and
-// definition and the reference documentation is messed up. Sigh.
-
-// === TextView Implementation ===
-/// @cond TextView_INTERNAL
-// Doxygen doesn't match these up well due to various type and template issues.
-// @internal If there is more than one overload for numeric types, it's easy to get ambiguity. The only
-// fix, unfortunately, is lots of overloads to cover the ambiguous cases.
-inline constexpr TextView::TextView(const char *ptr, size_t n) noexcept
-  : super_type(ptr, n == npos ? (ptr ? ::strlen(ptr) : 0) : n) {}
-inline constexpr TextView::TextView(const char *ptr, unsigned n) noexcept : super_type(ptr, size_t(n)) {}
-inline constexpr TextView::TextView(const char *ptr, ssize_t n) noexcept
-  : super_type(ptr, n < 0 ? (ptr ? ::strlen(ptr) : 0) : size_t(n)) {}
-inline constexpr TextView::TextView(const char *ptr, int n) noexcept
-  : super_type(ptr, n < 0 ? (ptr ? ::strlen(ptr) : 0) : size_t(n)) {}
-inline constexpr TextView::TextView(std::nullptr_t) noexcept : super_type(nullptr, 0) {}
-inline TextView::TextView(std::string const &str) noexcept : super_type(str) {}
-inline constexpr TextView::TextView(super_type const &that) noexcept : super_type(that) {}
-template <size_t N> constexpr TextView::TextView(const char (&s)[N]) noexcept : super_type(s, s[N - 1] ? N : N - 1) {}
-template <typename C, typename> constexpr TextView::TextView(C const &c) : super_type(c.data(), c.size()) {}
-
-inline void
-TextView::init_delimiter_set(std::string_view const &delimiters, std::bitset<256> &set) {
-  set.reset();
-  for (char c : delimiters)
-    set[static_cast<uint8_t>(c)] = true;
-}
-
-inline auto
-TextView::clear() -> self_type & {
-  new (this) self_type();
-  return *this;
-}
-
-inline constexpr char
-TextView::operator*() const {
-  return this->empty() ? char(0) : *(this->data());
-}
-
-inline constexpr bool
-TextView::operator!() const noexcept {
-  return this->empty();
-}
-
-inline constexpr TextView::operator bool() const noexcept {
-  return !this->empty();
-}
-
-inline auto
-TextView::operator++() -> self_type & {
-  this->remove_prefix(1);
-  return *this;
-}
-
-inline auto
-TextView::operator++(int) -> self_type {
-  self_type zret{*this};
-  this->remove_prefix(1);
-  return zret;
-}
-
-inline auto
-TextView::operator+=(size_t n) -> self_type &{
-  this->remove_prefix(n);
-  return *this;
-}
-
-template <size_t N>
-inline auto
-TextView::operator=(const char (&s)[N]) -> self_type & {
-  return *this = self_type{s, s[N - 1] ? N : N - 1};
-}
-
-inline auto
-TextView::operator=(super_type const &that) -> self_type & {
-  this->super_type::operator=(that);
-  return *this;
-}
-
-inline auto
-TextView::operator=(char *&s) -> self_type & {
-  this->super_type::operator=(s);
-  return *this;
-}
-
-inline auto
-TextView::operator=(char const *&s) -> self_type & {
-  this->super_type::operator=(s);
-  return *this;
-}
-
-inline auto
-TextView::operator=(const std::string &s) -> self_type & {
-  this->super_type::operator=(s);
-  return *this;
-}
-
-inline auto
-TextView::assign(char * & c_str) -> self_type & {
-  return this->assign(c_str, strlen(c_str));
-}
-
-inline auto
-TextView::assign(char const * & c_str) -> self_type & {
-  return this->assign(c_str, strlen(c_str));
-}
-
-inline auto
-TextView::assign(const std::string &s) -> self_type & {
-  *this = super_type(s);
-  return *this;
-}
-
-inline TextView &
-TextView::assign(char const *ptr, size_t n) {
-  *this = super_type(ptr, n == npos ? ( ptr ? ::strlen(ptr) : 0) : n);
-  return *this;
-}
-
-inline TextView &
-TextView::assign(char const *b, char const *e) {
-  *this = super_type(b, e - b);
-  return *this;
-}
-
-template <size_t N>
-inline auto
-TextView::assign(char const (&s)[N]) noexcept -> self_type & {
-  return *this = self_type{s, s[N - 1] ? N : N - 1};
-}
-
-inline constexpr auto
-TextView::prefix(size_t n) const noexcept -> self_type {
-  return {this->data(), std::min(n, this->size())};
-}
-
-inline constexpr TextView
-TextView::prefix(int n) const noexcept {
-  return {this->data(), std::min<size_t>(n, this->size())};
-}
-
-inline auto
-TextView::prefix_at(char c) const -> self_type {
-  self_type zret; // default to empty return.
-  if (auto n = this->find(c); n != npos) {
-    zret.assign(this->data(), n);
-  }
-  return zret;
-}
-
-inline TextView
-TextView::prefix_at(std::string_view const &delimiters) const {
-  self_type zret; // default to empty return.
-  if (auto n = this->find_first_of(delimiters); n != npos) {
-    zret.assign(this->data(), n);
-  }
-  return zret;
-}
-
-template <typename F>
-auto
-TextView::prefix_if(F const &pred) const -> self_type {
-  self_type zret; // default to empty return.
-  if (auto n = this->find_if(pred); n != npos) {
-    zret.assign(this->data(), n);
-  }
-  return zret;
-}
-
-inline auto
-TextView::remove_prefix(size_t n) -> self_type & {
-  this->super_type::remove_prefix(std::min(n, this->size()));
-  return *this;
-}
-
-inline TextView &
-TextView::remove_prefix_at(char c) {
-  if (auto n = this->find(c); n != npos) {
-    this->super_type::remove_prefix(n + 1);
-  }
-  return *this;
-}
-
-inline auto
-TextView::remove_prefix_at(std::string_view const &delimiters) -> self_type & {
-  if (auto n = this->find_first_of(delimiters); n != npos) {
-    this->super_type::remove_prefix(n + 1);
-  }
-  return *this;
-}
-
-template <typename F>
-auto
-TextView::remove_prefix_if(F const &pred) -> self_type & {
-  if (auto n = this->find_if(pred); n != npos) {
-    this->super_type::remove_prefix(n + 1);
-  }
-  return *this;
-}
-
-inline TextView
-TextView::split_prefix(size_t n) {
-  self_type zret; // default to empty return.
-  if (n < this->size()) {
-    zret = this->prefix(n);
-    this->remove_prefix(std::min(n + 1, this->size()));
-  }
-  return zret;
-}
-
-inline TextView
-TextView::split_prefix(int n) {
-  return this->split_prefix(size_t(n));
-}
-
-inline TextView
-TextView::split_prefix_at(char c) {
-  return this->split_prefix(this->find(c));
-}
-
-inline TextView
-TextView::split_prefix_at(std::string_view const &delimiters) {
-  return this->split_prefix(this->find_first_of(delimiters));
-}
-
-template <typename F>
-TextView::self_type
-TextView::split_prefix_if(F const &pred) {
-  return this->split_prefix(this->find_if(pred));
-}
-
-inline TextView
-TextView::take_prefix(size_t n) {
-  n              = std::min(n, this->size());
-  self_type zret = this->prefix(n);
-  this->remove_prefix(std::min(n + 1, this->size()));
-  return zret;
-}
-
-inline TextView
-TextView::take_prefix_at(char c) {
-  return this->take_prefix(this->find(c));
-}
-
-inline TextView
-TextView::take_prefix_at(std::string_view const &delimiters) {
-  return this->take_prefix(this->find_first_of(delimiters));
-}
-
-template <typename F>
-auto
-TextView::take_prefix_if(F const &pred) -> self_type {
-  return this->take_prefix(this->find_if(pred));
-}
-
-inline constexpr TextView
-TextView::suffix(size_t n) const noexcept {
-  n = std::min(n, this->size());
-  return {this->data_end() - n, n};
-}
-
-inline constexpr TextView
-TextView::suffix(int n) const noexcept {
-  return this->suffix(size_t(n));
-}
-
-inline TextView
-TextView::suffix_at(char c) const {
-  self_type zret;
-  if (auto n = this->rfind(c); n != npos) {
-    ++n;
-    zret.assign(this->data() + n, this->size() - n);
-  }
-  return zret;
-}
-
-inline TextView
-TextView::suffix_at(std::string_view const &delimiters) const {
-  self_type zret;
-  if (auto n = this->find_last_of(delimiters); n != npos) {
-    ++n;
-    zret.assign(this->data() + n, this->size() - n);
-  }
-  return zret;
-}
-
-template <typename F>
-auto
-TextView::suffix_if(F const &pred) const -> self_type {
-  self_type zret;
-  if (auto n = this->rfind_if(pred); n != npos) {
-    ++n;
-    zret.assign(this->data() + n, this->size() - n);
-  }
-  return zret;
-}
-
-inline auto
-TextView::remove_suffix(size_t n) -> self_type & {
-  this->super_type::remove_suffix(std::min(n, this->size()));
-  return *this;
-}
-
-inline TextView &
-TextView::remove_suffix_at(char c) {
-  if (auto n = this->rfind(c); n != npos) {
-    return this->remove_suffix(this->size() - n);
-  }
-  return this->clear();
-}
-
-inline TextView &
-TextView::remove_suffix_at(std::string_view const &delimiters) {
-  if (auto n = this->find_last_of(delimiters); n != npos) {
-    return this->remove_suffix(this->size() - n);
-  }
-  return this->clear();
-}
-
-template <typename F>
-TextView::self_type &
-TextView::remove_suffix_if(F const &pred) {
-  if (auto n = this->rfind_if(pred); n != npos) {
-    return this->remove_suffix(this->size() - n);
-  }
-  return this->clear();
-}
-
-inline TextView
-TextView::split_suffix(size_t n) {
-  self_type zret;
-  n    = std::min(n, this->size());
-  zret = this->suffix(n);
-  this->remove_suffix(n + 1);
-  return zret;
-}
-
-inline auto
-TextView::split_suffix(int n) -> self_type {
-  return this->split_suffix(size_t(n));
-}
-
-inline TextView
-TextView::split_suffix_at(char c) {
-  auto idx = this->rfind(c);
-  return npos == idx ? self_type{} : this->split_suffix(this->size() - (idx + 1));
-}
-
-inline auto
-TextView::split_suffix_at(std::string_view const &delimiters) -> self_type {
-  auto idx = this->find_last_of(delimiters);
-  return npos == idx ? self_type{} : this->split_suffix(this->size() - (idx + 1));
-}
-
-template <typename F>
-TextView::self_type
-TextView::split_suffix_if(F const &pred) {
-  return this->split_suffix(this->rfind_if(pred));
-}
-
-inline TextView
-TextView::take_suffix(size_t n) {
-  self_type zret{*this};
-  *this = zret.split_prefix(n);
-  return zret;
-}
-
-inline TextView
-TextView::take_suffix(int n) {
-  return this->take_suffix(size_t(n));
-}
-
-inline TextView
-TextView::take_suffix_at(char c) {
-  return this->take_suffix(this->rfind(c));
-}
-
-inline TextView
-TextView::take_suffix_at(std::string_view const &delimiters) {
-  return this->take_suffix(this->find_last_of(delimiters));
-}
-
-template <typename F>
-TextView::self_type
-TextView::take_suffix_if(F const &pred){
-  return this->take_suffix_at(this->rfind_if(pred));
-}
-
-template <typename F>
-inline size_t
-TextView::find_if(F const &pred) const {
-  for (const char *spot = this->data(), *limit = this->data_end(); spot < limit; ++spot)
-    if (pred(*spot))
-      return spot - this->data();
-  return npos;
-}
-
-template <typename F>
-inline size_t
-TextView::rfind_if(F const &pred) const {
-  for (const char *spot = this->data_end(), *limit = this->data(); spot > limit;)
-    if (pred(*--spot))
-      return spot - this->data();
-  return npos;
-}
-
-inline TextView &
-TextView::ltrim(char c) {
-  this->remove_prefix(this->find_first_not_of(c));
-  return *this;
-}
-
-inline TextView &
-TextView::rtrim(char c) {
-  auto n = this->find_last_not_of(c);
-  this->remove_suffix(this->size() - (n == npos ? 0 : n + 1));
-  return *this;
-}
-
-inline TextView &
-TextView::trim(char c) {
-  return this->ltrim(c).rtrim(c);
-}
-
-inline TextView &
-TextView::ltrim(std::string_view const &delimiters) {
-  std::bitset<256> valid;
-  this->init_delimiter_set(delimiters, valid);
-  const char *spot;
-  const char *limit;
-
-  for (spot = this->data(), limit = this->data_end(); spot < limit && valid[static_cast<uint8_t>(*spot)]; ++spot)
-    ;
-  this->remove_prefix(spot - this->data());
-
-  return *this;
-}
-
-inline TextView &
-TextView::ltrim(const char *delimiters) {
-  return this->ltrim(std::string_view(delimiters));
-}
-
-inline TextView &
-TextView::rtrim(std::string_view const &delimiters) {
-  std::bitset<256> valid;
-  this->init_delimiter_set(delimiters, valid);
-  const char *spot  = this->data_end();
-  const char *limit = this->data();
-
-  while (limit < spot-- && valid[static_cast<uint8_t>(*spot)])
-    ;
-
-  this->remove_suffix(this->data_end() - (spot + 1));
-  return *this;
-}
-
-inline TextView &
-TextView::trim(std::string_view const &delimiters) {
-  std::bitset<256> valid;
-  this->init_delimiter_set(delimiters, valid);
-  const char *spot;
-  const char *limit;
-
-  // Do this explicitly, so we don't have to initialize the character set twice.
-  for (spot = this->data(), limit = this->data_end(); spot < limit && valid[static_cast<uint8_t>(*spot)]; ++spot)
-    ;
-  this->remove_prefix(spot - this->data());
-
-  spot  = this->data_end();
-  limit = this->data();
-  while (limit < spot-- && valid[static_cast<uint8_t>(*spot)])
-    ;
-  this->remove_suffix(this->data_end() - (spot + 1));
-
-  return *this;
-}
-
-inline TextView &
-TextView::trim(const char *delimiters) {
-  return this->trim(std::string_view(delimiters));
-}
-
-template <typename F>
-TextView::self_type &
-TextView::ltrim_if(F const &pred) {
-  const char *spot;
-  const char *limit;
-  for (spot = this->data(), limit = this->data_end(); spot < limit && pred(*spot); ++spot)
-    ;
-  this->remove_prefix(spot - this->data());
-  return *this;
-}
-
-template <typename F>
-TextView::self_type &
-TextView::rtrim_if(F const &pred) {
-  const char *spot  = this->data_end();
-  const char *limit = this->data();
-  while (limit < spot-- && pred(*spot))
-    ;
-  this->remove_suffix(this->data_end() - (spot + 1));
-  return *this;
-}
-
-template <typename F>
-TextView::self_type &
-TextView::trim_if(F const &pred) {
-  return this->ltrim_if(pred).rtrim_if(pred);
-}
-
-constexpr inline auto
-TextView::data() const noexcept -> value_type const* {
-  return super_type::data();
-}
-
-constexpr inline auto
-TextView::data_end() const noexcept -> value_type const* {
-  return this->data() + this->size();
-}
-
-inline constexpr TextView
-TextView::substr(size_type pos, size_type count) const noexcept {
-  if (pos >= this->size()) {
-    return {};
-  }
-  count = std::min(this->size() - pos, count);
-  return {this->data() + pos, count};
-}
-
-inline bool
-TextView::starts_with(std::string_view const &prefix) const noexcept {
-  return this->size() >= prefix.size() && 0 == ::memcmp(this->data(), prefix.data(), prefix.size());
-}
-
-inline bool
-TextView::starts_with(char const *prefix) const {
-  return this->starts_with(super_type(prefix));
-}
-inline bool
-TextView::starts_with_nocase(char const *prefix) const {
-  return this->starts_with_nocase(super_type{prefix});
-}
-
-inline bool
-TextView::starts_with(char c) const noexcept {
-  return !this->empty() && c == this->front();
-}
-inline bool
-TextView::starts_with_nocase(char c) const noexcept {
-  return !this->empty() && tolower(c) == tolower(this->front());
-}
-
-inline bool
-TextView::starts_with_nocase(std::string_view const &prefix) const noexcept {
-  return this->size() >= prefix.size() && 0 == ::strncasecmp(this->data(), prefix.data(), prefix.size());
-}
-
-inline bool
-TextView::ends_with(std::string_view const &suffix) const noexcept {
-  return this->size() >= suffix.size() && 0 == ::memcmp(this->data_end() - suffix.size(), suffix.data(), suffix.size());
-}
-
-inline bool
-TextView::ends_with_nocase(std::string_view const &suffix) const noexcept {
-  return this->size() >= suffix.size() && 0 == ::strncasecmp(this->data_end() - suffix.size(), suffix.data(), suffix.size());
-}
-
-inline bool
-TextView::ends_with(char const *suffix) const {
-  return this->ends_with(super_type(suffix));
-}
-
-inline bool
-TextView::ends_with_nocase(char const *suffix) const {
-  return this->ends_with_nocase(super_type(suffix));
-}
-
-inline bool
-TextView::ends_with(char c) const noexcept {
-  return !this->empty() && c == this->back();
-}
-inline bool
-TextView::ends_with_nocase(char c) const noexcept {
-  return !this->empty() && tolower(c) == tolower(this->back());
-}
-
-template <typename Stream>
-Stream &
-TextView::stream_write(Stream &os, const TextView &b) const {
-  // Local function, avoids extra template work.
-  static const auto stream_fill = [](Stream &ostream, size_t n) -> Stream & {
-    static constexpr size_t pad_size = 8;
-    typename Stream::char_type padding[pad_size];
-
-    std::fill_n(padding, pad_size, ostream.fill());
-    for (; n >= pad_size && ostream.good(); n -= pad_size)
-      ostream.write(padding, pad_size);
-    if (n > 0 && ostream.good())
-      ostream.write(padding, n);
-    return ostream;
-  };
-
-  const std::size_t w = os.width();
-  if (w <= b.size()) {
-    os.write(b.data(), b.size());
-  } else {
-    const std::size_t pad_size = w - b.size();
-    const bool align_left      = (os.flags() & Stream::adjustfield) == Stream::left;
-    if (!align_left && os.good())
-      stream_fill(os, pad_size);
-    if (os.good())
-      os.write(b.data(), b.size());
-    if (align_left && os.good())
-      stream_fill(os, pad_size);
-  }
-  return os;
-}
-
-template <typename F>
-TextView::self_type
-TextView::clip_prefix_of(F const &pred) {
-  size_t idx = 0;
-  for (auto spot = this->data(), limit = spot + this->size(); spot < limit && pred(*spot); ++spot, ++idx)
-    ; // empty
-  TextView token = this->prefix(idx);
-  this->remove_prefix(idx);
-  return token;
-}
-
-template <typename F>
-TextView::self_type
-TextView::clip_suffix_of(F const &pred) {
-  size_t idx = this->size() - 1;
-  for (auto spot = this->data() + idx, limit = this->data(); spot >= limit && pred(*spot); --spot, --idx)
-    ; // empty
-  TextView token = this->suffix(idx);
-  this->remove_suffix(idx);
-  return token;
-}
-/// @endcond TextView_INTERNAL
-
-// Provide an instantiation for @c std::ostream as it's likely this is the only one ever used.
-extern template std::ostream &TextView::stream_write(std::ostream &, const TextView &) const;
-
-/** A transform view.
- *
- * @tparam X Transform functor type.
- * @tparam V Source view type.
- *
- * A transform view acts like a view on the original source view @a V with each element transformed by
- * @a X.
- *
- * This is used most commonly with @c std::string_view. For example, if the goal is to handle a
- * piece of text as if it were lower case without changing the actual text, the following would
- * make that possible.
- * @code
- * std:::string_view source; // original text.
- * TransformView<int (*)(int) noexcept, std::string_view> xv(&tolower, source);
- * @endcode
- *
- * To avoid having to figure out the exact signature of the transform, the convenience function
- * @c transform_view_of is provide.
- * @code
- * std::string_view source; // original text.
- * auto xv = transform_view_of(&tolower, source);
- * @endcode
- *
- * This class supports iterators but those should be avoided as use of them makes extra copies of the instance which
- * may be expensive if the functor is expensive. In cases where the functor is a function pointer or a lambda this isn't
- * an issue.
- */
-template <typename X, typename V> class TransformView {
-  using self_type = TransformView; ///< Self reference type.
-  using source_iterator = decltype(V{}.begin());
-
-public:
-  using transform_type    = X; ///< Export transform functor type.
-  using source_view_type  = V; ///< Export source view type.
-  using source_value_type = std::remove_reference_t<decltype(*source_iterator{})>;
-  /// Result type of calling the transform on an element of the source view.
-  using value_type = std::invoke_result_t<transform_type, source_value_type>;
-  /// This class serves as its own iterator.
-  using iterator = self_type;
-
-  /** Construct a transform view using transform @a xf on source view @a v.
-   *
-   * @param xf Transform instance.
-   * @param v Source view.
-   */
-  TransformView(transform_type &&xf, source_view_type const &v);
-
-  /** Construct a transform view using transform @a xf on source view @a v.
-   *
-   * @param xf Transform instance.
-   * @param v Source view.
-   */
-  TransformView(transform_type const &xf, source_view_type const &v);
-
-  /// Copy constructor.
-  TransformView(self_type const &that) = default;
-  /// Move constructor.
-  TransformView(self_type &&that) = default;
-
-  /// Copy assignment.
-  self_type &operator=(self_type const &that) = default;
-  /// Move assignment.
-  self_type &operator=(self_type &&that) = default;
-
-  /// Equality.
-  bool operator==(self_type const &that) const;
-  /// Inequality.
-  bool operator!=(self_type const &that) const;
-
-  /// Get the current element.
-  value_type operator*() const;
-  /// Move to next element.
-  self_type &operator++();
-  /// Move to next element.
-  self_type operator++(int);
-
-  /// Check if view is empty.
-  bool empty() const;
-  /// Check if bool is not empty.
-  explicit operator bool() const;
-
-  /// Iterator to first transformed character.
-  iterator begin() const { return *this; }
-  /// Iterator past last transformed character.
-  iterator end() const { return self_type{_xf, _limit}; }
-
-protected:
-  transform_type _xf;     ///< Per character transform functor.
-  source_iterator _spot;  ///< Current location in the source view.
-  source_iterator _limit; ///< End of source view.
-
-  /// Special constructor for making an empty instance to serve as the @c end iterator.
-  TransformView(transform_type && xf, source_iterator && limit) : _xf(xf), _spot(limit), _limit(limit) {}
-};
-
-template <typename X, typename V>
-TransformView<X, V>::TransformView(transform_type &&xf, source_view_type const &v) : _xf(xf), _spot(v.begin()), _limit(v.end()) {}
-
-template <typename X, typename V>
-TransformView<X, V>::TransformView(transform_type const &xf, source_view_type const &v)
-  : _xf(xf), _spot(v.begin()), _limit(v.end()) {}
-
-template <typename X, typename V>
-auto
-TransformView<X, V>::operator*() const -> value_type {
-  return _xf(*_spot);
-}
-
-template <typename X, typename V>
-auto
-TransformView<X, V>::operator++() -> self_type & {
-  ++_spot;
-  return *this;
-}
-
-template <typename X, typename V>
-auto
-TransformView<X, V>::operator++(int) -> self_type {
-  self_type zret{*this};
-  ++_spot;
-  return zret;
-}
-
-template <typename X, typename V>
-bool
-TransformView<X, V>::empty() const {
-  return _spot == _limit;
-}
-
-template <typename X, typename V> TransformView<X, V>::operator bool() const {
-  return _spot != _limit;
-}
-
-template <typename X, typename V>
-bool
-TransformView<X, V>::operator==(self_type const &that) const {
-  return _spot == that._spot && _limit == that._limit;
-}
-
-template <typename X, typename V>
-bool
-TransformView<X, V>::operator!=(self_type const &that) const {
-  return _spot != that._spot || _limit != that._limit;
-}
-
-/** Create a transformed view of a source.
- *
- * @tparam X The transform functor type.
- * @tparam V The source type.
- * @param xf The transform.
- * @param src The view source.
- * @return A @c TransformView that applies @a xf to @a src.
- */
-template <typename X, typename V>
-TransformView<X, V>
-transform_view_of(X const &xf, V const &src) {
-  return TransformView<X, V>(xf, src);
-}
-
-/** Identity transform view.
- *
- * @tparam V The source type.
- *
- * This is a transform that returns the input unmodified. This is convenient when a transform is
- * required in general but not in all cases.
- */
-template <typename V> class TransformView<void, V> {
-  using self_type = TransformView; ///< Self reference type.
-  /// Iterator over source, for internal use.
-  using source_iterator = decltype(V{}.begin());
-
-public:
-  using source_view_type  = V; ///< Export source view type.
-  using source_value_type = std::remove_reference_t<decltype(*source_iterator{})>;
-  /// Result type of calling the transform on an element of the source view.
-  using value_type = source_value_type;
-  /// This class serves as its own iterator.
-  using iterator = self_type;
-
-  /** Construct identity transform view from @a v.
-   *
-   * @param v Source view.
-   */
-  TransformView(source_view_type const &v) : _spot(v.begin()), _limit(v.end()) {}
-
-  /// Copy constructor.
-  TransformView(self_type const &that) = default;
-  /// Move constructor.
-  TransformView(self_type &&that) = default;
-
-  /// Copy assignment.
-  self_type &operator=(self_type const &that) = default;
-  /// Move assignment.
-  self_type &operator=(self_type &&that) = default;
-
-  /// Equality.
-  bool operator==(self_type const &that) const;
-  /// Inequality.
-  bool operator!=(self_type const &that) const;
-
-  /// Get the current element.
-  value_type operator*() const;
-
-  /// Move to next element.
-  self_type & operator++();
-
-  /// Move to next element.
-  self_type operator++(int);
-
-  /// Check if view is empty.
-  bool empty() const;
-
-  /// Check if bool is not empty.
-  explicit operator bool() const;
-
-  /// Iterator to first transformed character.
-  iterator begin() const;
-  /// Iterator past last transformed character.
-  iterator end() const;
-
-protected:
-  source_iterator _spot;  ///< Current location.
-  source_iterator _limit; ///< End marker.
-
-  /// Special constructor for making an empty instance to serve as the @c end iterator.
-  explicit TransformView(source_iterator && limit) : _spot(limit), _limit(limit) {}
-};
-
-template <typename V>
-auto
-TransformView<void, V>::operator*() const -> value_type {
-  return *_spot;
-}
-
-template <typename V>
-auto
-TransformView<void, V>::operator++() -> self_type & {
-  ++_spot;
-  return *this;
-}
-
-template <typename V>
-auto
-TransformView<void, V>::operator++(int) -> self_type {
-  auto zret{*this};
-  ++*this;
-  return zret;
-}
-
-template <typename V>
-bool
-TransformView<void, V>::operator==(const self_type &that) const {
-  return _spot == that._spot && _limit == that._limit;
-}
-
-template <typename V>
-bool
-TransformView<void, V>::operator!=(const self_type &that) const {
-  return _spot != that._spot || _limit != that._limit;
-}
-
-template <typename V>
-bool
-TransformView<void, V>::empty() const {
-  return _spot == _limit;
-}
-
-template <typename V>
-TransformView<void, V>::operator bool() const {
-  return _spot != _limit;
-}
-
-template <typename V>
-auto TransformView<void, V>::begin() const -> self_type { return *this; }
-
-template <typename V>
-auto TransformView<void, V>::end() const -> self_type { return self_type{_limit}; }
-
-/// @cond INTERNAL_DETAIL
-// Capture @c void transforms and make them identity transforms.
-template <typename V>
-TransformView<void, V>
-transform_view_of(V const &v) {
-  return TransformView<void, V>(v);
-}
-
-/// @endcond
-
-/** User literals for TextView.
- *
- * - _tv : TextView
- * - _sv : std::string_view
- */
-namespace literals {
-/** Literal constructor for @c std::string_view.
- *
- * @param s The source string.
- * @param n Size of the source string.
- * @return A @c string_view
- *
- * @internal This is provided because the STL one does not support @c constexpr which seems
- * rather bizarre to me, but there it is. Update: this depends on the version of the compiler,
- * so hopefully someday this can be removed.
- */
-constexpr std::string_view operator"" _sv(const char *s, size_t n) {
-  return {s, n};
-}
-
-/** Literal constructor for @c swoc::TextView.
- *
- * @param s The source string.
- * @param n Size of the source string.
- * @return A @c string_view
- *
- * @internal This is provided because the STL one does not support @c constexpr which seems
- * rather bizarre to me, but there it is. Update: this depends on the version of the compiler,
- * so hopefully someday this can be removed.
- */
-constexpr swoc::TextView operator"" _tv(const char *s, size_t n) {
-  return {s, n};
-}
-} // namespace literals
-
-}} // namespace swoc::SWOC_VERSION_NS
-
-namespace std {
+    /** Literal constructor for @c swoc::TextView.
+     *
+     * @param s The source string.
+     * @param n Size of the source string.
+     * @return A @c string_view
+     *
+     * @internal This is provided because the STL one does not support @c constexpr which seems
+     * rather bizarre to me, but there it is. Update: this depends on the version of the compiler,
+     * so hopefully someday this can be removed.
+     */
+    constexpr swoc::TextView
+    operator"" _tv(const char *s, size_t n)
+    {
+      return {s, n};
+    }
+  } // namespace literals
+
+} // namespace SWOC_VERSION_NS
+} // namespace swoc
+
+namespace std
+{
 /// Write the contents of @a view to the stream @a os.
 ostream &operator<<(ostream &os, const swoc::TextView &view);
 
@@ -2048,12 +2196,16 @@ template <typename X, typename V> struct iterator_traits<swoc::TransformView<X, 
 
 template <> struct hash<swoc::TextView> {
   static constexpr hash<string_view> super_hash{};
-  size_t operator()(swoc::TextView const& s) const { return super_hash(s); }
+  size_t
+  operator()(swoc::TextView const &s) const
+  {
+    return super_hash(s);
+  }
 };
 /// @endcond
 
 } // namespace std
 
 #if __GNUC__ == 11
-#  pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
 #endif

--- a/code/include/swoc/Vectray.h
+++ b/code/include/swoc/Vectray.h
@@ -17,417 +17,461 @@
 #include <swoc/MemSpan.h>
 #include <swoc/swoc_meta.h>
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
 
-/** Vectray provides a combination of static and dynamic storage modeled as an array.
- *
- * @tparam T Type of elements in the array.
- * @tparam N Number of statically allocated elements.
- * @tparam A Allocator.
- *
- * The goal is to provide static storage for the common case, avoiding memory allocation, while
- * still handling exceptional cases that need more storage. A common case is for @a N == 1 where
- * there is almost always a single value, but it is possible to have multiple values. @c Vectray
- * makes the single value case require no allocation while transparently handling the multiple
- * value case.
- *
- * The interface is designed to mimic that of @c std::vector.
- */
-template < typename T, size_t N, class A = std::allocator<T> >
-class Vectray {
-  using self_type = Vectray; ///< Self reference type.
-  using vector_type = std::vector<T, A>; ///< Internal dynamic storage type.
+  /** Vectray provides a combination of static and dynamic storage modeled as an array.
+   *
+   * @tparam T Type of elements in the array.
+   * @tparam N Number of statically allocated elements.
+   * @tparam A Allocator.
+   *
+   * The goal is to provide static storage for the common case, avoiding memory allocation, while
+   * still handling exceptional cases that need more storage. A common case is for @a N == 1 where
+   * there is almost always a single value, but it is possible to have multiple values. @c Vectray
+   * makes the single value case require no allocation while transparently handling the multiple
+   * value case.
+   *
+   * The interface is designed to mimic that of @c std::vector.
+   */
+  template <typename T, size_t N, class A = std::allocator<T>> class Vectray
+  {
+    using self_type   = Vectray;           ///< Self reference type.
+    using vector_type = std::vector<T, A>; ///< Internal dynamic storage type.
 
-public: // STL compliance types.
-  using value_type = T; ///< Element type for container.
-  using reference = std::remove_reference<T>&; ///< Reference to element.
-  using const_reference = std::remove_reference<T> const&; ///< Reference to constant element.
-  using pointer = std::remove_reference<T>*; ///< Pointer to element.
-  using const_pointer = std::remove_reference<T> const*; ///< Pointer to constant element.
-  using allocator_type = A; ///< Dynamic storage allocator.
-  using size_type = typename vector_type::size_type; ///< Type for element count.
-  using difference_type = typename vector_type::difference_type; ///< Iterator difference.
-  using iterator = typename swoc::MemSpan<T>::iterator; ///< Element iteration.
-  using const_iterator = typename swoc::MemSpan<const T>::iterator; ///< Constant element iteration.
-  // Need to add reverse iterators - @c reverse_iterator and @c const_reverse_iterator
+  public:                                                              // STL compliance types.
+    using value_type      = T;                                         ///< Element type for container.
+    using reference       = std::remove_reference<T> &;                ///< Reference to element.
+    using const_reference = std::remove_reference<T> const &;          ///< Reference to constant element.
+    using pointer         = std::remove_reference<T> *;                ///< Pointer to element.
+    using const_pointer   = std::remove_reference<T> const *;          ///< Pointer to constant element.
+    using allocator_type  = A;                                         ///< Dynamic storage allocator.
+    using size_type       = typename vector_type::size_type;           ///< Type for element count.
+    using difference_type = typename vector_type::difference_type;     ///< Iterator difference.
+    using iterator        = typename swoc::MemSpan<T>::iterator;       ///< Element iteration.
+    using const_iterator  = typename swoc::MemSpan<const T>::iterator; ///< Constant element iteration.
+    // Need to add reverse iterators - @c reverse_iterator and @c const_reverse_iterator
 
-  /// Internal (fixed) storage.
-  struct FixedStore {
-    std::array<std::byte, sizeof(T) * N> _raw; ///< Raw memory for element storage.
-    size_t _count = 0; ///< Number of valid elements.
-    allocator_type _a; ///< Allocator instance - used for construction.
+    /// Internal (fixed) storage.
+    struct FixedStore {
+      std::array<std::byte, sizeof(T) * N> _raw; ///< Raw memory for element storage.
+      size_t _count = 0;                         ///< Number of valid elements.
+      allocator_type _a;                         ///< Allocator instance - used for construction.
 
-    FixedStore() = default; ///< Default construct - empty.
+      FixedStore() = default; ///< Default construct - empty.
 
-    /** Construct with specific allocator @a a.
+      /** Construct with specific allocator @a a.
+       *
+       * @param a Allocator.
+       */
+      explicit FixedStore(allocator_type const &a) : _a(a) {}
+
+      ~FixedStore();
+
+      /// @return A span containing the valid elements.
+      MemSpan<T> span();
+
+      /// @return A pointer to the data.
+      T *data();
+
+      /// @return A pointer to the data.
+      T const *data() const;
+    };
+
+    using DynamicStore = vector_type; ///< Dynamic (heap) storage.
+
+    /// Element access.
+    using span = swoc::MemSpan<T>;
+    /// Constant element access.
+    using const_span = swoc::MemSpan<T const>;
+
+  public:
+    /// Default constructor, construct an empty container.
+    Vectray();
+    /// Destructor - destructs all contained elements.
+    /// @internal The internal store takes care of the details.
+    ~Vectray() = default;
+
+    /// Construct empty instance with allocator.
+    constexpr explicit Vectray(allocator_type const &a) : _store(std::in_place_type_t<FixedStore>{}, a) {}
+
+    /** Construct with @a n default constructed elements.
      *
-     * @param a Allocator.
+     * @param n Number of elements.
+     * @param alloc Allocator (optional - default constructed if not a parameter).
      */
-    explicit FixedStore(allocator_type const& a) : _a(a) {}
+    explicit Vectray(size_type n, allocator_type const &alloc = allocator_type{});
 
-    ~FixedStore();
+    /// Move constructor for difference static sized instance.
+    template <size_t M> Vectray(Vectray<T, M, A> &&that);
 
-    /// @return A span containing the valid elements.
-    MemSpan<T> span();
+    /// Move constructor.
+    Vectray(self_type &&that, allocator_type const &a);
+
+    /// @return The number of elements in the container.
+    size_type size() const;
 
     /// @return A pointer to the data.
-    T * data();
+    T *data();
 
     /// @return A pointer to the data.
-    T const * data() const;
+    T const *data() const;
+
+    /// @return @c true if no valid elements, @c false if at least one valid element.
+    bool empty() const;
+
+    /// Implicitly convert to a @c MemSpan.
+    operator span() { return this->items(); }
+    /// Implicitly convert to a @c MemSpan.
+    operator const_span() const { return this->items(); }
+
+    /** Index operator.
+     *
+     * @param idx Index of element.
+     * @return A reference to the element.
+     */
+    T &operator[](size_type idx);
+
+    /** Index operator (const).
+     *
+     * @param idx Index of element.
+     * @return A @c const reference to the element.
+     */
+    T const &operator[](size_type idx) const;
+
+    /// @return A reference to the first element.
+    T const &
+    front() const
+    {
+      return (*this)[0];
+    }
+
+    /// @return A reference to the first element.
+    T &
+    front()
+    {
+      return (*this)[0];
+    }
+
+    /// @return A reference to the last element.
+    T const &
+    back() const
+    {
+      return (*this)[this->size() - 1];
+    }
+
+    /// @return A reference to the last element.
+    T &
+    back()
+    {
+      return (*this)[this->size() - 1];
+    }
+    /** Append an element by copy.
+     *
+     * @param t Element to add.
+     * @return @a this.
+     */
+    self_type &push_back(T const &t);
+
+    /** Append an element by move.
+     *
+     * @param t Element to add.
+     * @return @a this.
+     */
+    self_type &push_back(T &&t);
+
+    /** Append an element by direct construction.
+     *
+     * @tparam Args Constructor parameter types.
+     * @param args Constructor arguments.
+     * @return @a this
+     */
+    template <typename... Args> self_type &emplace_back(Args &&...args);
+
+    /** Remove an element from the end of the current elements.
+     *
+     * @return @a this.
+     */
+    self_type &pop_back();
+
+    /// Iterator for first element.
+    const_iterator begin() const;
+
+    /// Iterator past last element.
+    const_iterator end() const;
+
+    /// Iterator for last element.
+    iterator begin();
+
+    /// Iterator past last element.
+    iterator end();
+
+    /// Force at internal storage to hold at least @a n items.
+    void reserve(size_type n);
+
+  protected:
+    /// Content storage.
+    /// @note This is constructed as fixed but can change to dynamic. It can never change back.
+    std::variant<FixedStore, DynamicStore> _store;
+
+    static constexpr auto FIXED   = 0; ///< Variant index for fixed storage.
+    static constexpr auto DYNAMIC = 1; ///< Variant index for dynamic storage.
+
+    /// Get the span of the valid items.
+    span items();
+    /// Get the span of the valid items.
+    const_span items() const;
+
+    /// Default size to reserve in the vector when switching to dynamic.
+    static constexpr size_type BASE_DYNAMIC_SIZE = (7 * N) / 5;
+
+    /** Transfer from fixed storage to dynamic storage.
+     *
+     * @param rN Numer of elements of storage to reserve in the vector.
+     *
+     * @note Must be called at most once for any instance.
+     */
+    void transfer(size_type rN = BASE_DYNAMIC_SIZE);
   };
 
-  using DynamicStore = vector_type; ///< Dynamic (heap) storage.
+  // --- Implementation ---
 
-  /// Element access.
-  using span = swoc::MemSpan<T>;
-  /// Constant element access.
-  using const_span = swoc::MemSpan<T const>;
+  template <typename T, size_t N, typename A> Vectray<T, N, A>::Vectray() {}
 
-public:
-  /// Default constructor, construct an empty container.
-  Vectray();
-  /// Destructor - destructs all contained elements.
-  /// @internal The internal store takes care of the details.
-  ~Vectray() = default;
-
-  /// Construct empty instance with allocator.
-  constexpr explicit Vectray(allocator_type const& a) : _store(std::in_place_type_t<FixedStore>{}, a) {}
-
-  /** Construct with @a n default constructed elements.
-   *
-   * @param n Number of elements.
-   * @param alloc Allocator (optional - default constructed if not a parameter).
-   */
-  explicit Vectray(size_type n, allocator_type const& alloc = allocator_type{});
-
-  /// Move constructor for difference static sized instance.
-  template < size_t M > Vectray(Vectray<T, M, A> && that);
-
-  /// Move constructor.
-  Vectray(self_type && that, allocator_type const& a);
-
-  /// @return The number of elements in the container.
-  size_type size() const;
-
-  /// @return A pointer to the data.
-  T * data();
-
-  /// @return A pointer to the data.
-  T const * data() const;
-
-  /// @return @c true if no valid elements, @c false if at least one valid element.
-  bool empty() const;
-
-  /// Implicitly convert to a @c MemSpan.
-  operator span () { return this->items(); }
-  /// Implicitly convert to a @c MemSpan.
-  operator const_span () const { return this->items(); }
-
-  /** Index operator.
-   *
-   * @param idx Index of element.
-   * @return A reference to the element.
-   */
-  T& operator[](size_type idx);
-
-  /** Index operator (const).
-   *
-   * @param idx Index of element.
-   * @return A @c const reference to the element.
-   */
-  T const& operator[](size_type idx) const;
-
-  /// @return A reference to the first element.
-  T const& front() const {
-    return (*this)[0];
+  template <typename T, size_t N, class A> Vectray<T, N, A>::Vectray(Vectray::size_type n, allocator_type const &alloc) : Vectray()
+  {
+    this->reserve(n);
+    while (n-- > 0) {
+      this->emplace_back();
+    }
   }
 
-  /// @return A reference to the first element.
-  T & front()  {
-    return (*this)[0];
-  }
-
-  /// @return A reference to the last element.
-  T const& back() const {
-    return (*this)[this->size()-1];
-  }
-
-  /// @return A reference to the last element.
-  T & back()  {
-    return (*this)[this->size()-1];
-  }
-  /** Append an element by copy.
-   *
-   * @param t Element to add.
-   * @return @a this.
-   */
-  self_type& push_back(T const& t);
-
-  /** Append an element by move.
-   *
-   * @param t Element to add.
-   * @return @a this.
-   */
-  self_type& push_back(T && t);
-
-  /** Append an element by direct construction.
-   *
-   * @tparam Args Constructor parameter types.
-   * @param args Constructor arguments.
-   * @return @a this
-   */
-  template < typename ... Args> self_type & emplace_back(Args && ... args);
-
-  /** Remove an element from the end of the current elements.
-   *
-   * @return @a this.
-   */
-  self_type& pop_back();
-
-  /// Iterator for first element.
-  const_iterator begin() const;
-
-  /// Iterator past last element.
-  const_iterator end() const;
-
-  /// Iterator for last element.
-  iterator begin();
-
-  /// Iterator past last element.
-  iterator end();
-
-  /// Force at internal storage to hold at least @a n items.
-  void reserve(size_type n);
-
-protected:
-  /// Content storage.
-  /// @note This is constructed as fixed but can change to dynamic. It can never change back.
-  std::variant<FixedStore, DynamicStore> _store;
-
-  static constexpr auto FIXED = 0; ///< Variant index for fixed storage.
-  static constexpr auto DYNAMIC = 1; ///< Variant index for dynamic storage.
-
-  /// Get the span of the valid items.
-  span items();
-  /// Get the span of the valid items.
-  const_span items() const;
-
-  /// Default size to reserve in the vector when switching to dynamic.
-  static constexpr size_type BASE_DYNAMIC_SIZE = (7 * N) / 5;
-
-
-  /** Transfer from fixed storage to dynamic storage.
-   *
-   * @param rN Numer of elements of storage to reserve in the vector.
-   *
-   * @note Must be called at most once for any instance.
-   */
-  void transfer(size_type rN = BASE_DYNAMIC_SIZE);
-};
-
-// --- Implementation ---
-
-template<typename T, size_t N, typename A>
-Vectray<T,N,A>::Vectray() {}
-
-template<typename T, size_t N, class A>
-Vectray<T, N, A>::Vectray(Vectray::size_type n, allocator_type const& alloc) : Vectray() {
-  this->reserve(n);
-  while (n-- > 0) {
-    this->emplace_back();
-  }
-}
-
-template <typename T, size_t N, class A> template <size_t M> Vectray<T, N, A>::Vectray(Vectray<T, M, A> &&that) {
-  // If @a that is already a vector, always move that here.
-  if (DYNAMIC == that._store.index()) {
-    _store = std::move(std::get<DYNAMIC>(that._store));
-  } else {
-    auto span = std::get<FIXED>(that._store).span();
-    if (span.size() > N) {
-
+  template <typename T, size_t N, class A> template <size_t M> Vectray<T, N, A>::Vectray(Vectray<T, M, A> &&that)
+  {
+    // If @a that is already a vector, always move that here.
+    if (DYNAMIC == that._store.index()) {
+      _store = std::move(std::get<DYNAMIC>(that._store));
     } else {
-      for ( auto && item : span ) {
-        this->template emplace_back(std::move(item));
+      auto span = std::get<FIXED>(that._store).span();
+      if (span.size() > N) {
+      } else {
+        for (auto &&item : span) {
+          this->template emplace_back(std::move(item));
+        }
       }
     }
   }
-}
 
-template <typename T, size_t N, class A> Vectray<T, N, A>::FixedStore::~FixedStore() {
-  for ( auto & item : this->span() ) {
-    std::destroy_at(std::addressof(item));
-  }
-}
-
-template<typename T, size_t N, class A>
-MemSpan<T> Vectray<T, N, A>::FixedStore::span() {
-  return MemSpan<std::byte>(_raw).template rebind<T>();
-}
-
-template<typename T, size_t N, class A>
-T * Vectray<T, N, A>::FixedStore::data() {
-  return reinterpret_cast<T*>(_raw.data());
-}
-
-template<typename T, size_t N, class A>
-T const * Vectray<T, N, A>::FixedStore::data() const {
-  return reinterpret_cast<T*>(_raw.data());
-}
-
-template<typename T, size_t N, typename A>
-T& Vectray<T,N,A>::operator[](size_type idx) {
-  return this->items()[idx];
-}
-
-template<typename T, size_t N, typename A>
-T const& Vectray<T,N,A>::operator[](size_type idx) const {
-  return this->items[idx];
-}
-
-template<typename T, size_t N, typename A>
-auto Vectray<T,N,A>::push_back(const T& t) -> self_type& {
-  std::visit(swoc::meta::vary{
-      [&](FixedStore& fs) -> void {
-        if (fs._count < N) {
-          new(reinterpret_cast<T*>(fs._raw.data()) + fs._count++) T(t); // A::traits ?
-        } else {
-          this->transfer();
-          std::get<DYNAMIC>(_store).push_back(t);
-        }
-      }
-      , [&](DynamicStore& ds) -> void {
-        ds.push_back(t);
-      }
-    }, _store);
-  return *this;
-}
-
-template<typename T, size_t N, typename A>
-auto Vectray<T,N,A>::push_back(T && t) -> self_type& {
-  std::visit(swoc::meta::vary{
-      [&](FixedStore& fs) -> void {
-        if (fs._count < N) {
-          new(reinterpret_cast<T*>(fs._raw.data()) + fs._count++) T(std::move(t)); // A::traits ?
-        } else {
-          this->transfer();
-          std::get<DYNAMIC>(_store).push_back(std::move(t));
-        }
-      }
-      , [&](DynamicStore& ds) -> void {
-        ds.push_back(std::move(t));
-      }
-    }, _store);
-  return *this;
-}
-
-template<typename T, size_t N, class A>
-template<typename... Args>
-typename Vectray<T,N,A>::self_type & Vectray<T, N, A>::emplace_back(Args && ... args) {
-  if (_store.index() == FIXED) {
-    auto& fs{std::get<FIXED>(_store)};
-    if (fs._count < N) {
-      new(reinterpret_cast<T*>(fs._raw.data()) + fs._count++) T(std::forward<Args>(args)...); // A::traits ?
-      return *this;
+  template <typename T, size_t N, class A> Vectray<T, N, A>::FixedStore::~FixedStore()
+  {
+    for (auto &item : this->span()) {
+      std::destroy_at(std::addressof(item));
     }
-    this->transfer(); // transfer to dynamic and fall through to add item.
   }
-  std::get<DYNAMIC>(_store).emplace_back(std::forward<Args>(args)...);
-  return *this;
-}
 
-template<typename T, size_t N, class A>
-auto Vectray<T, N, A>::pop_back() -> self_type & {
-  std::visit(swoc::meta::vary{
-               [&](FixedStore& fs) -> void { std::destroy_at(fs.span()[--fs._count]); }
-             , [&](DynamicStore& ds) -> void { ds.pop_back(); }
-             }, _store);
-  return *this;
-}
-
-template<typename T, size_t N, typename A>
-auto Vectray<T,N,A>::size() const -> size_type {
-  return std::visit(swoc::meta::vary{
-        [](FixedStore const& fs) { return fs._count; }
-      , [](DynamicStore const& ds) { return ds.size(); }
-  }, _store);
-}
-
-template<typename T, size_t N, typename A>
-bool Vectray<T,N,A>::empty() const {
-  return std::visit(swoc::meta::vary{
-           [](FixedStore const& fs) { return fs._count == 0; }
-         , [](DynamicStore const& ds) { return ds.empty(); }
-         }, _store);
-}
-
-// --- iterators
-template<typename T, size_t N, typename A>
-auto  Vectray<T,N,A>::begin() const -> const_iterator { return this->items().begin(); }
-
-template<typename T, size_t N, typename A>
-auto Vectray<T,N,A>::end() const -> const_iterator { return this->items().end(); }
-
-template<typename T, size_t N, typename A>
-auto  Vectray<T,N,A>::begin() -> iterator { return this->items().begin(); }
-
-template<typename T, size_t N, typename A>
-auto Vectray<T,N,A>::end() -> iterator { return this->items().end(); }
-// --- iterators
-
-template<typename T, size_t N, class A>
-void Vectray<T, N, A>::transfer(size_type rN) {
-  DynamicStore tmp{std::get<FIXED>(_store)._a};
-  tmp.reserve(rN);
-
-  for (auto&& item : this->items()) {
-    tmp.emplace_back(std::move(item)); // move if supported, copy if not.
+  template <typename T, size_t N, class A>
+  MemSpan<T>
+  Vectray<T, N, A>::FixedStore::span()
+  {
+    return MemSpan<std::byte>(_raw).template rebind<T>();
   }
-  // Fixed elements destroyed here, by variant.
-  _store = std::move(tmp);
-}
 
-template<typename T, size_t N, class A>
-auto Vectray<T, N, A>::items() const -> const_span {
-  return std::visit(swoc::meta::vary{
-      [](FixedStore const& fs) { fs.span(); }
-      , [](DynamicStore const& ds) { return const_span(ds.data(), ds.size()); }
-  }, _store);
-}
-
-template<typename T, size_t N, class A>
-T * Vectray<T, N, A>::data() {
-  return std::visit(swoc::meta::vary{
-                      [](FixedStore const& fs) { fs.data(); }
-                      , [](DynamicStore const& ds) { return ds.data(); }
-                    }, _store);
-}
-
-template<typename T, size_t N, class A>
-T const * Vectray<T, N, A>::data() const {
-  return std::visit(swoc::meta::vary{
-                      [](FixedStore const& fs) { fs.data(); }
-                      , [](DynamicStore const& ds) { return ds.data(); }
-                    }, _store);
-}
-
-template<typename T, size_t N, class A>
-auto Vectray<T, N, A>::items() -> span {
-  return std::visit(swoc::meta::vary{
-      [](FixedStore & fs) { return fs.span(); }
-      , [](DynamicStore & ds) { return span(ds.data(), ds.size()); }
-  }, _store);
-}
-
-template<typename T, size_t N, class A>
-void Vectray<T, N, A>::reserve(Vectray::size_type n) {
-  if (DYNAMIC == _store.index()) {
-    std::get<DYNAMIC>(_store).reserve(n);
-  } else if (n > N) {
-    this->transfer(n);
+  template <typename T, size_t N, class A>
+  T *
+  Vectray<T, N, A>::FixedStore::data()
+  {
+    return reinterpret_cast<T *>(_raw.data());
   }
-}
 
-}} // namespace swoc
+  template <typename T, size_t N, class A>
+  T const *
+  Vectray<T, N, A>::FixedStore::data() const
+  {
+    return reinterpret_cast<T *>(_raw.data());
+  }
 
+  template <typename T, size_t N, typename A>
+  T &
+  Vectray<T, N, A>::operator[](size_type idx)
+  {
+    return this->items()[idx];
+  }
+
+  template <typename T, size_t N, typename A>
+  T const &
+  Vectray<T, N, A>::operator[](size_type idx) const
+  {
+    return this->items[idx];
+  }
+
+  template <typename T, size_t N, typename A>
+  auto
+  Vectray<T, N, A>::push_back(const T &t) -> self_type &
+  {
+    std::visit(swoc::meta::vary{[&](FixedStore &fs) -> void {
+                                  if (fs._count < N) {
+                                    new (reinterpret_cast<T *>(fs._raw.data()) + fs._count++) T(t); // A::traits ?
+                                  } else {
+                                    this->transfer();
+                                    std::get<DYNAMIC>(_store).push_back(t);
+                                  }
+                                },
+                                [&](DynamicStore &ds) -> void { ds.push_back(t); }},
+               _store);
+    return *this;
+  }
+
+  template <typename T, size_t N, typename A>
+  auto
+  Vectray<T, N, A>::push_back(T &&t) -> self_type &
+  {
+    std::visit(swoc::meta::vary{[&](FixedStore &fs) -> void {
+                                  if (fs._count < N) {
+                                    new (reinterpret_cast<T *>(fs._raw.data()) + fs._count++) T(std::move(t)); // A::traits ?
+                                  } else {
+                                    this->transfer();
+                                    std::get<DYNAMIC>(_store).push_back(std::move(t));
+                                  }
+                                },
+                                [&](DynamicStore &ds) -> void { ds.push_back(std::move(t)); }},
+               _store);
+    return *this;
+  }
+
+  template <typename T, size_t N, class A>
+  template <typename... Args>
+  typename Vectray<T, N, A>::self_type &
+  Vectray<T, N, A>::emplace_back(Args &&...args)
+  {
+    if (_store.index() == FIXED) {
+      auto &fs{std::get<FIXED>(_store)};
+      if (fs._count < N) {
+        new (reinterpret_cast<T *>(fs._raw.data()) + fs._count++) T(std::forward<Args>(args)...); // A::traits ?
+        return *this;
+      }
+      this->transfer(); // transfer to dynamic and fall through to add item.
+    }
+    std::get<DYNAMIC>(_store).emplace_back(std::forward<Args>(args)...);
+    return *this;
+  }
+
+  template <typename T, size_t N, class A>
+  auto
+  Vectray<T, N, A>::pop_back() -> self_type &
+  {
+    std::visit(swoc::meta::vary{[&](FixedStore &fs) -> void { std::destroy_at(fs.span()[--fs._count]); },
+                                [&](DynamicStore &ds) -> void { ds.pop_back(); }},
+               _store);
+    return *this;
+  }
+
+  template <typename T, size_t N, typename A>
+  auto
+  Vectray<T, N, A>::size() const -> size_type
+  {
+    return std::visit(
+      swoc::meta::vary{[](FixedStore const &fs) { return fs._count; }, [](DynamicStore const &ds) { return ds.size(); }}, _store);
+  }
+
+  template <typename T, size_t N, typename A>
+  bool
+  Vectray<T, N, A>::empty() const
+  {
+    return std::visit(
+      swoc::meta::vary{[](FixedStore const &fs) { return fs._count == 0; }, [](DynamicStore const &ds) { return ds.empty(); }},
+      _store);
+  }
+
+  // --- iterators
+  template <typename T, size_t N, typename A>
+  auto
+  Vectray<T, N, A>::begin() const -> const_iterator
+  {
+    return this->items().begin();
+  }
+
+  template <typename T, size_t N, typename A>
+  auto
+  Vectray<T, N, A>::end() const -> const_iterator
+  {
+    return this->items().end();
+  }
+
+  template <typename T, size_t N, typename A>
+  auto
+  Vectray<T, N, A>::begin() -> iterator
+  {
+    return this->items().begin();
+  }
+
+  template <typename T, size_t N, typename A>
+  auto
+  Vectray<T, N, A>::end() -> iterator
+  {
+    return this->items().end();
+  }
+  // --- iterators
+
+  template <typename T, size_t N, class A>
+  void
+  Vectray<T, N, A>::transfer(size_type rN)
+  {
+    DynamicStore tmp{std::get<FIXED>(_store)._a};
+    tmp.reserve(rN);
+
+    for (auto &&item : this->items()) {
+      tmp.emplace_back(std::move(item)); // move if supported, copy if not.
+    }
+    // Fixed elements destroyed here, by variant.
+    _store = std::move(tmp);
+  }
+
+  template <typename T, size_t N, class A>
+  auto
+  Vectray<T, N, A>::items() const -> const_span
+  {
+    return std::visit(swoc::meta::vary{[](FixedStore const &fs) { fs.span(); },
+                                       [](DynamicStore const &ds) { return const_span(ds.data(), ds.size()); }},
+                      _store);
+  }
+
+  template <typename T, size_t N, class A>
+  T *
+  Vectray<T, N, A>::data()
+  {
+    return std::visit(swoc::meta::vary{[](FixedStore const &fs) { fs.data(); }, [](DynamicStore const &ds) { return ds.data(); }},
+                      _store);
+  }
+
+  template <typename T, size_t N, class A>
+  T const *
+  Vectray<T, N, A>::data() const
+  {
+    return std::visit(swoc::meta::vary{[](FixedStore const &fs) { fs.data(); }, [](DynamicStore const &ds) { return ds.data(); }},
+                      _store);
+  }
+
+  template <typename T, size_t N, class A>
+  auto
+  Vectray<T, N, A>::items() -> span
+  {
+    return std::visit(
+      swoc::meta::vary{[](FixedStore &fs) { return fs.span(); }, [](DynamicStore &ds) { return span(ds.data(), ds.size()); }},
+      _store);
+  }
+
+  template <typename T, size_t N, class A>
+  void
+  Vectray<T, N, A>::reserve(Vectray::size_type n)
+  {
+    if (DYNAMIC == _store.index()) {
+      std::get<DYNAMIC>(_store).reserve(n);
+    } else if (n > N) {
+      this->transfer(n);
+    }
+  }
+
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/include/swoc/bwf_base.h
+++ b/code/include/swoc/bwf_base.h
@@ -27,1308 +27,1412 @@
 #include "swoc/BufferWriter.h"
 #include "swoc/swoc_meta.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
-namespace bwf {
-/** Parsed version of a format specifier.
- *
- * Literals are represented as an instance of this class, with the type set to
- * @c LITERAL_TYPE and the literal text in the @a _ext field.
- */
-struct Spec {
-  using self_type = Spec; ///< Self reference type.
-
-  static constexpr char DEFAULT_TYPE = 'g'; ///< Default format type.
-  static constexpr char INVALID_TYPE = 0;   ///< Type for missing or invalid specifier.
-  static constexpr char LITERAL_TYPE = '"'; ///< Internal type to mark a literal.
-  static constexpr char CAPTURE_TYPE = 1;   ///< Internal type to mark a capture.
-
-  static constexpr char SIGN_ALWAYS = '+'; ///< Always print a sign character.
-  static constexpr char SIGN_NEVER  = ' '; ///< Never print a sign character.
-  static constexpr char SIGN_NEG    = '-'; ///< Print a sign character only for negative values (default).
-
-  /// Constructor a default instance.
-  constexpr Spec() {}
-
-  /// Construct by parsing @a fmt.
-  Spec(const TextView &fmt);
-
-  /// Parse a specifier.
-  /// State is not reset, @a this should be default constructed before calling.
-  bool parse(TextView fmt);
-
-  char _fill = ' ';      ///< Fill character.
-  char _sign = SIGN_NEG; ///< Numeric sign style.
-  /// Flag for how to align the output inside a limited width field.
-  enum class Align : char {
-    NONE,                            ///< No alignment.
-    LEFT,                            ///< Left alignment '<'.
-    RIGHT,                           ///< Right alignment '>'.
-    CENTER,                          ///< Center alignment '^'.
-    SIGN                             ///< Align plus/minus sign before numeric fill. '='
-  } _align           = Align::NONE;  ///< Output field alignment.
-  char _type         = DEFAULT_TYPE; ///< Type / radix indicator.
-  bool _radix_lead_p = false;        ///< Print leading radix indication.
-  // @a _min is unsigned because there's no point in an invalid default, 0 works fine.
-  unsigned int _min = 0;                                        ///< Minimum width.
-  int _prec         = -1;                                       ///< Precision
-  unsigned int _max = std::numeric_limits<unsigned int>::max(); ///< Maximum width
-  int _idx          = -1;                                       ///< Positional "name" of the specification.
-  std::string_view _name;                                       ///< Name of the specification.
-  std::string_view _ext;                                        ///< Extension if provided.
-
-  /// Global default instance for use in situations where a format specifier isn't available.
-  static const self_type DEFAULT;
-
-  /// Validate @a c is a specifier type indicator.
-  static bool is_type(char c);
-
-  /// Check if the type flag is numeric.
-  static bool is_numeric_type(char c);
-
-  /// Check if the type is an upper case variant.
-  static bool is_upper_case_type(char c);
-
-  /// Check if the type @a in @a this is numeric.
-  bool has_numeric_type() const;
-
-  /// Check if the type in @a this is an upper case variant.
-  bool has_upper_case_type() const;
-
-  /// Check if the type is a raw pointer.
-  bool has_pointer_type() const;
-
-  /// Check if the type is valid.
-  bool has_valid_type() const;
-
-protected:
-  /// Validate character is alignment character and return the appropriate enum value.
-  Align align_of(char c);
-
-  /// Validate is sign indicator.
-  bool is_sign(char c);
-
-  /// Handrolled initialization the character syntactic property data.
-  static const struct Property {
-    Property(); ///< Default constructor, creates initialized flag set.
-    /// Flag storage, indexed by character value.
-    uint8_t _data[0x100]{};
-    /// Flag mask values.
-    static constexpr uint8_t ALIGN_MASK        = 0x0F; ///< Alignment type.
-    static constexpr uint8_t TYPE_CHAR         = 0x10; ///< A valid type character.
-    static constexpr uint8_t UPPER_TYPE_CHAR   = 0x20; ///< Upper case flag.
-    static constexpr uint8_t NUMERIC_TYPE_CHAR = 0x40; ///< Numeric output.
-    static constexpr uint8_t SIGN_CHAR         = 0x80; ///< Is sign character.
-  } _prop; ///< Character property map.
-};
-
-/** Format string support.
- *
- * This contains the parsing logic for format strings and also serves as the type for pre-compiled
- * format string.
- *
- * When used by the print formatting logic, there is an abstraction layer, "extraction", which
- * performs the equivalent of the @c parse method. This allows the formatting to treat
- * pre-compiled or immediately parsed format strings the same. It also enables formatted print
- * support for any parser that can deliver literals and @c Spec instances.
- */
-struct Format {
-  using self_type = Format; ///< Self reference type.
-
-  /// Empty format.
-  Format() = default;
-
-  /// Construct from a format string @a fmt.
-  Format(TextView fmt);
-
-  /// Move constructor.
-  Format(self_type && that) = default;
-  /// No copy
-  Format(self_type const&) = delete;
-
-  /// Extraction support for TextView.
-  struct TextViewExtractor {
-    TextView _fmt; ///< Format string.
-
-    /// @return @c true if more format string, @c false if none.
-    explicit operator bool() const;
-
-    /** Extract next formatting elements.
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  namespace bwf
+  {
+    /** Parsed version of a format specifier.
      *
-     * @param literal_v [out] The next literal.
-     * @param spec [out] The next format specifier.
-     * @return @c true if @a spec was filled out, @c false if no specifier was found.
+     * Literals are represented as an instance of this class, with the type set to
+     * @c LITERAL_TYPE and the literal text in the @a _ext field.
      */
-    bool operator()(std::string_view &literal_v, Spec &spec);
+    struct Spec {
+      using self_type = Spec; ///< Self reference type.
 
-    /** Parse elements of a format string.
+      static constexpr char DEFAULT_TYPE = 'g'; ///< Default format type.
+      static constexpr char INVALID_TYPE = 0;   ///< Type for missing or invalid specifier.
+      static constexpr char LITERAL_TYPE = '"'; ///< Internal type to mark a literal.
+      static constexpr char CAPTURE_TYPE = 1;   ///< Internal type to mark a capture.
 
-        @param fmt The format string [in|out]
-        @param literal A literal if found
-        @param specifier A specifier if found (less enclosing braces)
-        @return @c true if a specifier was found, @c false if not.
+      static constexpr char SIGN_ALWAYS = '+'; ///< Always print a sign character.
+      static constexpr char SIGN_NEVER  = ' '; ///< Never print a sign character.
+      static constexpr char SIGN_NEG    = '-'; ///< Print a sign character only for negative values (default).
 
-        Pull off the next literal and/or specifier from @a fmt. The return value distinguishes
-        the case of no specifier found (@c false) or an empty specifier (@c true).
+      /// Constructor a default instance.
+      constexpr Spec() {}
 
-     */
-    static bool parse(TextView &fmt, std::string_view &literal, std::string_view &specifier);
-  };
+      /// Construct by parsing @a fmt.
+      Spec(const TextView &fmt);
 
-  /// Wrap the format string in an extractor.
-  static TextViewExtractor bind(TextView fmt);
+      /// Parse a specifier.
+      /// State is not reset, @a this should be default constructed before calling.
+      bool parse(TextView fmt);
 
-  /// Extraction support for pre-parsed format strings.
-  struct FormatExtractor {
-    MemSpan<Spec const> _fmt; ///< Parsed format string.
-    int _idx = 0;                  ///< Element index.
-    /// @return @c true if more format string, @c false if none.
-    explicit operator bool() const;
+      char _fill = ' ';      ///< Fill character.
+      char _sign = SIGN_NEG; ///< Numeric sign style.
+      /// Flag for how to align the output inside a limited width field.
+      enum class Align : char {
+        NONE,                            ///< No alignment.
+        LEFT,                            ///< Left alignment '<'.
+        RIGHT,                           ///< Right alignment '>'.
+        CENTER,                          ///< Center alignment '^'.
+        SIGN                             ///< Align plus/minus sign before numeric fill. '='
+      } _align           = Align::NONE;  ///< Output field alignment.
+      char _type         = DEFAULT_TYPE; ///< Type / radix indicator.
+      bool _radix_lead_p = false;        ///< Print leading radix indication.
+      // @a _min is unsigned because there's no point in an invalid default, 0 works fine.
+      unsigned int _min = 0;                                        ///< Minimum width.
+      int _prec         = -1;                                       ///< Precision
+      unsigned int _max = std::numeric_limits<unsigned int>::max(); ///< Maximum width
+      int _idx          = -1;                                       ///< Positional "name" of the specification.
+      std::string_view _name;                                       ///< Name of the specification.
+      std::string_view _ext;                                        ///< Extension if provided.
 
-    /** Extract next formatting elements.
+      /// Global default instance for use in situations where a format specifier isn't available.
+      static const self_type DEFAULT;
+
+      /// Validate @a c is a specifier type indicator.
+      static bool is_type(char c);
+
+      /// Check if the type flag is numeric.
+      static bool is_numeric_type(char c);
+
+      /// Check if the type is an upper case variant.
+      static bool is_upper_case_type(char c);
+
+      /// Check if the type @a in @a this is numeric.
+      bool has_numeric_type() const;
+
+      /// Check if the type in @a this is an upper case variant.
+      bool has_upper_case_type() const;
+
+      /// Check if the type is a raw pointer.
+      bool has_pointer_type() const;
+
+      /// Check if the type is valid.
+      bool has_valid_type() const;
+
+    protected:
+      /// Validate character is alignment character and return the appropriate enum value.
+      Align align_of(char c);
+
+      /// Validate is sign indicator.
+      bool is_sign(char c);
+
+      /// Handrolled initialization the character syntactic property data.
+      static const struct Property {
+        Property(); ///< Default constructor, creates initialized flag set.
+        /// Flag storage, indexed by character value.
+        uint8_t _data[0x100]{};
+        /// Flag mask values.
+        static constexpr uint8_t ALIGN_MASK        = 0x0F; ///< Alignment type.
+        static constexpr uint8_t TYPE_CHAR         = 0x10; ///< A valid type character.
+        static constexpr uint8_t UPPER_TYPE_CHAR   = 0x20; ///< Upper case flag.
+        static constexpr uint8_t NUMERIC_TYPE_CHAR = 0x40; ///< Numeric output.
+        static constexpr uint8_t SIGN_CHAR         = 0x80; ///< Is sign character.
+      } _prop;                                             ///< Character property map.
+    };
+
+    /** Format string support.
      *
-     * @param literal_v [out] The next literal.
-     * @param spec [out] The next format specifier.
-     * @return @c true if @a spec was filled out, @c false if no specifier was found.
-     */
-    bool operator()(std::string_view &literal_v, Spec &spec);
-  };
-
-  /// Wrap the format instance in an extractor.
-  FormatExtractor bind() const;
-
-  /// @return @c true if all specifiers are literal.
-  bool is_literal() const;
-
-  using Container = std::vector<Spec>;
-  Container _items; ///< Items from format string.
-
-  using iterator = Container::iterator;
-  using const_iterator = Container::const_iterator;
-
-  iterator begin() { return _items.begin(); }
-  iterator end() { return _items.end(); }
-  const_iterator begin() const { return _items.begin(); }
-  const_iterator end() const { return _items.end(); }
-};
-
-// Name binding - support for having format specifier names.
-
-/** Signature for a functor bound to a name.
- *
- * @param w The output.
- * @param spec The format specifier.
- *
- * The functor is expected to write to @a w based on @a spec.
- */
-using ExternalGeneratorSignature = BufferWriter &(BufferWriter &w, Spec const &spec);
-
-/** Base class for implementing a name binding functor.
- *
- * This expected to be inherited by other classes that provide the name binding service.
- * It does a few small but handy things.
- *
- * - Force a virtual destructor.
- * - Force the implementation of the binding method by declaring it as a pure virtual.
- * - Provide a standard "missing name" method.
- */
-class NameBinding {
-public:
-  virtual ~NameBinding(); ///< Force virtual destructor.
-
-  /** Generate output text for @a name on the output @a w using the format specifier @a spec.
-   * This must match the @c BoundNameSignature type.
-   *
-   * @param w Output stream.
-   * @param spec Parsed format specifier.
-   *
-   * @note The tag name can be found in @c spec._name.
-   *
-   * @return @a w
-   */
-  virtual BufferWriter &operator()(BufferWriter &w, Spec const &spec) const = 0;
-
-protected:
-  /** Standardized missing name method.
-   *
-   * @param w The destination buffer.
-   * @param spec Format specifier, used to determine the invalid name.
-   * @return @a w
-   */
-  static BufferWriter &err_invalid_name(BufferWriter &w, Spec const &spec);
-};
-
-/** An explicitly empty set of bound names.
- *
- * To simplify the overall implementation, a name binding is always required to format output.
- * This class is used in situations where there is no available binding or such names would not be
- * useful. This class with @c throw on any attempt to use a name.
- */
-class NilBinding : public NameBinding {
-public:
-  /// Do name based formatted output.
-  /// This always throws an exception.
-  BufferWriter &operator()(BufferWriter &, Spec const &) const override;
-};
-
-/** Associate generators with names.
- *
- *  @tparam F The function signature for generators in this container.
- *
- * This is a base class used by different types of name containers. It is not expected to be used
- * directly. A subclass should inherit from this by providing a function type @a F that is
- * suitable for the subclass generators.
- */
-template <typename F> class NameMap {
-public:
-  /// Signature for generators.
-  using Generator = std::function<F>;
-protected:
-  using Map = std::unordered_map<std::string_view, Generator>;
-private:
-  using self_type = NameMap; ///< self reference type.
-public:
-
-  /// Construct an empty container.
-  NameMap();
-
-  /// Construct and assign the names and generators in @a list
-  NameMap(std::initializer_list<std::tuple<std::string_view, Generator const &>> list);
-
-  /** Assign the @a generator to the @a name.
-   *
-   * @param name Name associated with the @a generator.
-   * @param generator The generator function.
-   */
-  self_type &assign(std::string_view const &name, Generator const &generator);
-
-  /** Check if a specific name is contained in this mapping.
-   *
-   * @param name Name to check.
-   * @return @c true if present, @c false if not.
-   */
-  bool contains(std::string_view name);
-
-protected:
-  /// Copy @a name in to local storage and return a view of it.
-  std::string_view localize(std::string_view const &name);
-
-  /// Name to name generator.
-  Map _map;              ///< Defined generators.
-  MemArena _arena{1024}; ///< Local name storage.
-};
-
-/** A class to hold external / context-free name bindings.
- *
- * These names access external data and therefore have no context. An externally accessible
- * singleton instance of this is used as the default if no explicit name set is provided. This
- * enables the executable to establish a set of global names to be used.
- */
-class ExternalNames : public NameMap<ExternalGeneratorSignature>, public NameBinding {
-  using self_type  = ExternalNames;                       ///< Self reference type.
-  using super_type = NameMap<ExternalGeneratorSignature>; ///< Super class.
-  using Map        = super_type::Map;                     ///< Inherit from superclass.
-
-public:
-  using super_type::super_type; // import constructors.
-
-  /// The bound accessor is this class.
-  NameBinding const &bind() const;
-
-  /// Bound name access.
-  BufferWriter &operator()(BufferWriter &w, const Spec &spec) const override;
-
-  /// @copydoc NameMap::assign(std::string_view const &name, Generator const &generator)
-};
-
-/** Associate names with context dependent generators.
- *
- * @tparam T The context type. This is used directly. If the context needs to be @c const
- * then this parameter should make that explicit, e.g. @c ContextNames<const Context>. This
- * parameter is accessible via the @c context_type alias.
- *
- * This provides a name binding that also has a local context, provided at the formatting call
- * site. The functors have access to this context and are presumed to use it to generate output.
- * This binding can also contain external generators which do not get access to the context to
- * make it convenient to add external generators as well as context generators.
- *
- * A context functor should have the signature
- * @code
- *   BufferWriter & generator(BufferWriter & w, const Spec & spec, T & context);
- * @endcode
- *
- * @a context will be the context for the binding passed to the formatter.
- *
- * This is used by the formatting logic by calling the @c bind method with a context object.
- */
-template <typename T> class ContextNames : public NameMap<BufferWriter &(BufferWriter &, const Spec &, T &)> {
-private:
-  using self_type  = ContextNames; ///< self reference type.
-  using super_type = NameMap<BufferWriter &(BufferWriter &, const Spec &, T &)>;
-  using Map        = typename super_type::Map;
-
-public:
-  using context_type = T; ///< Export for external convenience.
-  /// Functional type for a generator.
-  using Generator = typename super_type::Generator;
-  /// Signature for an external (context-free) generator.
-  using ExternalGenerator = std::function<ExternalGeneratorSignature>;
-
-  using super_type::super_type; // inherit @c super_type constructors.
-
-  /// Specialized binding for names in an instance of @c ContextNames
-  class Binding : public NameBinding {
-  public:
-    /** Override of virtual method to provide an implementation.
+     * This contains the parsing logic for format strings and also serves as the type for pre-compiled
+     * format string.
      *
-     * @param w Output.
-     * @param spec Format specifier for output.
+     * When used by the print formatting logic, there is an abstraction layer, "extraction", which
+     * performs the equivalent of the @c parse method. This allows the formatting to treat
+     * pre-compiled or immediately parsed format strings the same. It also enables formatted print
+     * support for any parser that can deliver literals and @c Spec instances.
+     */
+    struct Format {
+      using self_type = Format; ///< Self reference type.
+
+      /// Empty format.
+      Format() = default;
+
+      /// Construct from a format string @a fmt.
+      Format(TextView fmt);
+
+      /// Move constructor.
+      Format(self_type &&that) = default;
+      /// No copy
+      Format(self_type const &) = delete;
+
+      /// Extraction support for TextView.
+      struct TextViewExtractor {
+        TextView _fmt; ///< Format string.
+
+        /// @return @c true if more format string, @c false if none.
+        explicit operator bool() const;
+
+        /** Extract next formatting elements.
+         *
+         * @param literal_v [out] The next literal.
+         * @param spec [out] The next format specifier.
+         * @return @c true if @a spec was filled out, @c false if no specifier was found.
+         */
+        bool operator()(std::string_view &literal_v, Spec &spec);
+
+        /** Parse elements of a format string.
+
+            @param fmt The format string [in|out]
+            @param literal A literal if found
+            @param specifier A specifier if found (less enclosing braces)
+            @return @c true if a specifier was found, @c false if not.
+
+            Pull off the next literal and/or specifier from @a fmt. The return value distinguishes
+            the case of no specifier found (@c false) or an empty specifier (@c true).
+
+         */
+        static bool parse(TextView &fmt, std::string_view &literal, std::string_view &specifier);
+      };
+
+      /// Wrap the format string in an extractor.
+      static TextViewExtractor bind(TextView fmt);
+
+      /// Extraction support for pre-parsed format strings.
+      struct FormatExtractor {
+        MemSpan<Spec const> _fmt; ///< Parsed format string.
+        int _idx = 0;             ///< Element index.
+        /// @return @c true if more format string, @c false if none.
+        explicit operator bool() const;
+
+        /** Extract next formatting elements.
+         *
+         * @param literal_v [out] The next literal.
+         * @param spec [out] The next format specifier.
+         * @return @c true if @a spec was filled out, @c false if no specifier was found.
+         */
+        bool operator()(std::string_view &literal_v, Spec &spec);
+      };
+
+      /// Wrap the format instance in an extractor.
+      FormatExtractor bind() const;
+
+      /// @return @c true if all specifiers are literal.
+      bool is_literal() const;
+
+      using Container = std::vector<Spec>;
+      Container _items; ///< Items from format string.
+
+      using iterator       = Container::iterator;
+      using const_iterator = Container::const_iterator;
+
+      iterator
+      begin()
+      {
+        return _items.begin();
+      }
+      iterator
+      end()
+      {
+        return _items.end();
+      }
+      const_iterator
+      begin() const
+      {
+        return _items.begin();
+      }
+      const_iterator
+      end() const
+      {
+        return _items.end();
+      }
+    };
+
+    // Name binding - support for having format specifier names.
+
+    /** Signature for a functor bound to a name.
+     *
+     * @param w The output.
+     * @param spec The format specifier.
+     *
+     * The functor is expected to write to @a w based on @a spec.
+     */
+    using ExternalGeneratorSignature = BufferWriter &(BufferWriter &w, Spec const &spec);
+
+    /** Base class for implementing a name binding functor.
+     *
+     * This expected to be inherited by other classes that provide the name binding service.
+     * It does a few small but handy things.
+     *
+     * - Force a virtual destructor.
+     * - Force the implementation of the binding method by declaring it as a pure virtual.
+     * - Provide a standard "missing name" method.
+     */
+    class NameBinding
+    {
+    public:
+      virtual ~NameBinding(); ///< Force virtual destructor.
+
+      /** Generate output text for @a name on the output @a w using the format specifier @a spec.
+       * This must match the @c BoundNameSignature type.
+       *
+       * @param w Output stream.
+       * @param spec Parsed format specifier.
+       *
+       * @note The tag name can be found in @c spec._name.
+       *
+       * @return @a w
+       */
+      virtual BufferWriter &operator()(BufferWriter &w, Spec const &spec) const = 0;
+
+    protected:
+      /** Standardized missing name method.
+       *
+       * @param w The destination buffer.
+       * @param spec Format specifier, used to determine the invalid name.
+       * @return @a w
+       */
+      static BufferWriter &err_invalid_name(BufferWriter &w, Spec const &spec);
+    };
+
+    /** An explicitly empty set of bound names.
+     *
+     * To simplify the overall implementation, a name binding is always required to format output.
+     * This class is used in situations where there is no available binding or such names would not be
+     * useful. This class with @c throw on any attempt to use a name.
+     */
+    class NilBinding : public NameBinding
+    {
+    public:
+      /// Do name based formatted output.
+      /// This always throws an exception.
+      BufferWriter &operator()(BufferWriter &, Spec const &) const override;
+    };
+
+    /** Associate generators with names.
+     *
+     *  @tparam F The function signature for generators in this container.
+     *
+     * This is a base class used by different types of name containers. It is not expected to be used
+     * directly. A subclass should inherit from this by providing a function type @a F that is
+     * suitable for the subclass generators.
+     */
+    template <typename F> class NameMap
+    {
+    public:
+      /// Signature for generators.
+      using Generator = std::function<F>;
+
+    protected:
+      using Map = std::unordered_map<std::string_view, Generator>;
+
+    private:
+      using self_type = NameMap; ///< self reference type.
+    public:
+      /// Construct an empty container.
+      NameMap();
+
+      /// Construct and assign the names and generators in @a list
+      NameMap(std::initializer_list<std::tuple<std::string_view, Generator const &>> list);
+
+      /** Assign the @a generator to the @a name.
+       *
+       * @param name Name associated with the @a generator.
+       * @param generator The generator function.
+       */
+      self_type &assign(std::string_view const &name, Generator const &generator);
+
+      /** Check if a specific name is contained in this mapping.
+       *
+       * @param name Name to check.
+       * @return @c true if present, @c false if not.
+       */
+      bool contains(std::string_view name);
+
+    protected:
+      /// Copy @a name in to local storage and return a view of it.
+      std::string_view localize(std::string_view const &name);
+
+      /// Name to name generator.
+      Map _map;              ///< Defined generators.
+      MemArena _arena{1024}; ///< Local name storage.
+    };
+
+    /** A class to hold external / context-free name bindings.
+     *
+     * These names access external data and therefore have no context. An externally accessible
+     * singleton instance of this is used as the default if no explicit name set is provided. This
+     * enables the executable to establish a set of global names to be used.
+     */
+    class ExternalNames : public NameMap<ExternalGeneratorSignature>, public NameBinding
+    {
+      using self_type  = ExternalNames;                       ///< Self reference type.
+      using super_type = NameMap<ExternalGeneratorSignature>; ///< Super class.
+      using Map        = super_type::Map;                     ///< Inherit from superclass.
+
+    public:
+      using super_type::super_type; // import constructors.
+
+      /// The bound accessor is this class.
+      NameBinding const &bind() const;
+
+      /// Bound name access.
+      BufferWriter &operator()(BufferWriter &w, const Spec &spec) const override;
+
+      /// @copydoc NameMap::assign(std::string_view const &name, Generator const &generator)
+    };
+
+    /** Associate names with context dependent generators.
+     *
+     * @tparam T The context type. This is used directly. If the context needs to be @c const
+     * then this parameter should make that explicit, e.g. @c ContextNames<const Context>. This
+     * parameter is accessible via the @c context_type alias.
+     *
+     * This provides a name binding that also has a local context, provided at the formatting call
+     * site. The functors have access to this context and are presumed to use it to generate output.
+     * This binding can also contain external generators which do not get access to the context to
+     * make it convenient to add external generators as well as context generators.
+     *
+     * A context functor should have the signature
+     * @code
+     *   BufferWriter & generator(BufferWriter & w, const Spec & spec, T & context);
+     * @endcode
+     *
+     * @a context will be the context for the binding passed to the formatter.
+     *
+     * This is used by the formatting logic by calling the @c bind method with a context object.
+     */
+    template <typename T> class ContextNames : public NameMap<BufferWriter &(BufferWriter &, const Spec &, T &)>
+    {
+    private:
+      using self_type  = ContextNames; ///< self reference type.
+      using super_type = NameMap<BufferWriter &(BufferWriter &, const Spec &, T &)>;
+      using Map        = typename super_type::Map;
+
+    public:
+      using context_type = T; ///< Export for external convenience.
+      /// Functional type for a generator.
+      using Generator = typename super_type::Generator;
+      /// Signature for an external (context-free) generator.
+      using ExternalGenerator = std::function<ExternalGeneratorSignature>;
+
+      using super_type::super_type; // inherit @c super_type constructors.
+
+      /// Specialized binding for names in an instance of @c ContextNames
+      class Binding : public NameBinding
+      {
+      public:
+        /** Override of virtual method to provide an implementation.
+         *
+         * @param w Output.
+         * @param spec Format specifier for output.
+         * @return @a w
+         *
+         * This is called from the formatting logic to generate output for a named specifier. Subclasses
+         * that need to handle name dispatch differently need only override this method.
+         */
+        BufferWriter &
+        operator()(BufferWriter &w, const Spec &spec) const override
+        {
+          return _names(w, spec, _ctx);
+        }
+
+      protected:
+        /** Constructor.
+         *
+         * @param names Names to define for the binding.
+         * @param ctx Binding context.
+         */
+        Binding(ContextNames const &names, context_type &ctx) : _ctx(ctx), _names(names) {}
+
+        context_type &_ctx;         ///< Context for generators.
+        ContextNames const &_names; ///< Base set of names.
+
+        friend class ContextNames;
+      };
+
+      /** Assign the external generator @a bg to @a name.
+       *
+       * This is used for generators in the namespace that do not use the context.
+       *
+       * @param name Name associated with the generator.
+       * @param bg An external generator that requires no context.
+       * @return @c *this
+       */
+      self_type &assign(std::string_view const &name, const ExternalGenerator &bg);
+
+      /** Assign the @a generator to the @a name.
+       *
+       * @param name Name associated with the @a generator.
+       * @param generator The generator function.
+       *
+       * @internal This is a covarying override of the super type, added to covary and
+       * provide documentation.
+       */
+      self_type &assign(std::string_view const &name, Generator const &generator);
+
+      /** Bind the name map to a specific @a context.
+       *
+       * @param context The instance of @a T to use in the generators.
+       * @return A reference to an internal instance of a subclass of the protocol class @c BoundNames.
+       *
+       * This is used when passing the context name map to the formatter.
+       */
+      Binding bind(context_type &context);
+
+    protected:
+      /** Generate output based on the name in @a spec.
+       *
+       * @param w Output.
+       * @param spec Format specifier for output.
+       * @param ctx The context object.
+       * @return @a w
+       *
+       * This is called from the formatting logic to generate output for a named specifier. Subclasses
+       * that need to handle name dispatch differently should override this method. This method
+       * performs a name lookup in the local nameset.
+       */
+      virtual BufferWriter &operator()(BufferWriter &w, const Spec &spec, context_type &ctx) const;
+    };
+
+    /** Default global names.
+     * This nameset is used if no other is provided. Therefore bindings added to this nameset will be
+     * available in the default formatting use.
+     */
+    extern ExternalNames Global_Names;
+
+    // --------------- Implementation --------------------
+    /// --- Spec ---
+
+    inline Spec::Align
+    Spec::align_of(char c)
+    {
+      return static_cast<Align>(_prop._data[static_cast<unsigned>(c)] & Property::ALIGN_MASK);
+    }
+
+    inline bool
+    Spec::is_sign(char c)
+    {
+      return _prop._data[static_cast<unsigned>(c)] & Property::SIGN_CHAR;
+    }
+
+    inline bool
+    Spec::is_type(char c)
+    {
+      return _prop._data[static_cast<unsigned>(c)] & Property::TYPE_CHAR;
+    }
+
+    inline bool
+    Spec::is_upper_case_type(char c)
+    {
+      return _prop._data[static_cast<unsigned>(c)] & Property::UPPER_TYPE_CHAR;
+    }
+
+    inline bool
+    Spec::is_numeric_type(char c)
+    {
+      return _prop._data[static_cast<unsigned>(c)] & Property::NUMERIC_TYPE_CHAR;
+    }
+
+    inline bool
+    Spec::has_numeric_type() const
+    {
+      return _prop._data[static_cast<unsigned>(_type)] & Property::NUMERIC_TYPE_CHAR;
+    }
+
+    inline bool
+    Spec::has_upper_case_type() const
+    {
+      return _prop._data[static_cast<unsigned>(_type)] & Property::UPPER_TYPE_CHAR;
+    }
+
+    inline bool
+    Spec::has_pointer_type() const
+    {
+      return _type == 'p' || _type == 'P';
+    }
+
+    inline bool
+    Spec::has_valid_type() const
+    {
+      return _type != INVALID_TYPE;
+    }
+
+    inline auto
+    Format::bind(swoc::TextView fmt) -> TextViewExtractor
+    {
+      return {fmt};
+    }
+
+    inline auto
+    Format::bind() const -> FormatExtractor
+    {
+      return {_items};
+    }
+
+    inline Format::TextViewExtractor::operator bool() const
+    {
+      return !_fmt.empty();
+    }
+
+    inline Format::FormatExtractor::operator bool() const
+    {
+      return _idx < static_cast<int>(_fmt.size());
+    }
+
+    /// --- Names / Generators ---
+
+    inline BufferWriter &
+    NameBinding::err_invalid_name(BufferWriter &w, const Spec &spec)
+    {
+      return w.print("{{~{}~}}", spec._name);
+    }
+
+    inline BufferWriter &
+    NilBinding::operator()(BufferWriter &, bwf::Spec const &) const
+    {
+      throw std::runtime_error("Use of nil bound names in BW formatting");
+    }
+
+    template <typename T>
+    inline auto
+    ContextNames<T>::bind(context_type &ctx) -> Binding
+    {
+      return {*this, ctx};
+    }
+
+    template <typename T>
+    BufferWriter &
+    ContextNames<T>::operator()(BufferWriter &w, const Spec &spec, context_type &ctx) const
+    {
+      if (!spec._name.empty()) {
+        if (auto spot = super_type::_map.find(spec._name); spot != super_type::_map.end()) {
+          spot->second(w, spec, ctx);
+        } else {
+          Binding::err_invalid_name(w, spec);
+        }
+      }
+      return w;
+    }
+
+    template <typename F> NameMap<F>::NameMap() {}
+
+    template <typename F> NameMap<F>::NameMap(std::initializer_list<std::tuple<std::string_view, const Generator &>> list)
+    {
+      for (auto &&[name, generator] : list) {
+        this->assign(name, generator);
+      }
+    }
+
+    template <typename F>
+    bool
+    NameMap<F>::contains(std::string_view name)
+    {
+      return _map.end() != _map.find(name);
+    }
+
+    template <typename F>
+    std::string_view
+    NameMap<F>::localize(std::string_view const &name)
+    {
+      auto span = _arena.alloc_span<char>(name.size());
+      memcpy(span, name);
+      return std::string_view(span.data(), span.size());
+    }
+
+    template <typename F>
+    auto
+    NameMap<F>::assign(std::string_view const &name, Generator const &generator) -> self_type &
+    {
+      _map[this->localize(name)] = generator;
+      return *this;
+    }
+
+    inline BufferWriter &
+    ExternalNames::operator()(BufferWriter &w, const Spec &spec) const
+    {
+      if (!spec._name.empty()) {
+        if (auto spot = _map.find(spec._name); spot != _map.end()) {
+          spot->second(w, spec);
+        } else {
+          this->err_invalid_name(w, spec);
+        }
+      }
+      return w;
+    }
+
+    inline NameBinding const &
+    ExternalNames::bind() const
+    {
+      return *this;
+    }
+
+    template <typename T>
+    auto
+    ContextNames<T>::assign(std::string_view const &name, ExternalGenerator const &bg) -> self_type &
+    {
+      // wrap @a bg in a shim that discards the context so it can be stored in the map.
+      super_type::assign(name, [bg](BufferWriter &w, Spec const &spec, context_type &) -> BufferWriter & { return bg(w, spec); });
+      return *this;
+    }
+
+    template <typename T>
+    auto
+    ContextNames<T>::assign(std::string_view const &name, Generator const &g) -> self_type &
+    {
+      super_type::assign(name, g);
+      return *this;
+    }
+
+    /// --- Formatting ---
+
+    /// Internal signature for template generated formatting.
+    /// @a args is a forwarded tuple of arguments to be processed.
+    template <typename TUPLE> using ArgFormatterSignature = BufferWriter &(*)(BufferWriter &w, Spec const &, TUPLE const &args);
+
+    /// Internal error / reporting message generators
+    void Err_Bad_Arg_Index(BufferWriter &w, int i, size_t n);
+
+    // MSVC will expand the parameter pack inside a lambda but not gcc, so this indirection is required.
+
+    /// This selects the @a I th argument in the @a TUPLE arg pack and calls the formatter on it. This
+    /// (or the equivalent lambda) is needed because the array of formatters must have a homogenous
+    /// signature, not vary per argument. Effectively this indirection erases the type of the specific
+    /// argument being formatted. Instances of this have the signature @c ArgFormatterSignature.
+    template <typename TUPLE, size_t I>
+    BufferWriter &
+    Arg_Formatter(BufferWriter &w, Spec const &spec, TUPLE const &args)
+    {
+      return bwformat(w, spec, std::get<I>(args));
+    }
+
+    /// This exists only to expand the index sequence into an array of formatters for the tuple type
+    /// @a TUPLE.  Due to language limitations it cannot be done directly. The formatters can be
+    /// accessed via standard array access in contrast to templated tuple access. The actual array is
+    /// static and therefore at run time the only operation is loading the address of the array.
+    template <typename TUPLE, size_t... N>
+    ArgFormatterSignature<TUPLE> *
+    Get_Arg_Formatter_Array(std::index_sequence<N...>)
+    {
+      static ArgFormatterSignature<TUPLE> fa[sizeof...(N)] = {&bwf::Arg_Formatter<TUPLE, N>...};
+      return fa;
+    }
+
+    /// Perform alignment adjustments / fill on @a w of the content in @a lw.
+    /// This is the normal mechanism, in cases where the length can be known or limited before
+    /// conversion, it can be more efficient to work in a temporary local buffer and copy out
+    /// as needed without moving data in the output buffer.
+    void Adjust_Alignment(BufferWriter &aux, Spec const &spec);
+
+    /** Format @a n as an integral value.
+     *
+     * @param w Output buffer.
+     * @param spec Format specifier.
+     * @param n Input value to format.
+     * @param negative_p Input value should be treated as a negative value.
      * @return @a w
      *
-     * This is called from the formatting logic to generate output for a named specifier. Subclasses
-     * that need to handle name dispatch differently need only override this method.
+     * A leading sign character will be output based on @a spec and @a negative_p.
      */
-    BufferWriter &
-    operator()(BufferWriter &w, const Spec &spec) const override {
-      return _names(w, spec, _ctx);
-    }
+    BufferWriter &Format_Integer(BufferWriter &w, Spec const &spec, uintmax_t n, bool negative_p);
 
-  protected:
-    /** Constructor.
+    /** Format @a f as a floating point value.
      *
-     * @param names Names to define for the binding.
-     * @param ctx Binding context.
+     * @param w Output buffer.
+     * @param spec Format specifier.
+     * @param f Input value to format.
+     * @param negative_p Input value shoudl be treated as a negative value.
+     * @return @a w
+     *
+     * A leading sign character will be output based on @a spec and @a negative_p.
      */
-    Binding(ContextNames const &names, context_type &ctx) : _ctx(ctx), _names(names) {}
-
-    context_type &_ctx;         ///< Context for generators.
-    ContextNames const &_names; ///< Base set of names.
-
-    friend class ContextNames;
-  };
-
-  /** Assign the external generator @a bg to @a name.
-   *
-   * This is used for generators in the namespace that do not use the context.
-   *
-   * @param name Name associated with the generator.
-   * @param bg An external generator that requires no context.
-   * @return @c *this
-   */
-  self_type &assign(std::string_view const &name, const ExternalGenerator &bg);
-
-  /** Assign the @a generator to the @a name.
-   *
-   * @param name Name associated with the @a generator.
-   * @param generator The generator function.
-   *
-   * @internal This is a covarying override of the super type, added to covary and
-   * provide documentation.
-   */
-  self_type &assign(std::string_view const &name, Generator const &generator);
-
-  /** Bind the name map to a specific @a context.
-   *
-   * @param context The instance of @a T to use in the generators.
-   * @return A reference to an internal instance of a subclass of the protocol class @c BoundNames.
-   *
-   * This is used when passing the context name map to the formatter.
-   */
-  Binding bind(context_type &context);
-
-protected:
-  /** Generate output based on the name in @a spec.
-   *
-   * @param w Output.
-   * @param spec Format specifier for output.
-   * @param ctx The context object.
-   * @return @a w
-   *
-   * This is called from the formatting logic to generate output for a named specifier. Subclasses
-   * that need to handle name dispatch differently should override this method. This method
-   * performs a name lookup in the local nameset.
-   */
-  virtual BufferWriter &operator()(BufferWriter &w, const Spec &spec, context_type &ctx) const;
-};
-
-/** Default global names.
- * This nameset is used if no other is provided. Therefore bindings added to this nameset will be
- * available in the default formatting use.
- */
-extern ExternalNames Global_Names;
-
-// --------------- Implementation --------------------
-/// --- Spec ---
-
-inline Spec::Align
-Spec::align_of(char c) {
-  return static_cast<Align>(_prop._data[static_cast<unsigned>(c)] & Property::ALIGN_MASK);
-}
-
-inline bool
-Spec::is_sign(char c) {
-  return _prop._data[static_cast<unsigned>(c)] & Property::SIGN_CHAR;
-}
-
-inline bool
-Spec::is_type(char c) {
-  return _prop._data[static_cast<unsigned>(c)] & Property::TYPE_CHAR;
-}
-
-inline bool
-Spec::is_upper_case_type(char c) {
-  return _prop._data[static_cast<unsigned>(c)] & Property::UPPER_TYPE_CHAR;
-}
-
-inline bool
-Spec::is_numeric_type(char c) {
-  return _prop._data[static_cast<unsigned>(c)] & Property::NUMERIC_TYPE_CHAR;
-}
-
-inline bool
-Spec::has_numeric_type() const {
-  return _prop._data[static_cast<unsigned>(_type)] & Property::NUMERIC_TYPE_CHAR;
-}
-
-inline bool
-Spec::has_upper_case_type() const {
-  return _prop._data[static_cast<unsigned>(_type)] & Property::UPPER_TYPE_CHAR;
-}
-
-inline bool
-Spec::has_pointer_type() const {
-  return _type == 'p' || _type == 'P';
-}
-
-inline bool
-Spec::has_valid_type() const {
-  return _type != INVALID_TYPE;
-}
-
-inline auto
-Format::bind(swoc::TextView fmt) -> TextViewExtractor {
-  return {fmt};
-}
-
-inline auto
-Format::bind() const -> FormatExtractor {
-  return {_items};
-}
-
-inline Format::TextViewExtractor::operator bool() const {
-  return !_fmt.empty();
-}
-
-inline Format::FormatExtractor::operator bool() const {
-  return _idx < static_cast<int>(_fmt.size());
-}
-
-/// --- Names / Generators ---
-
-inline BufferWriter &
-NameBinding::err_invalid_name(BufferWriter &w, const Spec &spec) {
-  return w.print("{{~{}~}}", spec._name);
-}
-
-inline BufferWriter &
-NilBinding::operator()(BufferWriter &, bwf::Spec const &) const {
-  throw std::runtime_error("Use of nil bound names in BW formatting");
-}
-
-template <typename T>
-inline auto
-ContextNames<T>::bind(context_type &ctx) -> Binding {
-  return {*this, ctx};
-}
-
-template <typename T>
-BufferWriter &
-ContextNames<T>::operator()(BufferWriter &w, const Spec &spec, context_type &ctx) const {
-  if (!spec._name.empty()) {
-    if (auto spot = super_type::_map.find(spec._name); spot != super_type::_map.end()) {
-      spot->second(w, spec, ctx);
-    } else {
-      Binding::err_invalid_name(w, spec);
-    }
-  }
-  return w;
-}
-
-template <typename F> NameMap<F>::NameMap() {}
-
-template <typename F> NameMap<F>::NameMap(std::initializer_list<std::tuple<std::string_view, const Generator &>> list) {
-  for (auto &&[name, generator] : list) {
-    this->assign(name, generator);
-  }
-}
-
-template <typename F>
-bool
-NameMap<F>::contains(std::string_view name) {
-  return _map.end() != _map.find(name);
-}
-
-template <typename F>
-std::string_view
-NameMap<F>::localize(std::string_view const &name) {
-  auto span = _arena.alloc_span<char>(name.size());
-  memcpy(span, name);
-  return std::string_view(span.data(), span.size());
-}
-
-template <typename F>
-auto
-NameMap<F>::assign(std::string_view const &name, Generator const &generator) -> self_type & {
-  _map[this->localize(name)] = generator;
-  return *this;
-}
-
-inline BufferWriter &
-ExternalNames::operator()(BufferWriter &w, const Spec &spec) const {
-  if (!spec._name.empty()) {
-    if (auto spot = _map.find(spec._name); spot != _map.end()) {
-      spot->second(w, spec);
-    } else {
-      this->err_invalid_name(w, spec);
-    }
-  }
-  return w;
-}
-
-inline NameBinding const &
-ExternalNames::bind() const {
-  return *this;
-}
-
-template <typename T>
-auto
-ContextNames<T>::assign(std::string_view const &name, ExternalGenerator const &bg) -> self_type & {
-  // wrap @a bg in a shim that discards the context so it can be stored in the map.
-  super_type::assign(name, [bg](BufferWriter &w, Spec const &spec, context_type &) -> BufferWriter & { return bg(w, spec); });
-  return *this;
-}
-
-template <typename T>
-auto
-ContextNames<T>::assign(std::string_view const &name, Generator const &g) -> self_type & {
-  super_type::assign(name, g);
-  return *this;
-}
-
-/// --- Formatting ---
-
-/// Internal signature for template generated formatting.
-/// @a args is a forwarded tuple of arguments to be processed.
-template <typename TUPLE> using ArgFormatterSignature = BufferWriter &(*)(BufferWriter &w, Spec const &, TUPLE const &args);
-
-/// Internal error / reporting message generators
-void Err_Bad_Arg_Index(BufferWriter &w, int i, size_t n);
-
-// MSVC will expand the parameter pack inside a lambda but not gcc, so this indirection is required.
-
-/// This selects the @a I th argument in the @a TUPLE arg pack and calls the formatter on it. This
-/// (or the equivalent lambda) is needed because the array of formatters must have a homogenous
-/// signature, not vary per argument. Effectively this indirection erases the type of the specific
-/// argument being formatted. Instances of this have the signature @c ArgFormatterSignature.
-template <typename TUPLE, size_t I>
-BufferWriter &
-Arg_Formatter(BufferWriter &w, Spec const &spec, TUPLE const &args) {
-  return bwformat(w, spec, std::get<I>(args));
-}
-
-/// This exists only to expand the index sequence into an array of formatters for the tuple type
-/// @a TUPLE.  Due to language limitations it cannot be done directly. The formatters can be
-/// accessed via standard array access in contrast to templated tuple access. The actual array is
-/// static and therefore at run time the only operation is loading the address of the array.
-template <typename TUPLE, size_t... N>
-ArgFormatterSignature<TUPLE> *
-Get_Arg_Formatter_Array(std::index_sequence<N...>) {
-  static ArgFormatterSignature<TUPLE> fa[sizeof...(N)] = {&bwf::Arg_Formatter<TUPLE, N>...};
-  return fa;
-}
-
-/// Perform alignment adjustments / fill on @a w of the content in @a lw.
-/// This is the normal mechanism, in cases where the length can be known or limited before
-/// conversion, it can be more efficient to work in a temporary local buffer and copy out
-/// as needed without moving data in the output buffer.
-void Adjust_Alignment(BufferWriter &aux, Spec const &spec);
-
-/** Format @a n as an integral value.
- *
- * @param w Output buffer.
- * @param spec Format specifier.
- * @param n Input value to format.
- * @param negative_p Input value should be treated as a negative value.
- * @return @a w
- *
- * A leading sign character will be output based on @a spec and @a negative_p.
- */
-BufferWriter &Format_Integer(BufferWriter &w, Spec const &spec, uintmax_t n, bool negative_p);
-
-/** Format @a f as a floating point value.
- *
- * @param w Output buffer.
- * @param spec Format specifier.
- * @param f Input value to format.
- * @param negative_p Input value shoudl be treated as a negative value.
- * @return @a w
- *
- * A leading sign character will be output based on @a spec and @a negative_p.
- */
-BufferWriter &Format_Float(BufferWriter &w, Spec const &spec, double f, bool negative_p);
-
-/** Format output as a hexadecimal dump.
- *
- * @param w Output buffer.
- * @param view Input view.
- * @param digits Digit array for hexadecimal digits.
- *
- * This dumps the memory in the @a view as a hexadecimal string.
- */
-void Format_As_Hex(BufferWriter &w, std::string_view view, const char *digits);
-
-/* Capture support, which allows format extractors to capture arguments and consume them.
- * This was built in order to support C style formatting, which needs to capture arguments
- * to set the minimum width and/or the precision of other arguments.
- *
- * The key component is the ability to dynamically access an element of a tuple using
- * @c std::any.
- *
- * Note: Much of this was originally in the meta support but it caused problems in use if
- * the tuple header wasn't also included. I was unable to determine why, so this code doesn't
- * depend on tuple explicitly.
- */
-/// The signature for accessing an element of a tuple.
-template <typename T> using TupleAccessorSignature = std::any (*)(T const &t);
-
-/// Template access method.
-template <size_t IDX, typename T>
-std::any
-TupleAccessor(T const &t) {
-  return std::any(&std::get<IDX>(t));
-}
-
-/// Create and return an array of specialized accessors, indexed by tuple index.
-template <typename T, size_t... N>
-std::array<TupleAccessorSignature<T>, sizeof...(N)> &
-Tuple_Accessor_Array(std::index_sequence<N...>) {
-  static std::array<TupleAccessorSignature<T>, sizeof...(N)> accessors = {&TupleAccessor<N>...};
-  return accessors;
-}
-
-/// Get the Nth element of the tuple as @c std::any.
-template <typename T>
-std::any
-Tuple_Nth(T const &t, size_t idx) {
-  return Tuple_Accessor_Array<T>(std::make_index_sequence<std::tuple_size<T>::value>())[idx](t);
-}
-
-/// If capture is used, the format extractor must provide a @c capture method. This isn't required
-/// so make it compile time optional, but throw if the extractor sets up for capture and didn't
-/// provide one.
-template <typename F>
-auto
-arg_capture(F &&, BufferWriter &, Spec const &, std::any &&, swoc::meta::CaseTag<0>) -> void {
-  throw std::runtime_error("Capture specification used in format extractor that does not support capture");
-}
-
-template <typename F>
-auto
-arg_capture(F &&f, BufferWriter &w, Spec const &spec, std::any &&value, swoc::meta::CaseTag<1>)
-  -> decltype(f.capture(w, spec, value)) {
-  return f.capture(w, spec, value);
-}
-
-/** Extract the specifier type from an Extractor.
- *
- * @tparam EXTRACTOR Format extractor functor type.
- * @tparam VIEW String view argument type.
- * @tparam SPEC Specifier argument type.
- * @return A value of type @a SPEC
- *
- * This is never called - it exists to extract @a SPEC from a format extractor functor to be used
- * to declare the specifier instance passed to the format extractor. When used in this fashion
- * with @c decltype the extracted type is a reference and that must be removed for the actual
- * declaration type. The purpose is to enable format extractors to subclass @c bwf::Spec to
- * pass additional information along, particularly to a name binding without interfering with
- * the base use case.
- */
-template <typename EXTRACTOR, typename VIEW, typename SPEC>
-auto
-extractor_spec_type(bool (EXTRACTOR::*)(VIEW, SPEC)) -> SPEC {}
-
-/** A pack of arguments for formatting.
- *
- * @internal After much consideration, I decided this was the correct choice, to enable type
- * erasure of the arguments to the base formatting logic. This costs a virtual function dispatch
- * but prevents the formatting logic from being duplicated for every permutation of arguments.
- * Overall, for any reasonably sized project, I think this is the better option.
- *
- * This also supports passing arguments in other than a tuple, which is necessary in order to
- * pass arguments in various containers such as a vector.
- */
-class ArgPack {
-public:
-  virtual ~ArgPack() = default; /// Force virtual destructor for subclasses.
-
-  /** Get argument at index @a idx.
-   *
-   * @param idx Argument index.
-   * @return The argument value.
-   *
-   * In general the arguments will be stored by reference and so the returned @c std::any
-   * instance will be a reference type.
-   */
-  virtual std::any capture(unsigned idx) const = 0;
-
-  /** Generate formatted output for an argument.
-   *
-   * @param w Output.
-   * @param spec Formatting specifier.
-   * @param idx Argument index.
-   *
-   * @return @a w
-   */
-  virtual BufferWriter &print(BufferWriter &w, Spec const &spec, unsigned idx) const = 0;
-
-  /// Number of arguments in the pack.
-  virtual unsigned count() const = 0;
-};
-
-/** An argument pack based on a reference tuple.
- *
- * @tparam Args Type of arguments in the tuple.
- *
- * This contains a reference to the tuple, and so is only suitable for passing as a temporary.
- *
- */
-template <typename... Args> class ArgTuple : public ArgPack {
-public:
-  /// Construct from a tuple.
-  ArgTuple(std::tuple<Args...> const &tuple) : _tuple(tuple) {}
-
-protected:
-  /// Numnber of arguments in the tuple.
-  unsigned count() const override;
-
-  /// Generate formatted output on @a w for argument at @a idx.
-  BufferWriter &print(BufferWriter &w, Spec const &spec, unsigned idx) const override;
-
-  /// Capture the @a idx argument for later use.
-  std::any capture(unsigned idx) const override;
-
-  /// The source arguments.
-  std::tuple<Args...> const &_tuple;
-};
-
-template <typename... Args>
-unsigned
-ArgTuple<Args...>::count() const {
-  return sizeof...(Args);
-}
-
-template <typename... Args>
-BufferWriter &
-ArgTuple<Args...>::print(BufferWriter &w, Spec const &spec, unsigned idx) const {
-  static const auto _fa{bwf::Get_Arg_Formatter_Array<std::tuple<Args...>>(std::index_sequence_for<Args...>{})};
-  return _fa[idx](w, spec, _tuple);
-}
-
-template <typename... Args>
-std::any
-ArgTuple<Args...>::capture(unsigned idx) const {
-  return {Tuple_Nth(_tuple, idx)};
-}
-
-} // namespace bwf
-
-template <typename Binding, typename Extractor>
-BufferWriter &
-BufferWriter::print_nfv(Binding &&names, Extractor &&ex, bwf::ArgPack const &args) {
-  using namespace std::literals;
-  // This gets the actual specifier type from the Extractor - it must be a subclass of @c bwf::Spec
-  // but this enables format extractors to use a subclass if additional data needs to be passed
-  // via the specifier.
-  using spec_type =
-    typename std::remove_reference<decltype(bwf::extractor_spec_type(&std::remove_reference<Extractor>::type::operator()))>::type;
-  int N       = args.count();
-  int arg_idx = 0; // the next argument index to be processed.
-
-  // Parser is required to return @c false if there's no more data, @c true if something was parsed.
-  while (ex) {
-    std::string_view lit_v;
-    spec_type spec;
-    bool spec_p = ex(lit_v, spec);
-
-    // If there's a literal, just ship it.
-    if (lit_v.size()) {
-      this->write(lit_v);
+    BufferWriter &Format_Float(BufferWriter &w, Spec const &spec, double f, bool negative_p);
+
+    /** Format output as a hexadecimal dump.
+     *
+     * @param w Output buffer.
+     * @param view Input view.
+     * @param digits Digit array for hexadecimal digits.
+     *
+     * This dumps the memory in the @a view as a hexadecimal string.
+     */
+    void Format_As_Hex(BufferWriter &w, std::string_view view, const char *digits);
+
+    /* Capture support, which allows format extractors to capture arguments and consume them.
+     * This was built in order to support C style formatting, which needs to capture arguments
+     * to set the minimum width and/or the precision of other arguments.
+     *
+     * The key component is the ability to dynamically access an element of a tuple using
+     * @c std::any.
+     *
+     * Note: Much of this was originally in the meta support but it caused problems in use if
+     * the tuple header wasn't also included. I was unable to determine why, so this code doesn't
+     * depend on tuple explicitly.
+     */
+    /// The signature for accessing an element of a tuple.
+    template <typename T> using TupleAccessorSignature = std::any (*)(T const &t);
+
+    /// Template access method.
+    template <size_t IDX, typename T>
+    std::any
+    TupleAccessor(T const &t)
+    {
+      return std::any(&std::get<IDX>(t));
     }
 
-    if (spec_p) {
-      if (spec._name.size() == 0) {
-        spec._idx = arg_idx++;
+    /// Create and return an array of specialized accessors, indexed by tuple index.
+    template <typename T, size_t... N>
+    std::array<TupleAccessorSignature<T>, sizeof...(N)> &
+    Tuple_Accessor_Array(std::index_sequence<N...>)
+    {
+      static std::array<TupleAccessorSignature<T>, sizeof...(N)> accessors = {&TupleAccessor<N>...};
+      return accessors;
+    }
+
+    /// Get the Nth element of the tuple as @c std::any.
+    template <typename T>
+    std::any
+    Tuple_Nth(T const &t, size_t idx)
+    {
+      return Tuple_Accessor_Array<T>(std::make_index_sequence<std::tuple_size<T>::value>())[idx](t);
+    }
+
+    /// If capture is used, the format extractor must provide a @c capture method. This isn't required
+    /// so make it compile time optional, but throw if the extractor sets up for capture and didn't
+    /// provide one.
+    template <typename F>
+    auto
+    arg_capture(F &&, BufferWriter &, Spec const &, std::any &&, swoc::meta::CaseTag<0>) -> void
+    {
+      throw std::runtime_error("Capture specification used in format extractor that does not support capture");
+    }
+
+    template <typename F>
+    auto
+    arg_capture(F &&f, BufferWriter &w, Spec const &spec, std::any &&value, swoc::meta::CaseTag<1>)
+      -> decltype(f.capture(w, spec, value))
+    {
+      return f.capture(w, spec, value);
+    }
+
+    /** Extract the specifier type from an Extractor.
+     *
+     * @tparam EXTRACTOR Format extractor functor type.
+     * @tparam VIEW String view argument type.
+     * @tparam SPEC Specifier argument type.
+     * @return A value of type @a SPEC
+     *
+     * This is never called - it exists to extract @a SPEC from a format extractor functor to be used
+     * to declare the specifier instance passed to the format extractor. When used in this fashion
+     * with @c decltype the extracted type is a reference and that must be removed for the actual
+     * declaration type. The purpose is to enable format extractors to subclass @c bwf::Spec to
+     * pass additional information along, particularly to a name binding without interfering with
+     * the base use case.
+     */
+    template <typename EXTRACTOR, typename VIEW, typename SPEC>
+    auto
+    extractor_spec_type(bool (EXTRACTOR::*)(VIEW, SPEC)) -> SPEC
+    {
+    }
+
+    /** A pack of arguments for formatting.
+     *
+     * @internal After much consideration, I decided this was the correct choice, to enable type
+     * erasure of the arguments to the base formatting logic. This costs a virtual function dispatch
+     * but prevents the formatting logic from being duplicated for every permutation of arguments.
+     * Overall, for any reasonably sized project, I think this is the better option.
+     *
+     * This also supports passing arguments in other than a tuple, which is necessary in order to
+     * pass arguments in various containers such as a vector.
+     */
+    class ArgPack
+    {
+    public:
+      virtual ~ArgPack() = default; /// Force virtual destructor for subclasses.
+
+      /** Get argument at index @a idx.
+       *
+       * @param idx Argument index.
+       * @return The argument value.
+       *
+       * In general the arguments will be stored by reference and so the returned @c std::any
+       * instance will be a reference type.
+       */
+      virtual std::any capture(unsigned idx) const = 0;
+
+      /** Generate formatted output for an argument.
+       *
+       * @param w Output.
+       * @param spec Formatting specifier.
+       * @param idx Argument index.
+       *
+       * @return @a w
+       */
+      virtual BufferWriter &print(BufferWriter &w, Spec const &spec, unsigned idx) const = 0;
+
+      /// Number of arguments in the pack.
+      virtual unsigned count() const = 0;
+    };
+
+    /** An argument pack based on a reference tuple.
+     *
+     * @tparam Args Type of arguments in the tuple.
+     *
+     * This contains a reference to the tuple, and so is only suitable for passing as a temporary.
+     *
+     */
+    template <typename... Args> class ArgTuple : public ArgPack
+    {
+    public:
+      /// Construct from a tuple.
+      ArgTuple(std::tuple<Args...> const &tuple) : _tuple(tuple) {}
+
+    protected:
+      /// Numnber of arguments in the tuple.
+      unsigned count() const override;
+
+      /// Generate formatted output on @a w for argument at @a idx.
+      BufferWriter &print(BufferWriter &w, Spec const &spec, unsigned idx) const override;
+
+      /// Capture the @a idx argument for later use.
+      std::any capture(unsigned idx) const override;
+
+      /// The source arguments.
+      std::tuple<Args...> const &_tuple;
+    };
+
+    template <typename... Args>
+    unsigned
+    ArgTuple<Args...>::count() const
+    {
+      return sizeof...(Args);
+    }
+
+    template <typename... Args>
+    BufferWriter &
+    ArgTuple<Args...>::print(BufferWriter &w, Spec const &spec, unsigned idx) const
+    {
+      static const auto _fa{bwf::Get_Arg_Formatter_Array<std::tuple<Args...>>(std::index_sequence_for<Args...>{})};
+      return _fa[idx](w, spec, _tuple);
+    }
+
+    template <typename... Args>
+    std::any
+    ArgTuple<Args...>::capture(unsigned idx) const
+    {
+      return {Tuple_Nth(_tuple, idx)};
+    }
+
+  } // namespace bwf
+
+  template <typename Binding, typename Extractor>
+  BufferWriter &
+  BufferWriter::print_nfv(Binding &&names, Extractor &&ex, bwf::ArgPack const &args)
+  {
+    using namespace std::literals;
+    // This gets the actual specifier type from the Extractor - it must be a subclass of @c bwf::Spec
+    // but this enables format extractors to use a subclass if additional data needs to be passed
+    // via the specifier.
+    using spec_type =
+      typename std::remove_reference<decltype(bwf::extractor_spec_type(&std::remove_reference<Extractor>::type::operator()))>::type;
+    int N       = args.count();
+    int arg_idx = 0; // the next argument index to be processed.
+
+    // Parser is required to return @c false if there's no more data, @c true if something was parsed.
+    while (ex) {
+      std::string_view lit_v;
+      spec_type spec;
+      bool spec_p = ex(lit_v, spec);
+
+      // If there's a literal, just ship it.
+      if (lit_v.size()) {
+        this->write(lit_v);
       }
 
-      while (true) {
-        size_t width = this->remaining();
-        if (spec._max < width) {
-          width = spec._max;
+      if (spec_p) {
+        if (spec._name.size() == 0) {
+          spec._idx = arg_idx++;
         }
 
-        FixedBufferWriter lw{this->aux_data(), width};
+        while (true) {
+          size_t width = this->remaining();
+          if (spec._max < width) {
+            width = spec._max;
+          }
 
-        if (0 <= spec._idx) {
-          if (spec._idx < N) {
-            if (spec._type == bwf::Spec::CAPTURE_TYPE) {
-              bwf::arg_capture(ex, lw, spec, args.capture(spec._idx), swoc::meta::CaseArg);
+          FixedBufferWriter lw{this->aux_data(), width};
+
+          if (0 <= spec._idx) {
+            if (spec._idx < N) {
+              if (spec._type == bwf::Spec::CAPTURE_TYPE) {
+                bwf::arg_capture(ex, lw, spec, args.capture(spec._idx), swoc::meta::CaseArg);
+              } else {
+                args.print(lw, spec, spec._idx);
+              }
             } else {
-              args.print(lw, spec, spec._idx);
+              bwf::Err_Bad_Arg_Index(lw, spec._idx, N);
             }
-          } else {
-            bwf::Err_Bad_Arg_Index(lw, spec._idx, N);
+          } else if (spec._name.size()) {
+            names(lw, spec);
           }
-        } else if (spec._name.size()) {
-          names(lw, spec);
-        }
-        if (lw.extent()) {
-          bwf::Adjust_Alignment(lw, spec);
-          if (!this->commit(lw.extent())) {
-            continue;
+          if (lw.extent()) {
+            bwf::Adjust_Alignment(lw, spec);
+            if (!this->commit(lw.extent())) {
+              continue;
+            }
           }
+          break;
         }
-        break;
       }
     }
+    return *this;
   }
-  return *this;
-}
 
-template <typename... Args>
-BufferWriter &
-BufferWriter::print(const TextView &fmt, Args &&... args) {
-  return this->print_nfv(bwf::Global_Names.bind(), bwf::Format::bind(fmt), bwf::ArgTuple{std::forward_as_tuple(args...)});
-}
-
-template <typename... Args>
-BufferWriter &
-BufferWriter::print(bwf::Format const &fmt, Args &&... args) {
-  return this->print_nfv(bwf::Global_Names.bind(), fmt.bind(), bwf::ArgTuple{std::forward_as_tuple(args...)});
-}
-
-template <typename... Args>
-BufferWriter &
-BufferWriter::print_v(TextView const &fmt, std::tuple<Args...> const &args) {
-  return this->print_nfv(bwf::Global_Names.bind(), bwf::Format::bind(fmt), bwf::ArgTuple{args});
-}
-
-template <typename... Args>
-BufferWriter &
-BufferWriter::print_v(const bwf::Format &fmt, const std::tuple<Args...> &args) {
-  return this->print_nfv(bwf::Global_Names.bind(), fmt.bind(), bwf::ArgTuple{args});
-}
-
-template <typename Binding, typename Extractor>
-BufferWriter &
-BufferWriter::print_nfv(Binding const &names, Extractor &&f) {
-  return print_nfv(names, f, bwf::ArgTuple{std::make_tuple()});
-}
-
-template <typename Binding>
-BufferWriter &
-BufferWriter::print_n(Binding const &names, TextView const &fmt) {
-  return print_nfv(names, bwf::Format::bind(fmt), bwf::ArgTuple{std::make_tuple()});
-}
-
-inline MemSpan<char>
-BufferWriter::aux_span() {
-  return {this->aux_data(), this->remaining()};
-}
-
-// ---- Formatting for specific types.
-
-/** Output a @c string_view.
- *
- * @param w Output
- * @param spec Format specifier
- * @param sv View to format.
- * @return @a w
- *
- * @internal Must be first because it is used by other formatters, and is not inline.
- */
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, std::string_view sv);
-
-/** Format non-specialized pointers.
- *
- * @param w Output
- * @param spec Format specifier.
- * @param ptr Pointer to format.
- * @return @a w
- *
- * Non-specialized pointers are formatted simply as pointers, rather than the pointed to data.
- */
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, const void *ptr);
-
-/** Format a generic (void) memory span.
- *
- * @param w Output
- * @param spec Format specifier.
- * @param span Span to format.
- * @return @a w
- *
- * The format is by default "N:ptr" where N is the size and ptr is a hex formatter pointer. If the
- * format is "x" or "X" the span content is dumped as contiguous hex.
- */
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, MemSpan<void const> const &span);
-
-/** Format a generic (void) memory span.
- *
- * @param w Output
- * @param spec Format specifier.
- * @param span Span to format.
- * @return @a w
- *
- * The format is by default "N:ptr" where N is the size and ptr is a hex formatter pointer. If the
- * format is "x" or "X" the span content is dumped as contiguous hex.
- *
- * @internal Overload to avoid unfortunate ambiguities when constructing the span from other spans.
- * in particular @c MemSpan<char> vs. @c TextView.
- */
-inline BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, MemSpan<void> const &span) {
-  return bwformat(w, spec, span.rebind<void const>());
-}
-
-template <typename T>
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, MemSpan<T> const &span) {
-  bwf::Spec s{spec};
-  // If the precision isn't already specified, make it the size of the objects in the span.
-  // This will break the output into blocks of that size.
-  if (spec._prec <= 0) {
-    s._prec = sizeof(T);
+  template <typename... Args>
+  BufferWriter &
+  BufferWriter::print(const TextView &fmt, Args &&...args)
+  {
+    return this->print_nfv(bwf::Global_Names.bind(), bwf::Format::bind(fmt), bwf::ArgTuple{std::forward_as_tuple(args...)});
   }
-  return bwformat(w, s, span.template rebind<void const>());
-}
 
-template <size_t N>
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, const char (&a)[N]) {
-  return bwformat(w, spec, std::string_view(a, N - 1));
-}
-
-// Capture this explicitly so it doesn't go to any other pointer type.
-inline BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, std::nullptr_t) {
-  return bwformat(w, spec, static_cast<void *>(nullptr));
-}
-
-// Char pointer formatting
-inline BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, const char *v) {
-  if (spec._type == 'x' || spec._type == 'X' || spec._type == 'p' || spec._type == 'P') {
-    bwformat(w, spec, static_cast<const void *>(v));
-  } else if (v != nullptr) {
-    bwformat(w, spec, std::string_view(v));
-  } else {
-    bwformat(w, spec, nullptr);
+  template <typename... Args>
+  BufferWriter &
+  BufferWriter::print(bwf::Format const &fmt, Args &&...args)
+  {
+    return this->print_nfv(bwf::Global_Names.bind(), fmt.bind(), bwf::ArgTuple{std::forward_as_tuple(args...)});
   }
-  return w;
-}
-// doc end
 
-inline BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, std::string const &s) {
-  return bwformat(w, spec, std::string_view{s});
-}
-
-inline BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, TextView tv) {
-  return bwformat(w, spec, static_cast<std::string_view>(tv));
-}
-
-template <typename X, typename V>
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &, TransformView<X, V> &&view) {
-  while (view)
-    w.write(char(*(view++)));
-  return w;
-}
-
-template <typename F>
-auto
-bwformat(BufferWriter &w, bwf::Spec const &spec, F &&f) ->
-  typename std::enable_if<std::is_floating_point_v<typename std::remove_reference_t<F>>, BufferWriter &>::type
-{
-  return f < 0 ? bwf::Format_Float(w, spec, -f, true) : bwf::Format_Float(w, spec, f, false);
-}
-
-/* Integer types.
-
-   Due to some oddities for MacOS building, need a bit more template magic here. The underlying
-   integer rendering is in @c Format_Integer which takes @c intmax_t or @c uintmax_t. For @c
-   bwformat templates are defined, one for signed and one for unsigned. These forward their argument
-   to the internal renderer. To avoid additional ambiguity the template argument is checked with @c
-   std::enable_if to invalidate the overload if the argument type isn't a signed / unsigned
-   integer. One exception to this is @c char which is handled by a previous overload in order to
-   treat the value as a character and not an integer. The overall benefit is this works for any set
-   of integer types, rather tuning and hoping to get just the right set of overloads.
- */
-
-template <typename I>
-auto
-bwformat(BufferWriter &w, bwf::Spec const &spec, I &&i) ->
-  typename std::enable_if<std::is_unsigned<typename std::remove_reference<I>::type>::value &&
-                            std::is_integral<typename std::remove_reference<I>::type>::value,
-                          BufferWriter &>::type {
-  return bwf::Format_Integer(w, spec, i, false);
-}
-
-template <typename I>
-auto
-bwformat(BufferWriter &w, bwf::Spec const &spec, I &&i) ->
-  typename std::enable_if<std::is_signed<typename std::remove_reference<I>::type>::value &&
-                            std::is_integral<typename std::remove_reference<I>::type>::value,
-                          BufferWriter &>::type {
-  bool neg_p  = false;
-  uintmax_t n = static_cast<uintmax_t>(i);
-  if (i < 0) {
-    n     = static_cast<uintmax_t>(-i);
-    neg_p = true;
+  template <typename... Args>
+  BufferWriter &
+  BufferWriter::print_v(TextView const &fmt, std::tuple<Args...> const &args)
+  {
+    return this->print_nfv(bwf::Global_Names.bind(), bwf::Format::bind(fmt), bwf::ArgTuple{args});
   }
-  return bwf::Format_Integer(w, spec, n, neg_p);
-}
 
-inline BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &, char c) {
-  return w.write(c);
-}
-
-inline BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, bool f) {
-  using namespace std::literals;
-  if ('s' == spec._type) {
-    w.write(f ? "true"sv : "false"sv);
-  } else if ('S' == spec._type) {
-    w.write(f ? "TRUE"sv : "FALSE"sv);
-  } else {
-    bwf::Format_Integer(w, spec, static_cast<uintmax_t>(f), false);
+  template <typename... Args>
+  BufferWriter &
+  BufferWriter::print_v(const bwf::Format &fmt, const std::tuple<Args...> &args)
+  {
+    return this->print_nfv(bwf::Global_Names.bind(), fmt.bind(), bwf::ArgTuple{args});
   }
-  return w;
-}
 
-// std::string support
-/** Generate formatted output to a @c std::string @a s using format @a fmt with arguments @a args.
- *
- * @tparam Args Format argument types.
- * @param s Output string.
- * @param fmt Format string.
- * @param args A tuple of the format arguments.
- * @return @a s
- *
- * The output is generated to @a s as is. If @a s does not have sufficient space for the output
- * it is resized to be sufficient and the output formatted again. The result is that @a s will
- * containing exactly the formatted output.
- *
- * @note This function is intended for use by other formatting front ends, such as in classes that
- * need to generate formatted output. For direct use there is an overload that takes an argument
- * list.
- */
-template <typename... Args>
-std::string &
-bwprint_v(std::string &s, TextView fmt, std::tuple<Args...> const &args) {
-  auto const len = s.size(); // remember initial size
-  auto printer = [&]() {
-    return FixedBufferWriter(s.data(), s.capacity()).print_v(fmt, args).extent();
-  };
-  size_t n = printer();
-  s.resize(n);   // always need to resize - if shorter, must clip pre-existing text.
-  if (n > len) { // dropped data, try again.
-    printer();
+  template <typename Binding, typename Extractor>
+  BufferWriter &
+  BufferWriter::print_nfv(Binding const &names, Extractor &&f)
+  {
+    return print_nfv(names, f, bwf::ArgTuple{std::make_tuple()});
   }
-  return s;
-}
 
-/** Generate formatted output to a @c std::string @a s using format @a fmt with arguments @a args.
- *
- * @tparam Args Format argument types.
- * @param s Output string.
- * @param fmt Format string.
- * @param args Arguments for format string.
- * @return @a s
- *
- * The output is generated to @a s without resizing, completely replacing any existing text.
- * If @a s does not have sufficient space for the output
- * it is resized to be sufficient and the output formatted again. The result is that @a s will
- * contain exactly the formatted output.
- *
- * @note This is intended for direct use. For indirect use (as a backend for another class) see the
- * overload that takes an argument tuple.
- */
-template <typename... Args>
-std::string &
-bwprint(std::string &s, TextView fmt, Args &&... args) {
-  return bwprint_v(s, fmt, std::forward_as_tuple(args...));
-}
-
-/** Generate formatted output to a @c std::string @a s using format @a fmt with arguments @a args.
- *
- * @tparam Args Format argument types.
- * @param s Output string.
- * @param fmt Format string.
- * @param args Arguments for format string.
- * @return @a s
- *
- * The output is appended to @a s without resizing. If @a s does not have sufficient space for the output
- * it is resized to be sufficient and the output formatted again. The result is that @a s will
- * contain any previous text and the formatted output.
- */
-template <typename... Args>
-std::string &
-bwappend(std::string &s, TextView fmt, Args &&... args) {
-  auto const len = s.length(); // Text to preserve.
-  auto const capacity = s.capacity(); // Working space.
-  auto printer = [&]() {
-    return FixedBufferWriter(s.data()+len, s.capacity()-len).print(fmt, args...).extent();
-  };
-  // Resize first, otherwise capacity past @a len is cleared on @c resize.
-  s.resize(capacity);
-  auto n = printer() + len; // Get the final length.
-  s.resize(n); // Adjust to correct string length.
-  if (n > capacity) { // dropped data, write it again.
-    printer();
+  template <typename Binding>
+  BufferWriter &
+  BufferWriter::print_n(Binding const &names, TextView const &fmt)
+  {
+    return print_nfv(names, bwf::Format::bind(fmt), bwf::ArgTuple{std::make_tuple()});
   }
-  return s;
-}
 
-/// @cond COVARY
-template <typename... Args>
-auto
-FixedBufferWriter::print(TextView fmt, Args &&... args) -> self_type & {
-  return static_cast<self_type &>(this->super_type::print_v(fmt, std::forward_as_tuple(args...)));
-}
-
-template <typename... Args>
-auto
-FixedBufferWriter::print_v(TextView fmt, std::tuple<Args...> const &args) -> self_type & {
-  return static_cast<self_type &>(this->super_type::print_v(fmt, args));
-}
-
-template <typename... Args>
-auto
-FixedBufferWriter::print(bwf::Format const &fmt, Args &&... args) -> self_type & {
-  return static_cast<self_type &>(this->super_type::print_v(fmt, std::forward_as_tuple(args...)));
-}
-
-template <typename... Args>
-auto
-FixedBufferWriter::print_v(bwf::Format const &fmt, std::tuple<Args...> const &args) -> self_type & {
-  return static_cast<self_type &>(this->super_type::print_v(fmt, args));
-}
-/// @endcond
-
-// Special case support for @c Scalar, because @c Scalar is a base utility for some other utilities
-// there can be some unpleasant circularities if @c Scalar includes BufferWriter formatting. If the
-// support is here then it's fine because anything using BWF for @c Scalar must include this header.
-template <intmax_t N, typename C, typename T> class Scalar;
-namespace detail {
-template <typename T>
-auto
-tag_label(BufferWriter &, const bwf::Spec &, meta::CaseTag<0>) -> void {}
-
-template <typename T>
-auto
-tag_label(BufferWriter &w, const bwf::Spec &, meta::CaseTag<1>) -> decltype(T::label, meta::TypeFunc<void>()) {
-  w.print("{}", T::label);
-}
-} // namespace detail
-
-template <intmax_t N, typename C, typename T>
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, Scalar<N, C, T> const &x) {
-  bwformat(w, spec, x.value());
-  if (!spec.has_numeric_type()) {
-    detail::tag_label<T>(w, spec, meta::CaseArg);
+  inline MemSpan<char>
+  BufferWriter::aux_span()
+  {
+    return {this->aux_data(), this->remaining()};
   }
-  return w;
-}
 
-// Generically a stream operator is a formatter with the default specification.
-template <typename V>
-BufferWriter &
-operator<<(BufferWriter &w, V &&v) {
-  return bwformat(w, bwf::Spec::DEFAULT, std::forward<V>(v));
-}
+  // ---- Formatting for specific types.
 
-// Basic format wrappers - these are here because they're used internally.
-namespace bwf {
-/** Hex dump wrapper.
- *
- * This wrapper indicates the contained view should be dumped as raw memory in hexadecimal format.
- * This is intended primarily for internal use by other formatting logic.
- *
- * @see As_Hex
- */
-struct HexDump {
-  std::string_view _view; ///< A view of the memory to dump.
-
-  /** Dump @a n bytes starting at @a mem as hex.
+  /** Output a @c string_view.
    *
-   * @param mem First byte of memory to dump.
-   * @param n Number of bytes.
+   * @param w Output
+   * @param spec Format specifier
+   * @param sv View to format.
+   * @return @a w
+   *
+   * @internal Must be first because it is used by other formatters, and is not inline.
    */
-  HexDump(void const *mem, size_t n) : _view(static_cast<char const *>(mem), n) {}
-};
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, std::string_view sv);
 
-/** Treat @a t as raw memory and dump the memory as hexadecimal.
- *
- * @tparam T Type of argument.
- * @param t Object to dump.
- * @return @a A wrapper to do a hex dump.
- *
- * This is the standard way to do a hexadecimal memory dump of an object.
- *
- * @internal This function exists so that other types can overload it for special processing,
- * which would not be possible with just @c HexDump.
- */
-template <typename T>
-HexDump
-As_Hex(T const &t) {
-  return HexDump(&t, sizeof(T));
-}
+  /** Format non-specialized pointers.
+   *
+   * @param w Output
+   * @param spec Format specifier.
+   * @param ptr Pointer to format.
+   * @return @a w
+   *
+   * Non-specialized pointers are formatted simply as pointers, rather than the pointed to data.
+   */
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, const void *ptr);
 
-} // namespace bwf
+  /** Format a generic (void) memory span.
+   *
+   * @param w Output
+   * @param spec Format specifier.
+   * @param span Span to format.
+   * @return @a w
+   *
+   * The format is by default "N:ptr" where N is the size and ptr is a hex formatter pointer. If the
+   * format is "x" or "X" the span content is dumped as contiguous hex.
+   */
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, MemSpan<void const> const &span);
 
-/** Format a hex dump.
- *
- * @param w The output.
- * @param spec Format specifier.
- * @param hex Hex dump wrapper.
- * @return @a w
- */
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::HexDump const &hex);
+  /** Format a generic (void) memory span.
+   *
+   * @param w Output
+   * @param spec Format specifier.
+   * @param span Span to format.
+   * @return @a w
+   *
+   * The format is by default "N:ptr" where N is the size and ptr is a hex formatter pointer. If the
+   * format is "x" or "X" the span content is dumped as contiguous hex.
+   *
+   * @internal Overload to avoid unfortunate ambiguities when constructing the span from other spans.
+   * in particular @c MemSpan<char> vs. @c TextView.
+   */
+  inline BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, MemSpan<void> const &span)
+  {
+    return bwformat(w, spec, span.rebind<void const>());
+  }
 
-/** Format a buffer writer.
- *
- * @param w Output buffer,
- * @param spec Format specifier.
- * @param ww Input buffer
- * @return @a w
- *
- * This treats @a ww as a view and prints it as text.
- */
-inline BufferWriter &bwformat(BufferWriter &w, bwf::Spec const& spec, BufferWriter const& ww) {
-  return bwformat(w, spec, TextView(ww));
-}
+  template <typename T>
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, MemSpan<T> const &span)
+  {
+    bwf::Spec s{spec};
+    // If the precision isn't already specified, make it the size of the objects in the span.
+    // This will break the output into blocks of that size.
+    if (spec._prec <= 0) {
+      s._prec = sizeof(T);
+    }
+    return bwformat(w, s, span.template rebind<void const>());
+  }
 
-template <typename T>
-BufferWriter &
-BufferWriter::format(bwf::Spec const &spec, T const &t) {
-  return bwformat(*this, spec, t);
-}
+  template <size_t N>
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, const char (&a)[N])
+  {
+    return bwformat(w, spec, std::string_view(a, N - 1));
+  }
 
-template <typename T>
-BufferWriter &
-BufferWriter::format(bwf::Spec const &spec, T && t) {
-  return bwformat(*this, spec, t);
-}
+  // Capture this explicitly so it doesn't go to any other pointer type.
+  inline BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, std::nullptr_t)
+  {
+    return bwformat(w, spec, static_cast<void *>(nullptr));
+  }
 
-}} // namespace swoc::SWOC_VERSION_NS
+  // Char pointer formatting
+  inline BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, const char *v)
+  {
+    if (spec._type == 'x' || spec._type == 'X' || spec._type == 'p' || spec._type == 'P') {
+      bwformat(w, spec, static_cast<const void *>(v));
+    } else if (v != nullptr) {
+      bwformat(w, spec, std::string_view(v));
+    } else {
+      bwformat(w, spec, nullptr);
+    }
+    return w;
+  }
+  // doc end
+
+  inline BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, std::string const &s)
+  {
+    return bwformat(w, spec, std::string_view{s});
+  }
+
+  inline BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, TextView tv)
+  {
+    return bwformat(w, spec, static_cast<std::string_view>(tv));
+  }
+
+  template <typename X, typename V>
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &, TransformView<X, V> &&view)
+  {
+    while (view)
+      w.write(char(*(view++)));
+    return w;
+  }
+
+  template <typename F>
+  auto
+  bwformat(BufferWriter &w, bwf::Spec const &spec, F &&f) ->
+    typename std::enable_if<std::is_floating_point_v<typename std::remove_reference_t<F>>, BufferWriter &>::type
+  {
+    return f < 0 ? bwf::Format_Float(w, spec, -f, true) : bwf::Format_Float(w, spec, f, false);
+  }
+
+  /* Integer types.
+
+     Due to some oddities for MacOS building, need a bit more template magic here. The underlying
+     integer rendering is in @c Format_Integer which takes @c intmax_t or @c uintmax_t. For @c
+     bwformat templates are defined, one for signed and one for unsigned. These forward their argument
+     to the internal renderer. To avoid additional ambiguity the template argument is checked with @c
+     std::enable_if to invalidate the overload if the argument type isn't a signed / unsigned
+     integer. One exception to this is @c char which is handled by a previous overload in order to
+     treat the value as a character and not an integer. The overall benefit is this works for any set
+     of integer types, rather tuning and hoping to get just the right set of overloads.
+   */
+
+  template <typename I>
+  auto
+  bwformat(BufferWriter &w, bwf::Spec const &spec, I &&i) ->
+    typename std::enable_if<std::is_unsigned<typename std::remove_reference<I>::type>::value &&
+                              std::is_integral<typename std::remove_reference<I>::type>::value,
+                            BufferWriter &>::type
+  {
+    return bwf::Format_Integer(w, spec, i, false);
+  }
+
+  template <typename I>
+  auto
+  bwformat(BufferWriter &w, bwf::Spec const &spec, I &&i) ->
+    typename std::enable_if<std::is_signed<typename std::remove_reference<I>::type>::value &&
+                              std::is_integral<typename std::remove_reference<I>::type>::value,
+                            BufferWriter &>::type
+  {
+    bool neg_p  = false;
+    uintmax_t n = static_cast<uintmax_t>(i);
+    if (i < 0) {
+      n     = static_cast<uintmax_t>(-i);
+      neg_p = true;
+    }
+    return bwf::Format_Integer(w, spec, n, neg_p);
+  }
+
+  inline BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &, char c)
+  {
+    return w.write(c);
+  }
+
+  inline BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, bool f)
+  {
+    using namespace std::literals;
+    if ('s' == spec._type) {
+      w.write(f ? "true"sv : "false"sv);
+    } else if ('S' == spec._type) {
+      w.write(f ? "TRUE"sv : "FALSE"sv);
+    } else {
+      bwf::Format_Integer(w, spec, static_cast<uintmax_t>(f), false);
+    }
+    return w;
+  }
+
+  // std::string support
+  /** Generate formatted output to a @c std::string @a s using format @a fmt with arguments @a args.
+   *
+   * @tparam Args Format argument types.
+   * @param s Output string.
+   * @param fmt Format string.
+   * @param args A tuple of the format arguments.
+   * @return @a s
+   *
+   * The output is generated to @a s as is. If @a s does not have sufficient space for the output
+   * it is resized to be sufficient and the output formatted again. The result is that @a s will
+   * containing exactly the formatted output.
+   *
+   * @note This function is intended for use by other formatting front ends, such as in classes that
+   * need to generate formatted output. For direct use there is an overload that takes an argument
+   * list.
+   */
+  template <typename... Args>
+  std::string &
+  bwprint_v(std::string &s, TextView fmt, std::tuple<Args...> const &args)
+  {
+    auto const len = s.size(); // remember initial size
+    auto printer   = [&]() { return FixedBufferWriter(s.data(), s.capacity()).print_v(fmt, args).extent(); };
+    size_t n       = printer();
+    s.resize(n);   // always need to resize - if shorter, must clip pre-existing text.
+    if (n > len) { // dropped data, try again.
+      printer();
+    }
+    return s;
+  }
+
+  /** Generate formatted output to a @c std::string @a s using format @a fmt with arguments @a args.
+   *
+   * @tparam Args Format argument types.
+   * @param s Output string.
+   * @param fmt Format string.
+   * @param args Arguments for format string.
+   * @return @a s
+   *
+   * The output is generated to @a s without resizing, completely replacing any existing text.
+   * If @a s does not have sufficient space for the output
+   * it is resized to be sufficient and the output formatted again. The result is that @a s will
+   * contain exactly the formatted output.
+   *
+   * @note This is intended for direct use. For indirect use (as a backend for another class) see the
+   * overload that takes an argument tuple.
+   */
+  template <typename... Args>
+  std::string &
+  bwprint(std::string &s, TextView fmt, Args &&...args)
+  {
+    return bwprint_v(s, fmt, std::forward_as_tuple(args...));
+  }
+
+  /** Generate formatted output to a @c std::string @a s using format @a fmt with arguments @a args.
+   *
+   * @tparam Args Format argument types.
+   * @param s Output string.
+   * @param fmt Format string.
+   * @param args Arguments for format string.
+   * @return @a s
+   *
+   * The output is appended to @a s without resizing. If @a s does not have sufficient space for the output
+   * it is resized to be sufficient and the output formatted again. The result is that @a s will
+   * contain any previous text and the formatted output.
+   */
+  template <typename... Args>
+  std::string &
+  bwappend(std::string &s, TextView fmt, Args &&...args)
+  {
+    auto const len      = s.length();   // Text to preserve.
+    auto const capacity = s.capacity(); // Working space.
+    auto printer        = [&]() { return FixedBufferWriter(s.data() + len, s.capacity() - len).print(fmt, args...).extent(); };
+    // Resize first, otherwise capacity past @a len is cleared on @c resize.
+    s.resize(capacity);
+    auto n = printer() + len; // Get the final length.
+    s.resize(n);              // Adjust to correct string length.
+    if (n > capacity) {       // dropped data, write it again.
+      printer();
+    }
+    return s;
+  }
+
+  /// @cond COVARY
+  template <typename... Args>
+  auto
+  FixedBufferWriter::print(TextView fmt, Args &&...args) -> self_type &
+  {
+    return static_cast<self_type &>(this->super_type::print_v(fmt, std::forward_as_tuple(args...)));
+  }
+
+  template <typename... Args>
+  auto
+  FixedBufferWriter::print_v(TextView fmt, std::tuple<Args...> const &args) -> self_type &
+  {
+    return static_cast<self_type &>(this->super_type::print_v(fmt, args));
+  }
+
+  template <typename... Args>
+  auto
+  FixedBufferWriter::print(bwf::Format const &fmt, Args &&...args) -> self_type &
+  {
+    return static_cast<self_type &>(this->super_type::print_v(fmt, std::forward_as_tuple(args...)));
+  }
+
+  template <typename... Args>
+  auto
+  FixedBufferWriter::print_v(bwf::Format const &fmt, std::tuple<Args...> const &args) -> self_type &
+  {
+    return static_cast<self_type &>(this->super_type::print_v(fmt, args));
+  }
+  /// @endcond
+
+  // Special case support for @c Scalar, because @c Scalar is a base utility for some other utilities
+  // there can be some unpleasant circularities if @c Scalar includes BufferWriter formatting. If the
+  // support is here then it's fine because anything using BWF for @c Scalar must include this header.
+  template <intmax_t N, typename C, typename T> class Scalar;
+  namespace detail
+  {
+    template <typename T>
+    auto
+    tag_label(BufferWriter &, const bwf::Spec &, meta::CaseTag<0>) -> void
+    {
+    }
+
+    template <typename T>
+    auto
+    tag_label(BufferWriter &w, const bwf::Spec &, meta::CaseTag<1>) -> decltype(T::label, meta::TypeFunc<void>())
+    {
+      w.print("{}", T::label);
+    }
+  } // namespace detail
+
+  template <intmax_t N, typename C, typename T>
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, Scalar<N, C, T> const &x)
+  {
+    bwformat(w, spec, x.value());
+    if (!spec.has_numeric_type()) {
+      detail::tag_label<T>(w, spec, meta::CaseArg);
+    }
+    return w;
+  }
+
+  // Generically a stream operator is a formatter with the default specification.
+  template <typename V>
+  BufferWriter &
+  operator<<(BufferWriter &w, V &&v)
+  {
+    return bwformat(w, bwf::Spec::DEFAULT, std::forward<V>(v));
+  }
+
+  // Basic format wrappers - these are here because they're used internally.
+  namespace bwf
+  {
+    /** Hex dump wrapper.
+     *
+     * This wrapper indicates the contained view should be dumped as raw memory in hexadecimal format.
+     * This is intended primarily for internal use by other formatting logic.
+     *
+     * @see As_Hex
+     */
+    struct HexDump {
+      std::string_view _view; ///< A view of the memory to dump.
+
+      /** Dump @a n bytes starting at @a mem as hex.
+       *
+       * @param mem First byte of memory to dump.
+       * @param n Number of bytes.
+       */
+      HexDump(void const *mem, size_t n) : _view(static_cast<char const *>(mem), n) {}
+    };
+
+    /** Treat @a t as raw memory and dump the memory as hexadecimal.
+     *
+     * @tparam T Type of argument.
+     * @param t Object to dump.
+     * @return @a A wrapper to do a hex dump.
+     *
+     * This is the standard way to do a hexadecimal memory dump of an object.
+     *
+     * @internal This function exists so that other types can overload it for special processing,
+     * which would not be possible with just @c HexDump.
+     */
+    template <typename T>
+    HexDump
+    As_Hex(T const &t)
+    {
+      return HexDump(&t, sizeof(T));
+    }
+
+  } // namespace bwf
+
+  /** Format a hex dump.
+   *
+   * @param w The output.
+   * @param spec Format specifier.
+   * @param hex Hex dump wrapper.
+   * @return @a w
+   */
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::HexDump const &hex);
+
+  /** Format a buffer writer.
+   *
+   * @param w Output buffer,
+   * @param spec Format specifier.
+   * @param ww Input buffer
+   * @return @a w
+   *
+   * This treats @a ww as a view and prints it as text.
+   */
+  inline BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, BufferWriter const &ww)
+  {
+    return bwformat(w, spec, TextView(ww));
+  }
+
+  template <typename T>
+  BufferWriter &
+  BufferWriter::format(bwf::Spec const &spec, T const &t)
+  {
+    return bwformat(*this, spec, t);
+  }
+
+  template <typename T>
+  BufferWriter &
+  BufferWriter::format(bwf::Spec const &spec, T &&t)
+  {
+    return bwformat(*this, spec, t);
+  }
+
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/include/swoc/bwf_ex.h
+++ b/code/include/swoc/bwf_ex.h
@@ -14,271 +14,290 @@
 #include "swoc/bwf_base.h"
 #include "swoc/swoc_meta.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
-namespace bwf {
-using namespace swoc::literals; // enable ""sv
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  namespace bwf
+  {
+    using namespace swoc::literals; // enable ""sv
 
-/** Output @a text @a n times.
- *
- */
-struct Pattern {
-  int _n;                 ///< # of instances of @a pattern.
-  std::string_view _text; ///< output text.
-};
+    /** Output @a text @a n times.
+     *
+     */
+    struct Pattern {
+      int _n;                 ///< # of instances of @a pattern.
+      std::string_view _text; ///< output text.
+    };
 
-/** Format wrapper for @c errno.
- * This stores a copy of the argument or @c errno if an argument isn't provided. The output
- * is then formatted with the short, long, and numeric value of @c errno. If the format specifier
- * is type 'd' then just the numeric value is printed.
- */
-struct Errno {
-  int _e; ///< Errno value.
+    /** Format wrapper for @c errno.
+     * This stores a copy of the argument or @c errno if an argument isn't provided. The output
+     * is then formatted with the short, long, and numeric value of @c errno. If the format specifier
+     * is type 'd' then just the numeric value is printed.
+     */
+    struct Errno {
+      int _e; ///< Errno value.
 
-  /// Construct wrapper, default to current @c errno
-  explicit Errno(int e = errno) : _e(e) {}
-};
+      /// Construct wrapper, default to current @c errno
+      explicit Errno(int e = errno) : _e(e) {}
+    };
 
-/** Format wrapper for time stamps.
- * If the time isn't provided, the current epoch time is used. If the format string isn't
- * provided a format like "2017 Jun 29 14:11:29" is used.
- */
-struct Date {
-  /// Default format
-  static constexpr std::string_view DEFAULT_FORMAT{"%Y %b %d %H:%M:%S"_sv};
-  time_t _epoch; ///< The time.
-  std::string_view _fmt; ///< Data format.
+    /** Format wrapper for time stamps.
+     * If the time isn't provided, the current epoch time is used. If the format string isn't
+     * provided a format like "2017 Jun 29 14:11:29" is used.
+     */
+    struct Date {
+      /// Default format
+      static constexpr std::string_view DEFAULT_FORMAT{"%Y %b %d %H:%M:%S"_sv};
+      time_t _epoch;         ///< The time.
+      std::string_view _fmt; ///< Data format.
 
-  /** Constructor.
+      /** Constructor.
+       *
+       * @param t The timestamp.
+       * @param fmt Timestamp format.
+       */
+      Date(time_t t, std::string_view fmt = DEFAULT_FORMAT) : _epoch(t), _fmt(fmt) {}
+
+      /// Default construct using current time with optional format.
+      Date(std::string_view fmt = DEFAULT_FORMAT);
+    };
+
+    namespace detail
+    {
+      // Special case conversions - these handle nullptr because the @c std::string_view spec is stupid.
+      inline std::string_view
+      FirstOfConverter(std::nullptr_t)
+      {
+        return std::string_view{};
+      }
+
+      inline std::string_view
+      FirstOfConverter(char const *s)
+      {
+        return std::string_view{s ? s : ""};
+      }
+
+      // Otherwise do any compliant conversion.
+      template <typename T>
+      std::string_view
+      FirstOfConverter(T &&t)
+      {
+        return t;
+      }
+    } // namespace detail
+
+    /// Print the first of a list of strings that is not an empty string.
+    /// All arguments must be convertible to @c std::string_view.
+    template <typename... Args>
+    std::string_view
+    FirstOf(Args &&...args)
+    {
+      std::array<std::string_view, sizeof...(args)> strings{{detail::FirstOfConverter(args)...}};
+      for (auto &s : strings) {
+        if (!s.empty())
+          return s;
+      }
+      return std::string_view{};
+    }
+
+    /** Wrapper for a sub-text, where the @a args are output according to @a fmt.
+     *
+     * @tparam Args Argument types.
+     */
+    template <typename... Args> struct SubText {
+      using arg_pack = std::tuple<Args...>; ///< The pack of arguments for format string.
+      TextView _fmt;                        ///< Format string. If empty, do not generate output.
+      arg_pack _args;                       ///< Arguments to format string.
+
+      /// Construct with a specific @a fmt and @a args.
+      SubText(TextView const &fmt, arg_pack const &args) : _fmt(fmt), _args(args){};
+
+      /// Check for output not enabled.
+      bool operator!() const;
+
+      /// Check for output enabled.
+      explicit operator bool() const;
+    };
+
+    template <typename... Args> SubText<Args...>::operator bool() const
+    {
+      return !_fmt.empty();
+    }
+
+    template <typename... Args>
+    bool
+    SubText<Args...>::operator!() const
+    {
+      return _fmt.empty();
+    }
+
+    /** Optional printing wrapper.
+     *
+     * @tparam Args Arguments for output.
+     * @param flag Generate output flag.
+     * @param fmt Format for output and args.
+     * @param args The arguments.
+     * @return A wrapper for the optional text.
+     *
+     * This function is passed a @a flag, a printing format @a fmt, and a set of arguments @a args to
+     * be used by the format. Output is generated if @a flag is @c true, otherwise the empty string
+     * (no output) is generated. For example, if in a function there was a flag to determine if an
+     * extra tag with delimiters, e.g. "[tag]", was to be generated, this could be done with
+     *
+     * @code
+     *   w.print("Some other text{}.", bwf::If(flag, " [{}]", tag));
+     * @endcode
+     *
+     * @internal To disambiguate overloads, this is enabled only if there is at least one argument
+     * to be passed to the format string.
+     */
+    template <typename... Args>
+    SubText<Args...>
+    If(bool flag, TextView const &fmt, Args &&...args)
+    {
+      return SubText<Args...>(flag ? fmt : TextView{}, std::forward_as_tuple(args...));
+    }
+
+    namespace detail
+    {
+      // @a T has the @c empty() method.
+      template <typename T>
+      auto
+      Optional(meta::CaseTag<2>, TextView fmt, T &&t) -> decltype(void(t.empty()), meta::TypeFunc<SubText<T>>())
+      {
+        return SubText<T>(t.empty() ? TextView{} : fmt, std::forward_as_tuple(t));
+      }
+
+      // @a T is convertible to @c bool.
+      template <typename T>
+      auto
+      Optional(meta::CaseTag<1>, TextView fmt, T &&t) -> decltype(bool(t), meta::TypeFunc<SubText<T>>())
+      {
+        return SubText<T>(bool(t) ? fmt : TextView{}, std::forward_as_tuple(t));
+      }
+
+      // @a T is not optional, always print.
+      template <typename T>
+      auto
+      Optional(meta::CaseTag<0>, TextView fmt, T &&t) -> SubText<T>
+      {
+        return SubText<T>(fmt, std::forward_as_tuple(t));
+      }
+    } // namespace detail
+
+    /** Simplified optional text wrapper.
+     *
+     * @tparam ARG the type of the (single) argument.
+     * @param fmt Format string.
+     * @param arg The single argument to the format string and predicate.
+     * @return An optional text wrapper.
+     *
+     * This generates output iff @a arg is not empty. @a fmt is required to take only a single
+     * argument, which will be @a arg. This is a convenience overload, to handle the common case
+     * where the argument and the conditional are the same. The argument must have one of the
+     * following properties in order to serve as the conditional. These are checked in order.
+     *
+     * - The @c empty() method which returns @c true if the argument is empty and should not be printed.
+     *   This handles the case of C++ string types.
+     *
+     * - Conversion to @c bool which is @c false if the argument should not be printed. This covers the
+     *   case of pointers.
+     *
+     * As an example, if an output function had three strings @a alpha, @a bravo, and
+     * @a charlie, each of which could be null, which should be output with space separators,
+     * this would be
+     * @code
+     * w.print("Leading text{}{}{}.", Optional(" {}", alpha)
+     *                              , Optional(" {}", bravo)
+     *                              , Optional(" {}", charlie));
+     * @endcode
+     *
+     * Because of the property handling, these strings can be C styles strings ( @c char* ) or C++
+     * string types (such as @c std::string_view ).
+     *
+     */
+    template <typename ARG>
+    SubText<ARG>
+    Optional(TextView fmt, ARG &&arg)
+    {
+      return detail::Optional(meta::CaseArg, fmt, std::forward<ARG>(arg));
+    }
+
+    /** Convert from ASCII hexadecimal to raw bytes.
+     *
+     * E.g. if the source span contains "4576696c20446176652052756c7a" then "Evil Dave Rulz" is the output.
+     * For format specifier support, on lhe max width is used. Any @c MemSpan compatible class can be used
+     * as the target, including @c std::string and @c std::string_view.
+     *
+     * @code
+     *   void f(std::string const& str) {
+     *     w.print("{}", bwf::UnHex(str));
+     *     // ...
+     * @endcode
+     */
+    struct UnHex {
+      UnHex(MemSpan<void const> const &span) : _span(span) {}
+      MemSpan<void const> _span; ///< Source span.
+    };
+  } // namespace bwf
+
+  /** Repeatedly output a pattern.
    *
-   * @param t The timestamp.
-   * @param fmt Timestamp format.
+   * @param w Output.
+   * @param spec Format specifier.
+   * @param pattern Output patterning.
+   * @return @a w
+   *
+   * The @a pattern contains the count and text to output.
    */
-  Date(time_t t, std::string_view fmt = DEFAULT_FORMAT) : _epoch(t), _fmt(fmt) {}
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Pattern const &pattern);
 
-  /// Default construct using current time with optional format.
-  Date(std::string_view fmt = DEFAULT_FORMAT);
-};
+  /** Format an integer as an @c errno value.
+   *
+   * @param w Output.
+   * @param spec Format specifier.
+   * @param e Error code.
+   * @return @a w
+   */
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Errno const &e);
 
-namespace detail {
-// Special case conversions - these handle nullptr because the @c std::string_view spec is stupid.
-inline std::string_view
-FirstOfConverter(std::nullptr_t) {
-  return std::string_view{};
-}
+  /** Format a timestamp wrapped in a @c Date.
+   *
+   * @param w Output.
+   * @param spec Format specifier.
+   * @param date Timestamp.
+   * @return @a w
+   */
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Date const &date);
 
-inline std::string_view
-FirstOfConverter(char const *s) {
-  return std::string_view{s ? s : ""};
-}
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::UnHex const &obj);
 
-// Otherwise do any compliant conversion.
-template <typename T>
-std::string_view
-FirstOfConverter(T &&t) {
-  return t;
-}
-} // namespace detail
-
-/// Print the first of a list of strings that is not an empty string.
-/// All arguments must be convertible to @c std::string_view.
-template <typename... Args>
-std::string_view
-FirstOf(Args &&... args) {
-  std::array<std::string_view, sizeof...(args)> strings{{detail::FirstOfConverter(args)...}};
-  for (auto &s : strings) {
-    if (!s.empty())
-      return s;
+  /** Output a nested formatted string.
+   *
+   * @tparam Args Argument pack for @a subtext.
+   * @param w Output
+   * @param subtext Format string and arguments.
+   * @return @a w
+   *
+   * This supports a nested format string and arguments inside another format string. This is most often useful
+   * if one of the formats is fixed or pre-compiled.
+   *
+   * @code
+   * bwformat(w, "Line {} offset {} with data {}.", line_no, line_off, bwf::SubText("alpha {} bravo {}", alpha, bravo"));
+   * @endcode
+   *
+   * @see bwf::Subtext
+   */
+  template <typename... Args>
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &, bwf::SubText<Args...> const &subtext)
+  {
+    if (!subtext._fmt.empty()) {
+      w.print_v(subtext._fmt, subtext._args);
+    }
+    return w;
   }
-  return std::string_view{};
-}
 
-/** Wrapper for a sub-text, where the @a args are output according to @a fmt.
- *
- * @tparam Args Argument types.
- */
-template <typename... Args> struct SubText {
-  using arg_pack = std::tuple<Args...>; ///< The pack of arguments for format string.
-  TextView _fmt;                        ///< Format string. If empty, do not generate output.
-  arg_pack _args;                       ///< Arguments to format string.
-
-  /// Construct with a specific @a fmt and @a args.
-  SubText(TextView const &fmt, arg_pack const &args) : _fmt(fmt), _args(args){};
-
-  /// Check for output not enabled.
-  bool operator!() const;
-
-  /// Check for output enabled.
-  explicit operator bool() const;
-};
-
-template <typename... Args> SubText<Args...>::operator bool() const {
-  return !_fmt.empty();
-}
-
-template <typename... Args>
-bool
-SubText<Args...>::operator!() const {
-  return _fmt.empty();
-}
-
-/** Optional printing wrapper.
- *
- * @tparam Args Arguments for output.
- * @param flag Generate output flag.
- * @param fmt Format for output and args.
- * @param args The arguments.
- * @return A wrapper for the optional text.
- *
- * This function is passed a @a flag, a printing format @a fmt, and a set of arguments @a args to
- * be used by the format. Output is generated if @a flag is @c true, otherwise the empty string
- * (no output) is generated. For example, if in a function there was a flag to determine if an
- * extra tag with delimiters, e.g. "[tag]", was to be generated, this could be done with
- *
- * @code
- *   w.print("Some other text{}.", bwf::If(flag, " [{}]", tag));
- * @endcode
- *
- * @internal To disambiguate overloads, this is enabled only if there is at least one argument
- * to be passed to the format string.
- */
-template <typename... Args>
-SubText<Args...>
-If(bool flag, TextView const &fmt, Args &&... args) {
-  return SubText<Args...>(flag ? fmt : TextView{}, std::forward_as_tuple(args...));
-}
-
-namespace detail {
-// @a T has the @c empty() method.
-template <typename T>
-auto
-Optional(meta::CaseTag<2>, TextView fmt, T &&t) -> decltype(void(t.empty()), meta::TypeFunc<SubText<T>>()) {
-  return SubText<T>(t.empty() ? TextView{} : fmt, std::forward_as_tuple(t));
-}
-
-// @a T is convertible to @c bool.
-template <typename T>
-auto
-Optional(meta::CaseTag<1>, TextView fmt, T &&t) -> decltype(bool(t), meta::TypeFunc<SubText<T>>()) {
-  return SubText<T>(bool(t) ? fmt : TextView{}, std::forward_as_tuple(t));
-}
-
-// @a T is not optional, always print.
-template <typename T>
-auto
-Optional(meta::CaseTag<0>, TextView fmt, T &&t) -> SubText<T> {
-  return SubText<T>(fmt, std::forward_as_tuple(t));
-}
-} // namespace detail
-
-/** Simplified optional text wrapper.
- *
- * @tparam ARG the type of the (single) argument.
- * @param fmt Format string.
- * @param arg The single argument to the format string and predicate.
- * @return An optional text wrapper.
- *
- * This generates output iff @a arg is not empty. @a fmt is required to take only a single
- * argument, which will be @a arg. This is a convenience overload, to handle the common case
- * where the argument and the conditional are the same. The argument must have one of the
- * following properties in order to serve as the conditional. These are checked in order.
- *
- * - The @c empty() method which returns @c true if the argument is empty and should not be printed.
- *   This handles the case of C++ string types.
- *
- * - Conversion to @c bool which is @c false if the argument should not be printed. This covers the
- *   case of pointers.
- *
- * As an example, if an output function had three strings @a alpha, @a bravo, and
- * @a charlie, each of which could be null, which should be output with space separators,
- * this would be
- * @code
- * w.print("Leading text{}{}{}.", Optional(" {}", alpha)
- *                              , Optional(" {}", bravo)
- *                              , Optional(" {}", charlie));
- * @endcode
- *
- * Because of the property handling, these strings can be C styles strings ( @c char* ) or C++
- * string types (such as @c std::string_view ).
- *
- */
-template <typename ARG>
-SubText<ARG>
-Optional(TextView fmt, ARG &&arg) {
-  return detail::Optional(meta::CaseArg, fmt, std::forward<ARG>(arg));
-}
-
-/** Convert from ASCII hexadecimal to raw bytes.
- *
- * E.g. if the source span contains "4576696c20446176652052756c7a" then "Evil Dave Rulz" is the output.
- * For format specifier support, on lhe max width is used. Any @c MemSpan compatible class can be used
- * as the target, including @c std::string and @c std::string_view.
- *
- * @code
- *   void f(std::string const& str) {
- *     w.print("{}", bwf::UnHex(str));
- *     // ...
- * @endcode
- */
-struct UnHex {
-  UnHex(MemSpan<void const> const& span) : _span(span) {}
-  MemSpan<void const> _span; ///< Source span.
-};
-} // namespace bwf
-
-/** Repeatedly output a pattern.
- *
- * @param w Output.
- * @param spec Format specifier.
- * @param pattern Output patterning.
- * @return @a w
- *
- * The @a pattern contains the count and text to output.
- */
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Pattern const &pattern);
-
-/** Format an integer as an @c errno value.
- *
- * @param w Output.
- * @param spec Format specifier.
- * @param e Error code.
- * @return @a w
- */
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Errno const &e);
-
-/** Format a timestamp wrapped in a @c Date.
- *
- * @param w Output.
- * @param spec Format specifier.
- * @param date Timestamp.
- * @return @a w
- */
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Date const &date);
-
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const& spec, bwf::UnHex const& obj);
-
-/** Output a nested formatted string.
- *
- * @tparam Args Argument pack for @a subtext.
- * @param w Output
- * @param subtext Format string and arguments.
- * @return @a w
- *
- * This supports a nested format string and arguments inside another format string. This is most often useful
- * if one of the formats is fixed or pre-compiled.
- *
- * @code
- * bwformat(w, "Line {} offset {} with data {}.", line_no, line_off, bwf::SubText("alpha {} bravo {}", alpha, bravo"));
- * @endcode
- *
- * @see bwf::Subtext
- */
-template <typename... Args>
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &, bwf::SubText<Args...> const &subtext) {
-  if (!subtext._fmt.empty()) {
-    w.print_v(subtext._fmt, subtext._args);
-  }
-  return w;
-}
-
-}} // namespace swoc::SWOC_VERSION_NS
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/include/swoc/bwf_fwd.h
+++ b/code/include/swoc/bwf_fwd.h
@@ -12,21 +12,24 @@
 #include "swoc/swoc_version.h"
 #include "swoc/TextView.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
-class BufferWriter;
-class FixedBufferWriter;
-template <std::size_t N> class LocalBufferWriter;
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  class BufferWriter;
+  class FixedBufferWriter;
+  template <std::size_t N> class LocalBufferWriter;
 
-template <typename... Args>
-std::string & bwprint_v(std::string &s, TextView fmt, std::tuple<Args...> const &args);
+  template <typename... Args> std::string &bwprint_v(std::string &s, TextView fmt, std::tuple<Args...> const &args);
 
-template <typename... Args>
-std::string & bwprint(std::string &s, TextView fmt, Args &&... args);
+  template <typename... Args> std::string &bwprint(std::string &s, TextView fmt, Args &&...args);
 
-namespace bwf {
-struct Spec;
-struct Format;
-class NameBinding;
-class ArgPack;
-} // namespace bwf
-}} // namespace swoc
+  namespace bwf
+  {
+    struct Spec;
+    struct Format;
+    class NameBinding;
+    class ArgPack;
+  } // namespace bwf
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/include/swoc/bwf_ip.h
+++ b/code/include/swoc/bwf_ip.h
@@ -14,99 +14,115 @@
 #include "swoc/bwf_base.h"
 #include "swoc/swoc_ip.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
 
-// All of these expect the address to be in network order.
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, in6_addr const &addr);
+  // All of these expect the address to be in network order.
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, in6_addr const &addr);
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, sockaddr const *addr);
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, sockaddr const *addr);
 
-/// @{
-/// @internal The various @c sockaddr types are handled almost identically due to how formatting
-/// codes are handled so it's ugly to split the code base on family. Instead we depend on
-/// @a sa_family being set correctly.
+  /// @{
+  /// @internal The various @c sockaddr types are handled almost identically due to how formatting
+  /// codes are handled so it's ugly to split the code base on family. Instead we depend on
+  /// @a sa_family being set correctly.
 
-inline BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, sockaddr_in const *addr) {
-  return bwformat(w,spec,reinterpret_cast<sockaddr const*>(addr));
-}
-inline BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, sockaddr_in6 const *addr) {
-  return bwformat(w,spec,reinterpret_cast<sockaddr const*>(addr));
-}
+  inline BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, sockaddr_in const *addr)
+  {
+    return bwformat(w, spec, reinterpret_cast<sockaddr const *>(addr));
+  }
+  inline BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, sockaddr_in6 const *addr)
+  {
+    return bwformat(w, spec, reinterpret_cast<sockaddr const *>(addr));
+  }
 
-/// @}
+  /// @}
 
-// Use class information for ordering.
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP4Addr const &addr);
+  // Use class information for ordering.
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP4Addr const &addr);
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP6Addr const &addr);
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP6Addr const &addr);
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IPAddr const &addr);
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IPAddr const &addr);
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP4Srv const &addr);
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP4Srv const &addr);
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP6Srv const &addr);
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP6Srv const &addr);
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IPSrv const &addr);
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IPSrv const &addr);
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP4Range const &range);
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP4Range const &range);
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP6Range const &range);
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP6Range const &range);
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IPRange const &range);
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IPRange const &range);
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IPRangeView const &range);
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IPRangeView const &range);
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IPNet const &net);
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IPNet const &net);
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP4Net const &net);
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP4Net const &net);
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP6Net const &net);
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IP6Net const &net);
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IPMask const &mask);
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, IPMask const &mask);
 
-inline BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, IPEndpoint const &addr) {
-  return bwformat(w, spec, &addr.sa);
-}
+  inline BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, IPEndpoint const &addr)
+  {
+    return bwformat(w, spec, &addr.sa);
+  }
 
-/// Buffer space sufficient for printing any basic IP address type.
-static const size_t IP_STREAM_SIZE = 80;
+  /// Buffer space sufficient for printing any basic IP address type.
+  static const size_t IP_STREAM_SIZE = 80;
 
-}} // namespace swoc::SWOC_VERSION_NS
+} // namespace SWOC_VERSION_NS
+} // namespace swoc
 
-namespace std {
+namespace std
+{
 inline ostream &
-operator<<(ostream &s, swoc::IP4Addr const &addr) {
+operator<<(ostream &s, swoc::IP4Addr const &addr)
+{
   swoc::LocalBufferWriter<swoc::IP_STREAM_SIZE> w;
   return s << bwformat(w, swoc::bwf::Spec::DEFAULT, addr);
 }
 
 inline ostream &
-operator<<(ostream &s, swoc::IP6Addr const &addr) {
+operator<<(ostream &s, swoc::IP6Addr const &addr)
+{
   swoc::LocalBufferWriter<swoc::IP_STREAM_SIZE> w;
   return s << bwformat(w, swoc::bwf::Spec::DEFAULT, addr);
 }
 
 inline ostream &
-operator<<(ostream &s, swoc::IPAddr const &addr) {
+operator<<(ostream &s, swoc::IPAddr const &addr)
+{
   swoc::LocalBufferWriter<swoc::IP_STREAM_SIZE> w;
   return s << bwformat(w, swoc::bwf::Spec::DEFAULT, addr);
 }
 
 inline ostream &
-operator<<(ostream &s, swoc::IP4Range const &Range) {
+operator<<(ostream &s, swoc::IP4Range const &Range)
+{
   swoc::LocalBufferWriter<swoc::IP_STREAM_SIZE> w;
   return s << bwformat(w, swoc::bwf::Spec::DEFAULT, Range);
 }
 
 inline ostream &
-operator<<(ostream &s, swoc::IP6Range const &Range) {
+operator<<(ostream &s, swoc::IP6Range const &Range)
+{
   swoc::LocalBufferWriter<swoc::IP_STREAM_SIZE> w;
   return s << bwformat(w, swoc::bwf::Spec::DEFAULT, Range);
 }
 
 inline ostream &
-operator<<(ostream &s, swoc::IPRange const &Range) {
+operator<<(ostream &s, swoc::IPRange const &Range)
+{
   swoc::LocalBufferWriter<swoc::IP_STREAM_SIZE> w;
   return s << bwformat(w, swoc::bwf::Spec::DEFAULT, Range);
 }

--- a/code/include/swoc/bwf_std.h
+++ b/code/include/swoc/bwf_std.h
@@ -14,45 +14,52 @@
 #include "swoc/swoc_version.h"
 #include "swoc/bwf_base.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
-using namespace literals;
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  using namespace literals;
 
-/// Format atomics by stripping the atomic and formatting the underlying type.
-template <typename T>
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, std::atomic<T> const &v) {
-  return ::swoc::bwformat(w, spec, v.load());
-}
-
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, std::error_code const &ec);
-
-template <size_t N>
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const & /* spec */, std::bitset<N> const &bits) {
-  for (unsigned idx = 0; idx < N; ++idx) {
-    w.write(bits[idx] ? '1' : '0');
+  /// Format atomics by stripping the atomic and formatting the underlying type.
+  template <typename T>
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, std::atomic<T> const &v)
+  {
+    return ::swoc::bwformat(w, spec, v.load());
   }
-  return w;
-}
 
-template <typename Rep, typename Period>
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, std::chrono::duration<Rep, Period> const &d)
-{
-  return bwformat(w, spec, d.count());
-}
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, std::error_code const &ec);
 
-template <typename Clock, typename Duration>
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, std::chrono::time_point<Clock, Duration> const &t)
-{
-  return bwformat(w, spec, t.time_since_epoch());
-}
+  template <size_t N>
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const & /* spec */, std::bitset<N> const &bits)
+  {
+    for (unsigned idx = 0; idx < N; ++idx) {
+      w.write(bits[idx] ? '1' : '0');
+    }
+    return w;
+  }
 
-inline BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const& spec, std::exception const& e) {
-  w.write("Exception - "_tv);
-  return bwformat(w, spec, e.what());
-}
+  template <typename Rep, typename Period>
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, std::chrono::duration<Rep, Period> const &d)
+  {
+    return bwformat(w, spec, d.count());
+  }
 
-}} // end namespace swoc
+  template <typename Clock, typename Duration>
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, std::chrono::time_point<Clock, Duration> const &t)
+  {
+    return bwformat(w, spec, t.time_since_epoch());
+  }
+
+  inline BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, std::exception const &e)
+  {
+    w.write("Exception - "_tv);
+    return bwformat(w, spec, e.what());
+  }
+
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/include/swoc/string_view_util.h
+++ b/code/include/swoc/string_view_util.h
@@ -61,7 +61,8 @@ int memcmp(const std::string_view &lhs, const std::string_view &rhs);
  * @see memcmp
  */
 inline int
-strcmp(const std::string_view &lhs, const std::string_view &rhs) {
+strcmp(const std::string_view &lhs, const std::string_view &rhs)
+{
   return memcmp(lhs, rhs);
 }
 
@@ -83,6 +84,7 @@ strcmp(const std::string_view &lhs, const std::string_view &rhs) {
  *
  */
 inline void *
-memcpy(void *dst, const std::string_view &src) {
+memcpy(void *dst, const std::string_view &src)
+{
   return memcpy(dst, src.data(), src.size());
 }

--- a/code/include/swoc/swoc_file.h
+++ b/code/include/swoc/swoc_file.h
@@ -18,482 +18,541 @@
 #include "swoc/swoc_version.h"
 #include "swoc/TextView.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
-namespace file {
-
-using file_time_type = std::chrono::system_clock::time_point;
-
-enum class file_type : signed char {
-  none = 0, not_found = -1, regular = 1, directory = 2, symlink = 3,
-  block = 4, character = 5, fifo = 6, socket = 7, unknown = 8
-};
-
-/// Invalid file descriptor.
-static constexpr int NO_FD = -1;
-
-/// Scoped container for a file descriptor.
-struct unique_fd {
-  using self_type = unique_fd; ///< Self reference type.
-
-  /** Construct with file descriptor.
-   *
-   * @param fd File descriptor.
-   *
-   * The instance takes owernship of the file descriptor.
-   */
-  explicit unique_fd(int fd) : _fd(fd) {}
-
-  /// Non-copyable.
-  unique_fd(self_type const &) = delete;
-
-  /** Move construction.
-   *
-   * @param that Source instance.
-   *
-   * Ownership is from from @Wa that to @a this.
-   */
-  unique_fd(self_type && that) : _fd(that._fd) { that._fd = NO_FD; }
-
-  /// Close the file dscriptor.
-  ~unique_fd() { if (_fd != NO_FD) { ::close(_fd); _fd = NO_FD; }; }
-
-  /** Release ownership of the file descriptor.
-   *
-   * @return The file descriptor.
-   */
-  int release() { auto zret = _fd; _fd = NO_FD; return zret; }
-
-  /// Implicitly convert to file descriptor.
-  operator int() const { return _fd; }
-
-protected:
-  int _fd = NO_FD;
-};
-
-/** Utility class for file system paths.
- */
-class path {
-  using self_type = path; ///< Self reference type.
-
-public:
-  /// Default path separator.
-  static constexpr char SEPARATOR = '/';
-
-  /// Default construct empty path.
-  path() = default;
-
-  /// Copy constructor - copies the path.
-  path(const self_type &that) = default;
-
-  /// Move constructor.
-  path(self_type &&that) = default;
-
-  /// Construct from a null terminated string.
-  explicit path(const char *src);
-
-  /// Construct from a string view.
-  path(std::string_view src);
-
-  /// Construct with a copy of @a p.
-  path(std::string const& p);
-
-  /// Move from an existing string
-  path(std::string &&that);
-
-  /// Replace the path with a copy of @a that.
-  self_type &operator=(const self_type &that) = default;
-
-  /// Replace the path with the contents of @a that.
-  self_type &operator=(self_type &&that) = default;
-
-  /// Assign @a p as the path.
-  self_type &operator=(std::string_view p);
-
-  /** Append or replace path with @a that.
-   *
-   * If @a that is absolute, it replaces @a this. Otherwise @a that is appended with exactly one
-   * separator.
-   *
-   * @param that Filesystem path.
-   * @return @a this
-   */
-  self_type &operator/=(const self_type &that);
-
-  /** Append or replace path with @a that.
-   *
-   * If @a that is absolute, it replaces @a this. Otherwise @a that is appended with exactly one
-   * separator.
-   *
-   * @param that Filesystem path.
-   * @return @a this
-   */
-  self_type &operator/=(std::string_view that);
-
-  /// Check if the path is empty.
-  bool empty() const;
-
-  /// Check if the path is absolute.
-  bool is_absolute() const;
-
-  /// Check if the path is not absolute.
-  bool is_relative() const;
-
-  /// Path of the parent.
-  self_type parent_path() const;
-
-  /// @return Path excluding the root path, if nay.
-  self_type relative_path() const;
-
-  /** Filename part of the path.
-   *
-   * @param p Path.
-   * @return
-   */
-  self_type filename() const;
-
-  /// Access the path explicitly.
-  char const *c_str() const;
-
-  /// The path as a string.
-  std::string const &string() const;
-
-  /** Reserve space in the path.
-   *
-   * @param n Number of bytes to reserve.
-   * @return @a this.
-   */
-  self_type & reserve(size_t n);
-
-  /// A view of the path.
-  swoc::TextView view() const;
-
-protected:
-  std::string _path; ///< File path.
-};
-
-/// Information about a file.
-class file_status {
-  using self_type = file_status;
-
-public:
-  /// @return File type as an enumeration.
-  file_type type() const;
-
-  /// @return raw file mode data.
-  mode_t mode() const;
-
-protected:
-  struct ::stat _stat; ///< File information.
-  file_type _type = file_type::none;
-
-  void init();
-
-  friend self_type status(const path &file, std::error_code &ec) noexcept;
-  friend int file_type(const self_type &);
-  friend uintmax_t file_size(const self_type &);
-  friend bool is_regular_file(const self_type &);
-  friend bool is_dir(const self_type &);
-  friend bool is_char_device(const self_type &);
-  friend bool is_block_device(const self_type &);
-  friend bool exists(const self_type &);
-  friend file_time_type last_write_time(file_status const &fs);
-  friend file_time_type access_time(file_status const &fs);
-  friend file_time_type status_time(file_status const &fs);
-};
-
-/** Get the status of the file at @a p.
- *
- * @param file Path to file.
- * @param ec Error code return.
- * @return Status of the file.
- */
-file_status status(const path &file, std::error_code &ec) noexcept;
-
-// Related free functions.
-// These are separate because they are not part of std::filesystem::path.
-
-/// Return the file type value.
-[[deprecated("Use file_status::type")]] int file_type(const file_status &fs);
-
-/// Check if the path is to a regular file.
-bool is_regular_file(const file_status &fs);
-
-/// Check if the path is to a directory.
-bool is_dir(const file_status &p);
-
-/// Check if the path is to a character device.
-bool is_char_device(const file_status &fs);
-
-/// Check if the path is to a block device.
-bool is_block_device(const file_status &fs);
-
-/// Size of the file or block device.
-uintmax_t file_size(const file_status &fs);
-
-/// Check if file is readable.
-bool is_readable(const path &s);
-
-/// Check if path exists.
-bool exists(const path &p);
-
-/// Check if path exists.
-bool exists(const file_status &fs);
-
-/** Convert to absolute path.
- *
- * @param src Original path
- * @param ec Error code.
- * @return Absolute path.
- *
- * If @a path is already absolute, a copy of it is returned. Otherwise an absolute path is
- * constructed that refers to the same item in the file system as @a src. If an error occurs
- * then @a ec is set to indicate the type of error.
- */
-path absolute(path const &src, std::error_code &ec);
-
-/// Directory location suitable for temporary files
-path temp_directory_path();
-
-/// Current working directory.
-path current_path();
-
-/// @return Canonicalized absolute pathname
-path canonical(const path &p, std::error_code &ec);
-
-/** Create directory.
- *
- * @param p Path to directory.
- * @param ec Error code return.
- * @param mode Permissions for created directory.
- * @return @c true if @a p was created, @c false otherwise.
- *
- * @note Not fully implemented.
- */
-bool create_directory(const path &p, std::error_code &ec, mode_t mode = 0775) noexcept;
-
-/** Create directories.
- *
- * @param p Path to directory.
- * @param ec Error code return.
- * @param mode Permissions for created directories.
- * @return @c true if @a p was created, @c false otherwise.
- *
- * @note Not fully implemented.
- */
-bool create_directories(const path &p, std::error_code &ec, mode_t mode = 0775) noexcept;
-
-/** Copy files.
- *
- * @param from Source file
- * @param to Destination file.
- * @param ec Error code return.
- * @return @c true if @a from was copied, @c false on error.
-*
-* @note Not fully implemented.
- */
-bool copy(const path &from, const path &to, std::error_code &ec);
-
-/** Remove a file or empty directory.
- *
- * @param path Target.
- * @param ec Error return.
- * @return @c true if the operation succeeded, @c false if @a ec has an error code.
- */
-bool remove(const path &path, std::error_code &ec);
-
-/** Remove a file or a directory and all nested files.
- *
- * @param path Target.
- * @param ec Error return.
- * @return Number of items removed.
- */
-uintmax_t remove_all(const path &path, std::error_code &ec);
-
-/// @return The modified time for @a fs.
-[[deprecated("See last_write_time")]] file_time_type modify_time(file_status const &fs);
-/// @return The modified time for @a fs.
-file_time_type last_write_time(file_status const &fs);
-
-/** Modification time.
- *
- * @param p Path to target.
- * @return Time of last modification, or @c file_time_type::min() on error.
- */
-file_time_type last_write_time(path const& p, std::error_code &ec);
-
-/// @return The access time for @a fs.
-file_time_type access_time(file_status const &fs);
-/// @return The status change time for @a fs.
-file_time_type status_time(file_status const &fs);
-
-/** Load the file at @a p into a @c std::string.
- *
- * @param p Path to file
- * @param ec Error code result of the file operation.
- * @return The contents of the file.
- */
-std::string load(const path &p, std::error_code &ec);
-
-/* ------------------------------------------------------------------- */
-
-inline path::path(char const *src) : _path(src) {}
-
-inline path::path(std::string_view base) : _path(base) {}
-
-inline path::path(std::string const &p) : _path(p) {}
-
-inline path::path(std::string &&that) : _path(std::move(that)) {}
-
-inline path &
-path::operator=(std::string_view p) {
-  _path.assign(p);
-  return *this;
-}
-
-inline char const *
-path::c_str() const {
-  return _path.c_str();
-}
-
-inline std::string const &
-path::string() const {
-  return _path;
-}
-
-inline swoc::TextView
-path::view() const {
-  return {_path};
-}
-
-inline bool
-path::empty() const {
-  return _path.empty();
-}
-
-inline bool
-path::is_absolute() const {
-  return !_path.empty() && '/' == _path[0];
-}
-
-inline bool
-path::is_relative() const {
-  return !this->is_absolute();
-}
-
-inline path &
-path::operator/=(const self_type &that) {
-  return *this /= std::string_view(that._path);
-}
-
-/** Compare two paths.
- *
- * @return @c true if @a lhs is identical to @a rhs.
- */
-inline bool
-operator==(path const &lhs, path const &rhs) {
-  return lhs.view() == rhs.view();
-}
-
-/** Compare two paths.
- *
- * @return @c true if @a lhs is not identical to @a rhs.
- */
-inline bool
-operator!=(path const &lhs, path const &rhs) {
-  return lhs.view() != rhs.view();
-}
-
-/** Combine two strings as file paths.
- *
- * @return A @c path with the combined path.
- */
-inline path
-operator/(const path &lhs, const path &rhs) {
-  return path(lhs) /= rhs;
-}
-
-/** Combine two strings as file paths.
- *
- * @return A @c path with the combined path.
- */
-inline path
-operator/(path &&lhs, const path &rhs) {
-  return path(std::move(lhs)) /= rhs;
-}
-
-/** Combine two strings as file paths.
- *
- * @return A @c path with the combined path.
- */
-inline path
-operator/(const path &lhs, std::string_view rhs) {
-  return path(lhs) /= rhs;
-}
-
-inline auto
-path::reserve(size_t n) -> self_type & {
-  _path.reserve(n);
-  return *this;
-}
-
-/** Combine two strings as file paths.
- *
- * @return A @c path with the combined path.
- */
-inline path
-operator/(path &&lhs, std::string_view rhs) {
-  return path(std::move(lhs)) /= rhs;
-}
-
-// Can remove "enum" after the function @c file_type is removed.
-inline enum file_type file_status::type() const { return _type; }
-
-inline mode_t file_status::mode() const { return _stat.st_mode; }
-
-inline bool
-is_char_device(const file_status &fs) {
-  return fs._type == file_type::character;
-}
-
-inline bool
-is_block_device(const file_status &fs) {
-  return fs._type == file_type::block;
-}
-
-inline bool
-is_regular_file(const file_status &fs) {
-  return fs._type == file_type::regular;
-}
-
-inline bool
-is_dir(const file_status &fs) {
-  return fs._type == file_type::directory;
-}
-
-inline bool
-exists(const file_status &fs) {
-  return fs._type != file_type::none && fs._type != file_type::not_found;
-}
-
-inline file_time_type
-modify_time(file_status const &fs) {
-  return last_write_time(fs);
-}
-} // namespace file
-
-class BufferWriter;
-namespace bwf {
-struct Spec;
-}
-
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, file::path const &p);
-}} // namespace swoc::SWOC_VERSION_NS
-
-namespace std {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  namespace file
+  {
+
+    using file_time_type = std::chrono::system_clock::time_point;
+
+    enum class file_type : signed char {
+      none      = 0,
+      not_found = -1,
+      regular   = 1,
+      directory = 2,
+      symlink   = 3,
+      block     = 4,
+      character = 5,
+      fifo      = 6,
+      socket    = 7,
+      unknown   = 8
+    };
+
+    /// Invalid file descriptor.
+    static constexpr int NO_FD = -1;
+
+    /// Scoped container for a file descriptor.
+    struct unique_fd {
+      using self_type = unique_fd; ///< Self reference type.
+
+      /** Construct with file descriptor.
+       *
+       * @param fd File descriptor.
+       *
+       * The instance takes owernship of the file descriptor.
+       */
+      explicit unique_fd(int fd) : _fd(fd) {}
+
+      /// Non-copyable.
+      unique_fd(self_type const &) = delete;
+
+      /** Move construction.
+       *
+       * @param that Source instance.
+       *
+       * Ownership is from from @Wa that to @a this.
+       */
+      unique_fd(self_type &&that) : _fd(that._fd) { that._fd = NO_FD; }
+
+      /// Close the file dscriptor.
+      ~unique_fd()
+      {
+        if (_fd != NO_FD) {
+          ::close(_fd);
+          _fd = NO_FD;
+        };
+      }
+
+      /** Release ownership of the file descriptor.
+       *
+       * @return The file descriptor.
+       */
+      int
+      release()
+      {
+        auto zret = _fd;
+        _fd       = NO_FD;
+        return zret;
+      }
+
+      /// Implicitly convert to file descriptor.
+      operator int() const { return _fd; }
+
+    protected:
+      int _fd = NO_FD;
+    };
+
+    /** Utility class for file system paths.
+     */
+    class path
+    {
+      using self_type = path; ///< Self reference type.
+
+    public:
+      /// Default path separator.
+      static constexpr char SEPARATOR = '/';
+
+      /// Default construct empty path.
+      path() = default;
+
+      /// Copy constructor - copies the path.
+      path(const self_type &that) = default;
+
+      /// Move constructor.
+      path(self_type &&that) = default;
+
+      /// Construct from a null terminated string.
+      explicit path(const char *src);
+
+      /// Construct from a string view.
+      path(std::string_view src);
+
+      /// Construct with a copy of @a p.
+      path(std::string const &p);
+
+      /// Move from an existing string
+      path(std::string &&that);
+
+      /// Replace the path with a copy of @a that.
+      self_type &operator=(const self_type &that) = default;
+
+      /// Replace the path with the contents of @a that.
+      self_type &operator=(self_type &&that) = default;
+
+      /// Assign @a p as the path.
+      self_type &operator=(std::string_view p);
+
+      /** Append or replace path with @a that.
+       *
+       * If @a that is absolute, it replaces @a this. Otherwise @a that is appended with exactly one
+       * separator.
+       *
+       * @param that Filesystem path.
+       * @return @a this
+       */
+      self_type &operator/=(const self_type &that);
+
+      /** Append or replace path with @a that.
+       *
+       * If @a that is absolute, it replaces @a this. Otherwise @a that is appended with exactly one
+       * separator.
+       *
+       * @param that Filesystem path.
+       * @return @a this
+       */
+      self_type &operator/=(std::string_view that);
+
+      /// Check if the path is empty.
+      bool empty() const;
+
+      /// Check if the path is absolute.
+      bool is_absolute() const;
+
+      /// Check if the path is not absolute.
+      bool is_relative() const;
+
+      /// Path of the parent.
+      self_type parent_path() const;
+
+      /// @return Path excluding the root path, if nay.
+      self_type relative_path() const;
+
+      /** Filename part of the path.
+       *
+       * @param p Path.
+       * @return
+       */
+      self_type filename() const;
+
+      /// Access the path explicitly.
+      char const *c_str() const;
+
+      /// The path as a string.
+      std::string const &string() const;
+
+      /** Reserve space in the path.
+       *
+       * @param n Number of bytes to reserve.
+       * @return @a this.
+       */
+      self_type &reserve(size_t n);
+
+      /// A view of the path.
+      swoc::TextView view() const;
+
+    protected:
+      std::string _path; ///< File path.
+    };
+
+    /// Information about a file.
+    class file_status
+    {
+      using self_type = file_status;
+
+    public:
+      /// @return File type as an enumeration.
+      file_type type() const;
+
+      /// @return raw file mode data.
+      mode_t mode() const;
+
+    protected:
+      struct ::stat _stat; ///< File information.
+      file_type _type = file_type::none;
+
+      void init();
+
+      friend self_type status(const path &file, std::error_code &ec) noexcept;
+      friend int file_type(const self_type &);
+      friend uintmax_t file_size(const self_type &);
+      friend bool is_regular_file(const self_type &);
+      friend bool is_dir(const self_type &);
+      friend bool is_char_device(const self_type &);
+      friend bool is_block_device(const self_type &);
+      friend bool exists(const self_type &);
+      friend file_time_type last_write_time(file_status const &fs);
+      friend file_time_type access_time(file_status const &fs);
+      friend file_time_type status_time(file_status const &fs);
+    };
+
+    /** Get the status of the file at @a p.
+     *
+     * @param file Path to file.
+     * @param ec Error code return.
+     * @return Status of the file.
+     */
+    file_status status(const path &file, std::error_code &ec) noexcept;
+
+    // Related free functions.
+    // These are separate because they are not part of std::filesystem::path.
+
+    /// Return the file type value.
+    [[deprecated("Use file_status::type")]] int file_type(const file_status &fs);
+
+    /// Check if the path is to a regular file.
+    bool is_regular_file(const file_status &fs);
+
+    /// Check if the path is to a directory.
+    bool is_dir(const file_status &p);
+
+    /// Check if the path is to a character device.
+    bool is_char_device(const file_status &fs);
+
+    /// Check if the path is to a block device.
+    bool is_block_device(const file_status &fs);
+
+    /// Size of the file or block device.
+    uintmax_t file_size(const file_status &fs);
+
+    /// Check if file is readable.
+    bool is_readable(const path &s);
+
+    /// Check if path exists.
+    bool exists(const path &p);
+
+    /// Check if path exists.
+    bool exists(const file_status &fs);
+
+    /** Convert to absolute path.
+     *
+     * @param src Original path
+     * @param ec Error code.
+     * @return Absolute path.
+     *
+     * If @a path is already absolute, a copy of it is returned. Otherwise an absolute path is
+     * constructed that refers to the same item in the file system as @a src. If an error occurs
+     * then @a ec is set to indicate the type of error.
+     */
+    path absolute(path const &src, std::error_code &ec);
+
+    /// Directory location suitable for temporary files
+    path temp_directory_path();
+
+    /// Current working directory.
+    path current_path();
+
+    /// @return Canonicalized absolute pathname
+    path canonical(const path &p, std::error_code &ec);
+
+    /** Create directory.
+     *
+     * @param p Path to directory.
+     * @param ec Error code return.
+     * @param mode Permissions for created directory.
+     * @return @c true if @a p was created, @c false otherwise.
+     *
+     * @note Not fully implemented.
+     */
+    bool create_directory(const path &p, std::error_code &ec, mode_t mode = 0775) noexcept;
+
+    /** Create directories.
+     *
+     * @param p Path to directory.
+     * @param ec Error code return.
+     * @param mode Permissions for created directories.
+     * @return @c true if @a p was created, @c false otherwise.
+     *
+     * @note Not fully implemented.
+     */
+    bool create_directories(const path &p, std::error_code &ec, mode_t mode = 0775) noexcept;
+
+    /** Copy files.
+     *
+     * @param from Source file
+     * @param to Destination file.
+     * @param ec Error code return.
+     * @return @c true if @a from was copied, @c false on error.
+     *
+     * @note Not fully implemented.
+     */
+    bool copy(const path &from, const path &to, std::error_code &ec);
+
+    /** Remove a file or empty directory.
+     *
+     * @param path Target.
+     * @param ec Error return.
+     * @return @c true if the operation succeeded, @c false if @a ec has an error code.
+     */
+    bool remove(const path &path, std::error_code &ec);
+
+    /** Remove a file or a directory and all nested files.
+     *
+     * @param path Target.
+     * @param ec Error return.
+     * @return Number of items removed.
+     */
+    uintmax_t remove_all(const path &path, std::error_code &ec);
+
+    /// @return The modified time for @a fs.
+    [[deprecated("See last_write_time")]] file_time_type modify_time(file_status const &fs);
+    /// @return The modified time for @a fs.
+    file_time_type last_write_time(file_status const &fs);
+
+    /** Modification time.
+     *
+     * @param p Path to target.
+     * @return Time of last modification, or @c file_time_type::min() on error.
+     */
+    file_time_type last_write_time(path const &p, std::error_code &ec);
+
+    /// @return The access time for @a fs.
+    file_time_type access_time(file_status const &fs);
+    /// @return The status change time for @a fs.
+    file_time_type status_time(file_status const &fs);
+
+    /** Load the file at @a p into a @c std::string.
+     *
+     * @param p Path to file
+     * @param ec Error code result of the file operation.
+     * @return The contents of the file.
+     */
+    std::string load(const path &p, std::error_code &ec);
+
+    /* ------------------------------------------------------------------- */
+
+    inline path::path(char const *src) : _path(src) {}
+
+    inline path::path(std::string_view base) : _path(base) {}
+
+    inline path::path(std::string const &p) : _path(p) {}
+
+    inline path::path(std::string &&that) : _path(std::move(that)) {}
+
+    inline path &
+    path::operator=(std::string_view p)
+    {
+      _path.assign(p);
+      return *this;
+    }
+
+    inline char const *
+    path::c_str() const
+    {
+      return _path.c_str();
+    }
+
+    inline std::string const &
+    path::string() const
+    {
+      return _path;
+    }
+
+    inline swoc::TextView
+    path::view() const
+    {
+      return {_path};
+    }
+
+    inline bool
+    path::empty() const
+    {
+      return _path.empty();
+    }
+
+    inline bool
+    path::is_absolute() const
+    {
+      return !_path.empty() && '/' == _path[0];
+    }
+
+    inline bool
+    path::is_relative() const
+    {
+      return !this->is_absolute();
+    }
+
+    inline path &
+    path::operator/=(const self_type &that)
+    {
+      return *this /= std::string_view(that._path);
+    }
+
+    /** Compare two paths.
+     *
+     * @return @c true if @a lhs is identical to @a rhs.
+     */
+    inline bool
+    operator==(path const &lhs, path const &rhs)
+    {
+      return lhs.view() == rhs.view();
+    }
+
+    /** Compare two paths.
+     *
+     * @return @c true if @a lhs is not identical to @a rhs.
+     */
+    inline bool
+    operator!=(path const &lhs, path const &rhs)
+    {
+      return lhs.view() != rhs.view();
+    }
+
+    /** Combine two strings as file paths.
+     *
+     * @return A @c path with the combined path.
+     */
+    inline path
+    operator/(const path &lhs, const path &rhs)
+    {
+      return path(lhs) /= rhs;
+    }
+
+    /** Combine two strings as file paths.
+     *
+     * @return A @c path with the combined path.
+     */
+    inline path
+    operator/(path &&lhs, const path &rhs)
+    {
+      return path(std::move(lhs)) /= rhs;
+    }
+
+    /** Combine two strings as file paths.
+     *
+     * @return A @c path with the combined path.
+     */
+    inline path
+    operator/(const path &lhs, std::string_view rhs)
+    {
+      return path(lhs) /= rhs;
+    }
+
+    inline auto
+    path::reserve(size_t n) -> self_type &
+    {
+      _path.reserve(n);
+      return *this;
+    }
+
+    /** Combine two strings as file paths.
+     *
+     * @return A @c path with the combined path.
+     */
+    inline path
+    operator/(path &&lhs, std::string_view rhs)
+    {
+      return path(std::move(lhs)) /= rhs;
+    }
+
+    // Can remove "enum" after the function @c file_type is removed.
+    inline enum file_type
+    file_status::type() const
+    {
+      return _type;
+    }
+
+    inline mode_t
+    file_status::mode() const
+    {
+      return _stat.st_mode;
+    }
+
+    inline bool
+    is_char_device(const file_status &fs)
+    {
+      return fs._type == file_type::character;
+    }
+
+    inline bool
+    is_block_device(const file_status &fs)
+    {
+      return fs._type == file_type::block;
+    }
+
+    inline bool
+    is_regular_file(const file_status &fs)
+    {
+      return fs._type == file_type::regular;
+    }
+
+    inline bool
+    is_dir(const file_status &fs)
+    {
+      return fs._type == file_type::directory;
+    }
+
+    inline bool
+    exists(const file_status &fs)
+    {
+      return fs._type != file_type::none && fs._type != file_type::not_found;
+    }
+
+    inline file_time_type
+    modify_time(file_status const &fs)
+    {
+      return last_write_time(fs);
+    }
+  } // namespace file
+
+  class BufferWriter;
+  namespace bwf
+  {
+    struct Spec;
+  }
+
+  BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, file::path const &p);
+} // namespace SWOC_VERSION_NS
+} // namespace swoc
+
+namespace std
+{
 /// Enable use of path as a key in STL hashed containers.
 template <> struct hash<swoc::file::path> {
   size_t
-  operator()(swoc::file::path const &path) const {
+  operator()(swoc::file::path const &path) const
+  {
     return hash<string_view>()(path.view());
   }
 };

--- a/code/include/swoc/swoc_ip.h
+++ b/code/include/swoc/swoc_ip.h
@@ -20,31 +20,39 @@
 #include "swoc/IPSrv.h"
 #include "swoc/IPRange.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
 
-// --- Cross type address operators
+  // --- Cross type address operators
 
-inline bool
-operator==(IPAddr const &lhs, IPEndpoint const &rhs) {
-  return lhs == &rhs.sa;
-}
+  inline bool
+  operator==(IPAddr const &lhs, IPEndpoint const &rhs)
+  {
+    return lhs == &rhs.sa;
+  }
 
-/// Equality.
-inline bool
-operator==(IPEndpoint const &lhs, IPAddr const &rhs) {
-  return &lhs.sa == rhs;
-}
+  /// Equality.
+  inline bool
+  operator==(IPEndpoint const &lhs, IPAddr const &rhs)
+  {
+    return &lhs.sa == rhs;
+  }
 
-/// Inequality.
-inline bool
-operator!=(IPAddr const &lhs, IPEndpoint const &rhs) {
-  return !(lhs == &rhs.sa);
-}
+  /// Inequality.
+  inline bool
+  operator!=(IPAddr const &lhs, IPEndpoint const &rhs)
+  {
+    return !(lhs == &rhs.sa);
+  }
 
-/// Inequality.
-inline bool
-operator!=(IPEndpoint const &lhs, IPAddr const &rhs) {
-  return !(rhs == &lhs.sa);
-}
+  /// Inequality.
+  inline bool
+  operator!=(IPEndpoint const &lhs, IPAddr const &rhs)
+  {
+    return !(rhs == &lhs.sa);
+  }
 
-}} // namespace swoc::SWOC_VERSION_NS
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/include/swoc/swoc_meta.h
+++ b/code/include/swoc/swoc_meta.h
@@ -12,227 +12,237 @@
 
 #include "swoc/swoc_version.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS { namespace meta {
-/** This creates an ordered series of meta template cases that can be used to select one of a set
- * of functions in a priority ordering. A set of templated overloads take an (extra) argument of
- * the case structures, each a different one. Calling the function invokes the highest case that
- * is valid. Because of SFINAE the templates can have errors, as long as at least one doesn't.
- * The root technique is to use @c decltype to check an expression for the overload to be valid.
- * Because the compiler will evaluate everything it can while parsing the template this
- * expression must be delayed until the template is instantiated. This is done by making the
- * return type @c auto and making the @c decltype dependent on the template parameter. In
- * addition, the comma operator can be used to force a specific return type while also checking
- * the expression for validity. E.g.
- *
- * @code
- * template <typename T> auto func(T && t, CaseTag<0>) -> decltype(t.item, int()) { }
- * @endcode
- *
- * The comma operator discards the type and value of the left operand therefore the return type of
- * the function is @c int but this overload will not be available if @c t.item does not compile
- * (e.g., there is no such member). The presence of @c t.item also prevents this compilation check
- * from happening until overload selection is needed. Therefore if the goal was a function that
- * would return the value of the @c T::count member if present and 0 if not, the code would be
- *
- * @code
- * template <typename T> auto Get_Count(T && t, CaseTag<0>)
- *   -> int
- * { return 0; }
- * template <typename T> auto Get_Count(T && t, CaseTag<1>)
- *   -> decltype(t.count, int())
- * { return t.count; }
- * int Get_Count(Thing& t) { return GetCount(t, CaseArg); }
- * @endcode
- *
- * Note the overloads will be checked from the highest case to the lowest and the first one that
- * is valid (via SFINAE) is used. This is the point of using the case arguments, to force an
- * ordering on the overload selection. Unfortunately this means the functions @b must be
- * templated, even if there's no other reason for it, because it depends on SFINAE which doesn't
- * apply to normal overloads.
- *
- * The key point is the expression in the @c decltype should be the same expression used in the
- * method to verify it will compile. It is annoying to type it twice but there's not a better
- * option.
- *
- * Note @c decltype does not accept explicit types - to have the type of "int" a function returning
- * @c int must be provided.  This is easy for simple builtin types such as @c int - use the
- * constructor @c int(). For @c void and non-simple types (such as @c int* ) this is a bit more
- * challenging. A general utility is provided for this - @c TypeFunc. For the @c void case this
- * would be <tt>decltype(TypeFunc<void>())</tt>. For @c int* it would be
- * <tt>decltype(TypeFunc<int *>())</tt>.
- */
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  namespace meta
+  {
+    /** This creates an ordered series of meta template cases that can be used to select one of a set
+     * of functions in a priority ordering. A set of templated overloads take an (extra) argument of
+     * the case structures, each a different one. Calling the function invokes the highest case that
+     * is valid. Because of SFINAE the templates can have errors, as long as at least one doesn't.
+     * The root technique is to use @c decltype to check an expression for the overload to be valid.
+     * Because the compiler will evaluate everything it can while parsing the template this
+     * expression must be delayed until the template is instantiated. This is done by making the
+     * return type @c auto and making the @c decltype dependent on the template parameter. In
+     * addition, the comma operator can be used to force a specific return type while also checking
+     * the expression for validity. E.g.
+     *
+     * @code
+     * template <typename T> auto func(T && t, CaseTag<0>) -> decltype(t.item, int()) { }
+     * @endcode
+     *
+     * The comma operator discards the type and value of the left operand therefore the return type of
+     * the function is @c int but this overload will not be available if @c t.item does not compile
+     * (e.g., there is no such member). The presence of @c t.item also prevents this compilation check
+     * from happening until overload selection is needed. Therefore if the goal was a function that
+     * would return the value of the @c T::count member if present and 0 if not, the code would be
+     *
+     * @code
+     * template <typename T> auto Get_Count(T && t, CaseTag<0>)
+     *   -> int
+     * { return 0; }
+     * template <typename T> auto Get_Count(T && t, CaseTag<1>)
+     *   -> decltype(t.count, int())
+     * { return t.count; }
+     * int Get_Count(Thing& t) { return GetCount(t, CaseArg); }
+     * @endcode
+     *
+     * Note the overloads will be checked from the highest case to the lowest and the first one that
+     * is valid (via SFINAE) is used. This is the point of using the case arguments, to force an
+     * ordering on the overload selection. Unfortunately this means the functions @b must be
+     * templated, even if there's no other reason for it, because it depends on SFINAE which doesn't
+     * apply to normal overloads.
+     *
+     * The key point is the expression in the @c decltype should be the same expression used in the
+     * method to verify it will compile. It is annoying to type it twice but there's not a better
+     * option.
+     *
+     * Note @c decltype does not accept explicit types - to have the type of "int" a function returning
+     * @c int must be provided.  This is easy for simple builtin types such as @c int - use the
+     * constructor @c int(). For @c void and non-simple types (such as @c int* ) this is a bit more
+     * challenging. A general utility is provided for this - @c TypeFunc. For the @c void case this
+     * would be <tt>decltype(TypeFunc<void>())</tt>. For @c int* it would be
+     * <tt>decltype(TypeFunc<int *>())</tt>.
+     */
 
-/// Case hierarchy.
-template <unsigned N> struct CaseTag : /** @cond DOXYGEN_FAIL */ public CaseTag<N - 1> /** @endcond */ {
-  constexpr CaseTag() {}
+    /// Case hierarchy.
+    template <unsigned N> struct CaseTag : /** @cond DOXYGEN_FAIL */ public CaseTag<N - 1> /** @endcond */ {
+      constexpr CaseTag() {}
 
-  static constexpr unsigned value = N; ///< Case tag value.
-};
+      static constexpr unsigned value = N; ///< Case tag value.
+    };
 
-/// Case hierarchy anchor.
-template <> struct CaseTag<0> {
-  constexpr CaseTag() {}
+    /// Case hierarchy anchor.
+    template <> struct CaseTag<0> {
+      constexpr CaseTag() {}
 
-  static constexpr unsigned value = 0; ///< Case tag value.
-};
+      static constexpr unsigned value = 0; ///< Case tag value.
+    };
 
-/** This is the final case - it forces the class hierarchy.
- * After defining the cases using the indexed case arguments, this is used to perform the call.
- * To increase the hierarchy depth, change the template argument to a larger number.
- */
-static constexpr CaseTag<9> CaseArg{};
+    /** This is the final case - it forces the class hierarchy.
+     * After defining the cases using the indexed case arguments, this is used to perform the call.
+     * To increase the hierarchy depth, change the template argument to a larger number.
+     */
+    static constexpr CaseTag<9> CaseArg{};
 
-/** A typed function for use in @c decltype.
- *
- * @tparam T The desired type.
- * @return @a T
- *
- * This function has no implementation. It should be used only inside @c decltype when a specific
- * type (rather than the type of an expression) is needed. For a type @a T that has a expression
- * default constructor this can be used.
- *
- * @code
- * decltype(T())
- * @endcode
- *
- * But if there is no default constructor this will not compile. This is a work around, so the
- * previous expression would be
- *
- * @code
- * decltype(meta::TypeFunc<T>())
- * @endcode
- *
- * Note this can also be a problem for even built in types like @c unsigned @c long for which
- * the expression
- *
- * @code
- * decltype(unsigned long())
- * @endcode
- *
- * does not compile.
- */
-template <typename T> T TypeFunc();
+    /** A typed function for use in @c decltype.
+     *
+     * @tparam T The desired type.
+     * @return @a T
+     *
+     * This function has no implementation. It should be used only inside @c decltype when a specific
+     * type (rather than the type of an expression) is needed. For a type @a T that has a expression
+     * default constructor this can be used.
+     *
+     * @code
+     * decltype(T())
+     * @endcode
+     *
+     * But if there is no default constructor this will not compile. This is a work around, so the
+     * previous expression would be
+     *
+     * @code
+     * decltype(meta::TypeFunc<T>())
+     * @endcode
+     *
+     * Note this can also be a problem for even built in types like @c unsigned @c long for which
+     * the expression
+     *
+     * @code
+     * decltype(unsigned long())
+     * @endcode
+     *
+     * does not compile.
+     */
+    template <typename T> T TypeFunc();
 
-/** Template parameter eraser.
- *
- * @tparam T Parameter to erase (pass explicitly)
- * @tparam U Parameter for forwarded value (implicit)
- * @param u Forward value
- * @return @a u
- *
- * This has no effect on @a u but fools the compiler in to thinking @a T has been used.
- * This avoids metaprogramming issues with unused template parameters.
- *
- * Suppose an API has changed a function from "cheer_for_delain" to "cheer_delain". To handle this
- * the metacase support is used, but there is no apparent template parameter. A fake one can be used
- * and defaulted to @c void. But that creates the unused template parameter warning. This is fixed
- * by doing something to erase the template parameter @a V while forwarding parameter @a x. The result
- * is a function @c f that calls the correct function automatically. Note this can't be in the body of
- * the function because even for SFINAE the function body must compile and the variant with the wrong
- * function will fail.
- *
- * @code
- *   template <typename V = void>
- *   auto f(UDT x, swoc::meta::CaseTag<0>) -> decltype(cheer_for_delain(eraser<V>(x)))
- *   { return cheer_for_delain(eraser<V>(x));  }
- *
- *   template <typename V = void>
- *   auto f(UDT x, swoc::meta::CaseTag<1>) -> decltype(cheer_delain(eraser<V>(x)))
- *   { return cheer_delain(eraser<V>(x)); }
- *
- *   f(x, swoc::meta::CaseArg); // Invoke the correctly named function
- * @endcode
- */
-template <typename T, typename U>
-constexpr auto
-eraser(U &&u) -> U {
-  return std::forward<U>(u);
-}
+    /** Template parameter eraser.
+     *
+     * @tparam T Parameter to erase (pass explicitly)
+     * @tparam U Parameter for forwarded value (implicit)
+     * @param u Forward value
+     * @return @a u
+     *
+     * This has no effect on @a u but fools the compiler in to thinking @a T has been used.
+     * This avoids metaprogramming issues with unused template parameters.
+     *
+     * Suppose an API has changed a function from "cheer_for_delain" to "cheer_delain". To handle this
+     * the metacase support is used, but there is no apparent template parameter. A fake one can be used
+     * and defaulted to @c void. But that creates the unused template parameter warning. This is fixed
+     * by doing something to erase the template parameter @a V while forwarding parameter @a x. The result
+     * is a function @c f that calls the correct function automatically. Note this can't be in the body of
+     * the function because even for SFINAE the function body must compile and the variant with the wrong
+     * function will fail.
+     *
+     * @code
+     *   template <typename V = void>
+     *   auto f(UDT x, swoc::meta::CaseTag<0>) -> decltype(cheer_for_delain(eraser<V>(x)))
+     *   { return cheer_for_delain(eraser<V>(x));  }
+     *
+     *   template <typename V = void>
+     *   auto f(UDT x, swoc::meta::CaseTag<1>) -> decltype(cheer_delain(eraser<V>(x)))
+     *   { return cheer_delain(eraser<V>(x)); }
+     *
+     *   f(x, swoc::meta::CaseArg); // Invoke the correctly named function
+     * @endcode
+     */
+    template <typename T, typename U>
+    constexpr auto
+    eraser(U &&u) -> U
+    {
+      return std::forward<U>(u);
+    }
 
-/** Support for variable parameter lambdas.
- *
- * @tparam Args Lambdas to combine.
- *
- * This creates a class that has an overloaded function operator, with each overload corresponding
- * to one of the provided lambdas. The original use case is with @c std::visit where this can be
- * used to construct the @a visitor from a collection of lambdas.
- *
- * @code
- * std::variant<int, bool> v;
- * std::visit(swoc::meta::vary{
- *   [] (int & i) { ... },
- *   [] (bool & b) { ... }
- *   }, v);
- * @endcode
- */
-template <typename... Args> struct vary : public Args... { using Args::operator()...; };
-/// Template argument deduction guide (C++17 required).
-template <typename... Args> vary(Args...) -> vary<Args...>;
+    /** Support for variable parameter lambdas.
+     *
+     * @tparam Args Lambdas to combine.
+     *
+     * This creates a class that has an overloaded function operator, with each overload corresponding
+     * to one of the provided lambdas. The original use case is with @c std::visit where this can be
+     * used to construct the @a visitor from a collection of lambdas.
+     *
+     * @code
+     * std::variant<int, bool> v;
+     * std::visit(swoc::meta::vary{
+     *   [] (int & i) { ... },
+     *   [] (bool & b) { ... }
+     *   }, v);
+     * @endcode
+     */
+    template <typename... Args> struct vary : public Args... {
+      using Args::operator()...;
+    };
+    /// Template argument deduction guide (C++17 required).
+    template <typename... Args> vary(Args...) -> vary<Args...>;
 
-/** Check if a type is any of a set of types.
- *
- * @tparam T Type to check.
- * @tparam Types Type list to match against.
- *
- * @a value is @c true if @a T is the same as any of @a Types. This is commonly used with
- * @c enable_if to enable a function / method only if the argument type is one of a fixed set.
- * @code
- *   template < typename T > auto f(T const& t)
- *     -> std::enable_if_t<swoc::meta::is_any_of<T, int, float, bool>::value, void>::value
- *   { ... }
- */
-template <typename T, typename... Types> struct is_any_of {
-  static constexpr bool value = std::disjunction<std::is_same<T, Types>...>::value;
-};
+    /** Check if a type is any of a set of types.
+     *
+     * @tparam T Type to check.
+     * @tparam Types Type list to match against.
+     *
+     * @a value is @c true if @a T is the same as any of @a Types. This is commonly used with
+     * @c enable_if to enable a function / method only if the argument type is one of a fixed set.
+     * @code
+     *   template < typename T > auto f(T const& t)
+     *     -> std::enable_if_t<swoc::meta::is_any_of<T, int, float, bool>::value, void>::value
+     *   { ... }
+     */
+    template <typename T, typename... Types> struct is_any_of {
+      static constexpr bool value = std::disjunction<std::is_same<T, Types>...>::value;
+    };
 
-template <typename T, typename... Types> struct is_homogenous {
-  static constexpr bool value = std::conjunction<std::is_same<T, Types>...>::value;
-  using type                  = T;
-};
+    template <typename T, typename... Types> struct is_homogenous {
+      static constexpr bool value = std::conjunction<std::is_same<T, Types>...>::value;
+      using type                  = T;
+    };
 
-/// Helper variable template for is_any_of
-template <typename T, typename... Types> inline constexpr bool is_any_of_v = is_any_of<T, Types...>::value;
+    /// Helper variable template for is_any_of
+    template <typename T, typename... Types> inline constexpr bool is_any_of_v = is_any_of<T, Types...>::value;
 
-/** Type list support class.
- *
- * @tparam Types List of types.
- *
- * The examples for the nested meta functions presume a type list has been defined like
- * @code
- * using TL = swoc::meta::type_list<int, bool, float, double>;
- * @endcode
- */
-template <typename... Types> struct type_list {
-  /// Length of the type list.
-  static constexpr size_t size = sizeof...(Types);
+    /** Type list support class.
+     *
+     * @tparam Types List of types.
+     *
+     * The examples for the nested meta functions presume a type list has been defined like
+     * @code
+     * using TL = swoc::meta::type_list<int, bool, float, double>;
+     * @endcode
+     */
+    template <typename... Types> struct type_list {
+      /// Length of the type list.
+      static constexpr size_t size = sizeof...(Types);
 
-  /** Define a type using the types in the list.
-   * Give a type list, defining a variant that has those types would be
-   * @code
-   * using v = TL::template apply<std::variant>;
-   * @endcode
-   *
-   * The primary reason to do this is if the type list is needed elsewhere (e.g. to enable
-   * methods only for variant types).
-   *
-   * @see contains
-   */
-  template <template <typename... Pack> typename T> using apply = T<Types...>;
+      /** Define a type using the types in the list.
+       * Give a type list, defining a variant that has those types would be
+       * @code
+       * using v = TL::template apply<std::variant>;
+       * @endcode
+       *
+       * The primary reason to do this is if the type list is needed elsewhere (e.g. to enable
+       * methods only for variant types).
+       *
+       * @see contains
+       */
+      template <template <typename... Pack> typename T> using apply = T<Types...>;
 
-  /** Determine if a type @a T is a member of the type list.
-   *
-   * @tparam T Type to check.
-   *
-   * Frequently used with @c enable_if. This is handy for variants, if the list of variant
-   * types is encoded in the type list.
-   *
-   * @code
-   * template < typename T > auto f(T const& t)
-   *   -> std::enable_if_t<TL::template contains<T>::value, void>
-   * { ... }
-   * @endcode
-   */
-  template <typename T> static constexpr bool contains = is_any_of<T, Types...>::value;
-};
+      /** Determine if a type @a T is a member of the type list.
+       *
+       * @tparam T Type to check.
+       *
+       * Frequently used with @c enable_if. This is handy for variants, if the list of variant
+       * types is encoded in the type list.
+       *
+       * @code
+       * template < typename T > auto f(T const& t)
+       *   -> std::enable_if_t<TL::template contains<T>::value, void>
+       * { ... }
+       * @endcode
+       */
+      template <typename T> static constexpr bool contains = is_any_of<T, Types...>::value;
+    };
 
-}}} // namespace swoc::SWOC_VERSION_NS::meta
+  } // namespace meta
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/include/swoc/swoc_version.h
+++ b/code/include/swoc/swoc_version.h
@@ -26,8 +26,12 @@
 #define SWOC_VERSION_NS _1_5_6
 #endif
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
-static constexpr unsigned MAJOR_VERSION = 1;
-static constexpr unsigned MINOR_VERSION = 5;
-static constexpr unsigned POINT_VERSION = 6;
-}} // namespace swoc::SWOC_VERSION_NS
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  static constexpr unsigned MAJOR_VERSION = 1;
+  static constexpr unsigned MINOR_VERSION = 5;
+  static constexpr unsigned POINT_VERSION = 6;
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/src/ArenaWriter.cc
+++ b/code/src/ArenaWriter.cc
@@ -6,43 +6,50 @@
 
 #include "swoc/ArenaWriter.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
 
-ArenaWriter &
-ArenaWriter::write(char c) {
-  if (_attempted >= _capacity) {
-    this->realloc(_attempted + 1);
+  ArenaWriter &
+  ArenaWriter::write(char c)
+  {
+    if (_attempted >= _capacity) {
+      this->realloc(_attempted + 1);
+    }
+    this->super_type::write(c);
+    return *this;
   }
-  this->super_type::write(c);
-  return *this;
-}
 
-ArenaWriter &
-ArenaWriter::write(void const *data, size_t n) {
-  if (n + _attempted > _capacity) {
-    this->realloc(n + _attempted);
+  ArenaWriter &
+  ArenaWriter::write(void const *data, size_t n)
+  {
+    if (n + _attempted > _capacity) {
+      this->realloc(n + _attempted);
+    }
+    this->super_type::write(data, n);
+    return *this;
   }
-  this->super_type::write(data, n);
-  return *this;
-}
 
-bool
-ArenaWriter::commit(size_t n) {
-  if (_attempted + n > _capacity) {
-    this->realloc(_attempted + n);
-    return false;
+  bool
+  ArenaWriter::commit(size_t n)
+  {
+    if (_attempted + n > _capacity) {
+      this->realloc(_attempted + n);
+      return false;
+    }
+    return this->super_type::commit(n);
   }
-  return this->super_type::commit(n);
-}
 
-void
-ArenaWriter::realloc(size_t n) {
-  auto text                    = this->view(); // Current data.
-  auto span                    = _arena.require(n).remnant().rebind<char>();
-  const_cast<char *&>(_buffer) = span.data();
-  _capacity                    = span.size();
-  memcpy(_buffer, text.data(), text.size());
-}
+  void
+  ArenaWriter::realloc(size_t n)
+  {
+    auto text                    = this->view(); // Current data.
+    auto span                    = _arena.require(n).remnant().rebind<char>();
+    const_cast<char *&>(_buffer) = span.data();
+    _capacity                    = span.size();
+    memcpy(_buffer, text.data(), text.size());
+  }
 
-}  // namespace SWOC_VERSION_NS
-}  // namespace swoc
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/src/Errata.cc
+++ b/code/src/Errata.cc
@@ -18,172 +18,192 @@ using std::string_view;
 using namespace std::literals;
 using namespace swoc::literals;
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
-/** List of sinks for abandoned erratum.
- */
-namespace {
-std::vector<Errata::Sink::Handle> Sink_List;
-}
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  /** List of sinks for abandoned erratum.
+   */
+  namespace
+  {
+    std::vector<Errata::Sink::Handle> Sink_List;
+  }
 
-string_view
-Errata::Data::localize(string_view src) {
-  auto span = _arena.alloc(src.size()).rebind<char>();
-  memcpy(span.data(), src.data(), src.size());
-  return { span.data(), span.size() };
-}
+  string_view
+  Errata::Data::localize(string_view src)
+  {
+    auto span = _arena.alloc(src.size()).rebind<char>();
+    memcpy(span.data(), src.data(), src.size());
+    return {span.data(), span.size()};
+  }
 
-/* ----------------------------------------------------------------------- */
-// methods for Errata
+  /* ----------------------------------------------------------------------- */
+  // methods for Errata
 
-Errata::Severity Errata::DEFAULT_SEVERITY(2);
-Errata::Severity Errata::FAILURE_SEVERITY(2);
-Errata::Severity Errata::FILTER_SEVERITY(0);
+  Errata::Severity Errata::DEFAULT_SEVERITY(2);
+  Errata::Severity Errata::FAILURE_SEVERITY(2);
+  Errata::Severity Errata::FILTER_SEVERITY(0);
 
-/// Default set of severity names.
-std::array<swoc::TextView, 3> Severity_Names{{"Info", "Warning", "Error"}};
+  /// Default set of severity names.
+  std::array<swoc::TextView, 3> Severity_Names{
+    {"Info", "Warning", "Error"}
+  };
 
-swoc::MemSpan<TextView const> Errata::SEVERITY_NAMES{Severity_Names.data(), Severity_Names.size()};
+  swoc::MemSpan<TextView const> Errata::SEVERITY_NAMES{Severity_Names.data(), Severity_Names.size()};
 
-Errata::~Errata() {
-  this->sink();
-}
+  Errata::~Errata()
+  {
+    this->sink();
+  }
 
-Errata&
-Errata::sink() {
-  if (_data) {
-    for (auto &f : Sink_List) {
-      (*f)(*this);
+  Errata &
+  Errata::sink()
+  {
+    if (_data) {
+      for (auto &f : Sink_List) {
+        (*f)(*this);
+      }
+      this->clear();
     }
-    this->clear();
+    return *this;
   }
-  return *this;
-}
 
-Errata &
-Errata::note(code_type const &code) {
-  return this->note("{}"_sv, code);
-}
-
-Errata &
-Errata::note(code_type const &code, Severity severity) {
-  return this->note(severity, "{}"_sv, code);
-}
-
-Errata::Data *
-Errata::data() {
-  if (!_data) {
-    MemArena arena{512}; // POOMA value, seems reasonable.
-    _data = arena.make<Data>(std::move(arena));
+  Errata &
+  Errata::note(code_type const &code)
+  {
+    return this->note("{}"_sv, code);
   }
-  return _data;
-}
 
-Errata &
-Errata::note_s(std::optional<Severity> severity, std::string_view text) {
-  if (severity.has_value()) {
-    this->update(*severity);
+  Errata &
+  Errata::note(code_type const &code, Severity severity)
+  {
+    return this->note(severity, "{}"_sv, code);
   }
-  if (!severity.has_value() || *severity >= FILTER_SEVERITY) {
-    auto span = this->alloc(text.size());
-    memcpy(span, text);
-    this->note_localized(TextView(span), severity);
-  }
-  return *this;
-}
 
-Errata &
-Errata::note_localized(std::string_view const &text, std::optional<Severity> severity) {
-  auto d        = this->data();
-  auto *n = d->_arena.make<Annotation>(text, severity);
-  d->_notes.append(n);
-  return *this;
-}
-
-MemSpan<char>
-Errata::alloc(size_t n) {
-  return this->data()->_arena.alloc(n).rebind<char>();
-}
-
-Errata &
-Errata::note(const self_type &that) {
-  if (that._data) {
-    auto d       = this->data();
-    if (that.has_severity()) {
-      this->update(that.severity());
+  Errata::Data *
+  Errata::data()
+  {
+    if (!_data) {
+      MemArena arena{512}; // POOMA value, seems reasonable.
+      _data = arena.make<Data>(std::move(arena));
     }
-    for (auto const &annotation : that) {
-      d->_notes.append(d->_arena.make<Annotation>(d->localize(annotation._text), annotation._severity, annotation._level + 1));
+    return _data;
+  }
+
+  Errata &
+  Errata::note_s(std::optional<Severity> severity, std::string_view text)
+  {
+    if (severity.has_value()) {
+      this->update(*severity);
     }
-  }
-  return *this;
-}
-
-auto Errata::update(Severity severity) -> self_type & {
-  if (! _data || ! _data->_severity.has_value() || _data->_severity.value() < severity) {
-    this->assign(severity);
-  }
-  return *this;
-}
-
-void
-Errata::register_sink(Sink::Handle const &s) {
-  Sink_List.push_back(s);
-}
-
-BufferWriter &
-bwformat(BufferWriter &bw, bwf::Spec const &spec, Errata::Severity level) {
-  if (level < Errata::SEVERITY_NAMES.size()) {
-    bwformat(bw, spec, Errata::SEVERITY_NAMES[level]);
-  } else {
-    bwformat(bw, spec, level._raw);
-  }
-  return bw;
-}
-
-BufferWriter &
-bwformat(BufferWriter &bw, bwf::Spec const &, Errata const &errata) {
-  bwf::Format const code_fmt{"[{0:s} {0:d}] "};
-
-  if (errata.has_severity()) {
-    bw.print("{}{}", errata.severity(), errata.severity_glue_text());
-  }
-
-  if (errata.code()) {
-    bw.print(code_fmt, errata.code());
-  }
-
-  bool trailing_p = false;
-  auto glue = errata.annotation_glue_text();
-  auto a_s_glue = errata.annotation_severity_glue_text();
-  auto id_txt = errata.indent_text();
-  for (auto &note : errata) {
-    if (note.text()) {
-      bw.print("{}{}{}{}"
-               , swoc::bwf::If(trailing_p, "{}", glue)
-               , swoc::bwf::Pattern{int(note.level()), id_txt}
-               , swoc::bwf::If(note.has_severity(), "{}{}", note.severity(), a_s_glue)
-               , note.text());
-      trailing_p = true;
+    if (!severity.has_value() || *severity >= FILTER_SEVERITY) {
+      auto span = this->alloc(text.size());
+      memcpy(span, text);
+      this->note_localized(TextView(span), severity);
     }
+    return *this;
   }
-  if (trailing_p && errata._data->_glue_final_p) {
-    bw.print("{}", glue);
+
+  Errata &
+  Errata::note_localized(std::string_view const &text, std::optional<Severity> severity)
+  {
+    auto d  = this->data();
+    auto *n = d->_arena.make<Annotation>(text, severity);
+    d->_notes.append(n);
+    return *this;
   }
-  return bw;
-}
 
-std::ostream &
-Errata::write(std::ostream &out) const {
-  std::string tmp;
-  tmp.reserve(1024);
-  bwprint(tmp, "{}", *this);
-  return out << tmp;
-}
+  MemSpan<char>
+  Errata::alloc(size_t n)
+  {
+    return this->data()->_arena.alloc(n).rebind<char>();
+  }
 
-std::ostream &
-operator<<(std::ostream &os, Errata const &err) {
-  return err.write(os);
-}
+  Errata &
+  Errata::note(const self_type &that)
+  {
+    if (that._data) {
+      auto d = this->data();
+      if (that.has_severity()) {
+        this->update(that.severity());
+      }
+      for (auto const &annotation : that) {
+        d->_notes.append(d->_arena.make<Annotation>(d->localize(annotation._text), annotation._severity, annotation._level + 1));
+      }
+    }
+    return *this;
+  }
 
-}  // namespace SWOC_VERSION_NS
-}  // namespace swoc
+  auto
+  Errata::update(Severity severity) -> self_type &
+  {
+    if (!_data || !_data->_severity.has_value() || _data->_severity.value() < severity) {
+      this->assign(severity);
+    }
+    return *this;
+  }
+
+  void
+  Errata::register_sink(Sink::Handle const &s)
+  {
+    Sink_List.push_back(s);
+  }
+
+  BufferWriter &
+  bwformat(BufferWriter &bw, bwf::Spec const &spec, Errata::Severity level)
+  {
+    if (level < Errata::SEVERITY_NAMES.size()) {
+      bwformat(bw, spec, Errata::SEVERITY_NAMES[level]);
+    } else {
+      bwformat(bw, spec, level._raw);
+    }
+    return bw;
+  }
+
+  BufferWriter &
+  bwformat(BufferWriter &bw, bwf::Spec const &, Errata const &errata)
+  {
+    bwf::Format const code_fmt{"[{0:s} {0:d}] "};
+
+    if (errata.has_severity()) {
+      bw.print("{}{}", errata.severity(), errata.severity_glue_text());
+    }
+
+    if (errata.code()) {
+      bw.print(code_fmt, errata.code());
+    }
+
+    bool trailing_p = false;
+    auto glue       = errata.annotation_glue_text();
+    auto a_s_glue   = errata.annotation_severity_glue_text();
+    auto id_txt     = errata.indent_text();
+    for (auto &note : errata) {
+      if (note.text()) {
+        bw.print("{}{}{}{}", swoc::bwf::If(trailing_p, "{}", glue), swoc::bwf::Pattern{int(note.level()), id_txt},
+                 swoc::bwf::If(note.has_severity(), "{}{}", note.severity(), a_s_glue), note.text());
+        trailing_p = true;
+      }
+    }
+    if (trailing_p && errata._data->_glue_final_p) {
+      bw.print("{}", glue);
+    }
+    return bw;
+  }
+
+  std::ostream &
+  Errata::write(std::ostream &out) const
+  {
+    std::string tmp;
+    tmp.reserve(1024);
+    bwprint(tmp, "{}", *this);
+    return out << tmp;
+  }
+
+  std::ostream &
+  operator<<(std::ostream &os, Errata const &err)
+  {
+    return err.write(os);
+  }
+
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/src/MemArena.cc
+++ b/code/src/MemArena.cc
@@ -8,256 +8,279 @@
 #include "swoc/MemArena.h"
 #include <algorithm>
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
 
-void (*MemArena::destroyer)(MemArena*) = std::destroy_at<MemArena>;
+  void (*MemArena::destroyer)(MemArena *) = std::destroy_at<MemArena>;
 
-inline bool
-MemArena::Block::satisfies(size_t n, size_t align) const {
-  auto r = this->remaining();
-  return r >= (n + align_padding(this->data() + allocated, align));
-}
-
-MemArena::MemArena(MemSpan<void> static_block) {
-  static constexpr Scalar<16, size_t> MIN_BLOCK_SIZE = round_up(sizeof(Block) + Block::MIN_FREE_SPACE);
-  if (static_block.size() < MIN_BLOCK_SIZE) {
-    throw std::domain_error("MemArena static block is too small.");
+  inline bool
+  MemArena::Block::satisfies(size_t n, size_t align) const
+  {
+    auto r = this->remaining();
+    return r >= (n + align_padding(this->data() + allocated, align));
   }
-  // Construct the block data in the block and put it on the list. Make a note this is the
-  // static block that shouldn't be deleted.
-  auto space       = static_block.size() - sizeof(Block);
-  _static_block    = new (static_block.data()) Block(space);
-  _active_reserved = space;
-  _active.prepend(_static_block);
-}
 
-// Need to break these out because the default implementation doesn't clear the
-// integral values in @a that.
+  MemArena::MemArena(MemSpan<void> static_block)
+  {
+    static constexpr Scalar<16, size_t> MIN_BLOCK_SIZE = round_up(sizeof(Block) + Block::MIN_FREE_SPACE);
+    if (static_block.size() < MIN_BLOCK_SIZE) {
+      throw std::domain_error("MemArena static block is too small.");
+    }
+    // Construct the block data in the block and put it on the list. Make a note this is the
+    // static block that shouldn't be deleted.
+    auto space       = static_block.size() - sizeof(Block);
+    _static_block    = new (static_block.data()) Block(space);
+    _active_reserved = space;
+    _active.prepend(_static_block);
+  }
 
-MemArena::MemArena(swoc::MemArena::self_type &&that)
- noexcept   : _active_allocated(that._active_allocated),
-    _active_reserved(that._active_reserved),
-    _frozen_allocated(that._frozen_allocated),
-    _frozen_reserved(that._frozen_reserved),
-    _reserve_hint(that._reserve_hint),
-    _frozen(std::move(that._frozen)),
-    _active(std::move(that._active)),
-    _static_block(that._static_block) {
-  // Clear data in @a that to indicate all of the memory has been moved.
-  that._active_allocated = that._active_reserved = 0;
-  that._frozen_allocated = that._frozen_reserved = 0;
-  that._reserve_hint                             = 0;
-  that._static_block                             = nullptr;
-}
+  // Need to break these out because the default implementation doesn't clear the
+  // integral values in @a that.
 
-MemArena *
-MemArena::construct_self_contained(size_t n) {
-  MemArena tmp{n + sizeof(MemArena)};
-  return tmp.make<MemArena>(std::move(tmp));
-}
+  MemArena::MemArena(swoc::MemArena::self_type &&that) noexcept
+    : _active_allocated(that._active_allocated),
+      _active_reserved(that._active_reserved),
+      _frozen_allocated(that._frozen_allocated),
+      _frozen_reserved(that._frozen_reserved),
+      _reserve_hint(that._reserve_hint),
+      _frozen(std::move(that._frozen)),
+      _active(std::move(that._active)),
+      _static_block(that._static_block)
+  {
+    // Clear data in @a that to indicate all of the memory has been moved.
+    that._active_allocated = that._active_reserved = 0;
+    that._frozen_allocated = that._frozen_reserved = 0;
+    that._reserve_hint                             = 0;
+    that._static_block                             = nullptr;
+  }
 
-MemArena &
-MemArena::operator=(swoc::MemArena::self_type &&that)  noexcept {
-  this->clear();
-  std::swap(_active_allocated, that._active_allocated);
-  std::swap(_active_reserved, that._active_reserved);
-  std::swap(_frozen_allocated, that._frozen_allocated);
-  std::swap(_frozen_reserved, that._frozen_reserved);
-  std::swap(_reserve_hint, that._reserve_hint);
-  _active = std::move(that._active);
-  _frozen = std::move(that._frozen);
-  return *this;
-}
+  MemArena *
+  MemArena::construct_self_contained(size_t n)
+  {
+    MemArena tmp{n + sizeof(MemArena)};
+    return tmp.make<MemArena>(std::move(tmp));
+  }
 
-MemArena::Block *
-MemArena::make_block(size_t n) {
-  // If there's no reservation hint, use the extent. This is transient because the hint is cleared.
-  if (_reserve_hint == 0) {
-    if (_active_reserved) {
-      _reserve_hint = _active_reserved;
-    } else if (_frozen_allocated) { // immediately after freezing - use that extent.
-      _reserve_hint = _frozen_allocated;
+  MemArena &
+  MemArena::operator=(swoc::MemArena::self_type &&that) noexcept
+  {
+    this->clear();
+    std::swap(_active_allocated, that._active_allocated);
+    std::swap(_active_reserved, that._active_reserved);
+    std::swap(_frozen_allocated, that._frozen_allocated);
+    std::swap(_frozen_reserved, that._frozen_reserved);
+    std::swap(_reserve_hint, that._reserve_hint);
+    _active = std::move(that._active);
+    _frozen = std::move(that._frozen);
+    return *this;
+  }
+
+  MemArena::Block *
+  MemArena::make_block(size_t n)
+  {
+    // If there's no reservation hint, use the extent. This is transient because the hint is cleared.
+    if (_reserve_hint == 0) {
+      if (_active_reserved) {
+        _reserve_hint = _active_reserved;
+      } else if (_frozen_allocated) { // immediately after freezing - use that extent.
+        _reserve_hint = _frozen_allocated;
+      }
+    }
+    n             = std::max<size_t>(n, _reserve_hint);
+    _reserve_hint = 0; // did this, clear for next time.
+    // Add in overhead and round up to paragraph units.
+    n = Paragraph{round_up(n + ALLOC_HEADER_SIZE + sizeof(Block))};
+    // If more than a page or withing a quarter page of a full page,
+    // round up to page unit size and clip back to account for alloc header.
+    if (n >= (Page::SCALE - QuarterPage::SCALE)) {
+      n = Page{round_up(n)} - ALLOC_HEADER_SIZE;
+    } else if (n >= QuarterPage::SCALE) { // if at least a quarter page, round up to quarter pages.
+      n = QuarterPage{round_up(n)};
+    }
+
+    // Allocate space for the Block instance and the request memory and construct a Block at the front.
+    // In theory this could use ::operator new(n) but this causes a size mismatch during ::operator delete.
+    // Easier to use malloc and override @c delete.
+    auto free_space   = n - sizeof(Block);
+    _active_reserved += free_space;
+    return new (::malloc(n)) Block(free_space);
+  }
+
+  MemSpan<void>
+  MemArena::alloc(size_t n, size_t align)
+  {
+    MemSpan<void> zret;
+    this->require(n, align);
+    auto block         = _active.head();
+    zret               = block->alloc(n, align);
+    _active_allocated += n;
+    // If this block is now full, move it to the back.
+    if (block->is_full() && block != _active.tail()) {
+      _active.erase(block);
+      _active.append(block);
+    }
+    return zret;
+  }
+
+  MemArena &
+  MemArena::freeze(size_t n)
+  {
+    this->destroy_frozen();
+    _frozen = std::move(_active);
+    // Update the meta data.
+    _frozen_allocated = _active_allocated;
+    _active_allocated = 0;
+    _frozen_reserved  = _active_reserved;
+    _active_reserved  = 0;
+
+    _reserve_hint = n;
+
+    return *this;
+  }
+
+  MemArena &
+  MemArena::thaw()
+  {
+    this->destroy_frozen();
+    _frozen_reserved = _frozen_allocated = 0;
+    if (_static_block) {
+      _static_block->discard();
+      _active.prepend(_static_block);
+      _active_reserved += _static_block->remaining();
+    }
+    return *this;
+  }
+
+  bool
+  MemArena::contains(const void *ptr) const
+  {
+    auto pred = [ptr](const Block &b) -> bool { return b.contains(ptr); };
+
+    return std::any_of(_active.begin(), _active.end(), pred) || std::any_of(_frozen.begin(), _frozen.end(), pred);
+  }
+
+  MemArena &
+  MemArena::require(size_t n, size_t align)
+  {
+    auto spot = _active.begin();
+    Block *block{nullptr};
+
+    // Search back through the list until a full block is hit, which is a miss.
+    while (spot != _active.end() && !spot->satisfies(n, align)) {
+      if (spot->is_full()) {
+        spot = _active.end();
+      } else {
+        ++spot;
+      }
+    }
+    if (spot == _active.end()) {   // no block has enough free space
+      block = this->make_block(n); // assuming a new block is sufficiently aligned.
+      _active.prepend(block);
+    } else if (spot != _active.begin()) {
+      // big enough space, move to the head of the list.
+      block = spot;
+      _active.erase(block);
+      _active.prepend(block);
+    }
+    // Invariant - the head active block has at least @a n bytes of free storage.
+    return *this;
+  }
+
+  void
+  MemArena::destroy_active()
+  {
+    auto sb = _static_block; // C++20 nonsense - capture of @a this is incompatible with C++17.
+    _active
+      .apply([=](Block *b) {
+        if (b != sb) {
+          delete b;
+        }
+      })
+      .clear();
+  }
+
+  void
+  MemArena::destroy_frozen()
+  {
+    auto sb = _static_block; // C++20 nonsense - capture of @a this is incompatible with C++17.
+    _frozen
+      .apply([=](Block *b) {
+        if (b != sb) {
+          delete b;
+        }
+      })
+      .clear();
+  }
+
+  MemArena &
+  MemArena::clear(size_t hint)
+  {
+    _reserve_hint    = hint ? hint : _frozen_allocated + _active_allocated;
+    _frozen_reserved = _frozen_allocated = 0;
+    _active_reserved = _active_allocated = 0;
+    this->destroy_frozen();
+    this->destroy_active();
+
+    return *this;
+  }
+
+  MemArena &
+  MemArena::discard(size_t hint)
+  {
+    _reserve_hint = hint ? hint : _frozen_allocated + _active_allocated;
+    for (auto &block : _active) {
+      block.discard();
+    }
+    _active_allocated = 0;
+    return *this;
+  }
+
+  MemArena::~MemArena()
+  {
+    // Destruct in a way that makes it safe for the instance to be in one of its own memory blocks.
+    // This means copying members that will be used during the delete.
+    Block *ba = _active.head();
+    Block *bf = _frozen.head();
+    Block *sb = _static_block;
+
+    _active.clear();
+    _frozen.clear();
+    while (bf) {
+      Block *b = bf;
+      bf       = bf->_link._next;
+      if (b != sb) {
+        delete b;
+      }
+    }
+    while (ba) {
+      Block *b = ba;
+      ba       = ba->_link._next;
+      if (b != sb) {
+        delete b;
+      }
     }
   }
-  n             = std::max<size_t>(n, _reserve_hint);
-  _reserve_hint = 0; // did this, clear for next time.
-  // Add in overhead and round up to paragraph units.
-  n = Paragraph{round_up(n + ALLOC_HEADER_SIZE + sizeof(Block))};
-  // If more than a page or withing a quarter page of a full page,
-  // round up to page unit size and clip back to account for alloc header.
-  if (n >= (Page::SCALE - QuarterPage::SCALE)) {
-    n = Page{round_up(n)} - ALLOC_HEADER_SIZE;
-  } else if (n >= QuarterPage::SCALE) { // if at least a quarter page, round up to quarter pages.
-    n = QuarterPage{round_up(n)};
-  }
-
-  // Allocate space for the Block instance and the request memory and construct a Block at the front.
-  // In theory this could use ::operator new(n) but this causes a size mismatch during ::operator delete.
-  // Easier to use malloc and override @c delete.
-  auto free_space = n - sizeof(Block);
-  _active_reserved += free_space;
-  return new (::malloc(n)) Block(free_space);
-}
-
-MemSpan<void>
-MemArena::alloc(size_t n, size_t align) {
-  MemSpan<void> zret;
-  this->require(n, align);
-  auto block = _active.head();
-  zret       = block->alloc(n, align);
-  _active_allocated += n;
-  // If this block is now full, move it to the back.
-  if (block->is_full() && block != _active.tail()) {
-    _active.erase(block);
-    _active.append(block);
-  }
-  return zret;
-}
-
-MemArena &
-MemArena::freeze(size_t n) {
-  this->destroy_frozen();
-  _frozen = std::move(_active);
-  // Update the meta data.
-  _frozen_allocated = _active_allocated;
-  _active_allocated = 0;
-  _frozen_reserved  = _active_reserved;
-  _active_reserved  = 0;
-
-  _reserve_hint = n;
-
-  return *this;
-}
-
-MemArena &
-MemArena::thaw() {
-  this->destroy_frozen();
-  _frozen_reserved = _frozen_allocated = 0;
-  if (_static_block) {
-    _static_block->discard();
-    _active.prepend(_static_block);
-    _active_reserved += _static_block->remaining();
-  }
-  return *this;
-}
-
-bool
-MemArena::contains(const void *ptr) const {
-  auto pred = [ptr](const Block &b) -> bool { return b.contains(ptr); };
-
-  return std::any_of(_active.begin(), _active.end(), pred) || std::any_of(_frozen.begin(), _frozen.end(), pred);
-}
-
-MemArena &
-MemArena::require(size_t n, size_t align) {
-  auto spot = _active.begin();
-  Block *block{nullptr};
-
-  // Search back through the list until a full block is hit, which is a miss.
-  while (spot != _active.end() && !spot->satisfies(n, align)) {
-    if (spot->is_full()) {
-      spot = _active.end();
-    } else {
-      ++spot;
-}
-  }
-  if (spot == _active.end()) {   // no block has enough free space
-    block = this->make_block(n); // assuming a new block is sufficiently aligned.
-    _active.prepend(block);
-  } else if (spot != _active.begin()) {
-    // big enough space, move to the head of the list.
-    block = spot;
-    _active.erase(block);
-    _active.prepend(block);
-  }
-  // Invariant - the head active block has at least @a n bytes of free storage.
-  return *this;
-}
-
-void
-MemArena::destroy_active() {
-  auto sb = _static_block; // C++20 nonsense - capture of @a this is incompatible with C++17.
-  _active
-    .apply([=](Block *b) {
-      if (b != sb) {
-        delete b;
-}
-    })
-    .clear();
-}
-
-void
-MemArena::destroy_frozen() {
-  auto sb = _static_block; // C++20 nonsense - capture of @a this is incompatible with C++17.
-  _frozen
-    .apply([=](Block *b) {
-      if (b != sb) {
-        delete b;
-}
-    })
-    .clear();
-}
-
-MemArena &
-MemArena::clear(size_t hint) {
-  _reserve_hint    = hint ? hint : _frozen_allocated + _active_allocated;
-  _frozen_reserved = _frozen_allocated = 0;
-  _active_reserved = _active_allocated = 0;
-  this->destroy_frozen();
-  this->destroy_active();
-
-  return *this;
-}
-
-MemArena &
-MemArena::discard(size_t hint) {
-  _reserve_hint = hint ? hint : _frozen_allocated + _active_allocated;
-  for (auto &block : _active) {
-    block.discard();
-  }
-  _active_allocated = 0;
-  return *this;
-}
-
-MemArena::~MemArena() {
-  // Destruct in a way that makes it safe for the instance to be in one of its own memory blocks.
-  // This means copying members that will be used during the delete.
-  Block *ba = _active.head();
-  Block *bf = _frozen.head();
-  Block *sb = _static_block;
-
-  _active.clear();
-  _frozen.clear();
-  while (bf) {
-    Block *b = bf;
-    bf       = bf->_link._next;
-    if (b != sb) {
-      delete b;
-}
-  }
-  while (ba) {
-    Block *b = ba;
-    ba       = ba->_link._next;
-    if (b != sb) {
-      delete b;
-}
-  }
-}
 
 #if __has_include(<memory_resource>)
-void *
-MemArena::do_allocate(std::size_t bytes, std::size_t align) {
-  return this->alloc(bytes, align).data();
-}
+  void *
+  MemArena::do_allocate(std::size_t bytes, std::size_t align)
+  {
+    return this->alloc(bytes, align).data();
+  }
 
-void
-MemArena::do_deallocate(void *, size_t, size_t) {}
+  void
+  MemArena::do_deallocate(void *, size_t, size_t)
+  {
+  }
 
-bool
-MemArena::do_is_equal(std::pmr::memory_resource const &that) const noexcept {
-  return this == &that;
-}
+  bool
+  MemArena::do_is_equal(std::pmr::memory_resource const &that) const noexcept
+  {
+    return this == &that;
+  }
 #endif
 
-}  // namespace SWOC_VERSION_NS
-}  // namespace swoc
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/src/RBTree.cc
+++ b/code/src/RBTree.cc
@@ -7,298 +7,314 @@
 
 #include "swoc/RBTree.h"
 
-namespace swoc { inline namespace SWOC_VERSION_NS { namespace detail {
-// These equality operators are only used in this file.
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  namespace detail
+  {
+    // These equality operators are only used in this file.
 
-/// Equality.
-/// @note If @a n is @c NULL it is treated as having the color @c BLACK.
-/// @return @c true if @a c and the color of @a n are the same.
-inline bool
-operator==(RBNode *n, RBNode::Color c) {
-  return c == (n ? n->color() : RBNode::Color::BLACK);
-}
-
-/// Equality.
-/// @note If @a n is @c NULL it is treated as having the color @c BLACK.
-/// @return @c true if @a c and the color of @a n are the same.
-inline bool
-operator==(RBNode::Color c, RBNode *n) {
-  return n == c;
-}
-
-RBNode *
-RBNode::child_at(Direction d) const {
-  return d == Direction::RIGHT ? _right : d == Direction::LEFT ? _left : nullptr;
-}
-
-RBNode *
-RBNode::rotate(Direction dir) {
-  self_type *parent   = _parent; // Cache because it can change before we use it.
-  Direction child_dir = _parent ? _parent->direction_of(this) : Direction::NONE;
-  Direction other_dir = this->flip(dir);
-  self_type *child    = this;
-
-  if (dir != Direction::NONE && this->child_at(other_dir)) {
-    child = this->child_at(other_dir);
-    this->clear_child(other_dir);
-    this->set_child(child->child_at(dir), other_dir);
-    child->clear_child(dir);
-    child->set_child(this, dir);
-    child->structure_fixup();
-    this->structure_fixup();
-    if (parent) {
-      parent->clear_child(child_dir);
-      parent->set_child(child, child_dir);
-    } else {
-      child->_parent = nullptr;
-    }
-  }
-  return child;
-}
-
-RBNode *
-RBNode::set_child(self_type *child, Direction dir) {
-  if (child) {
-    child->_parent = this;
-  }
-  if (dir == Direction::RIGHT) {
-    _right = child;
-  } else if (dir == Direction::LEFT) {
-    _left = child;
-  }
-  return child;
-}
-
-RBNode *
-RBNode::ripple_structure_fixup() {
-  self_type *root = this; // last node seen, root node at the end
-  self_type *p    = this;
-  while (p) {
-    p->structure_fixup();
-    root = p;
-    p    = root->_parent;
-  }
-  return root;
-}
-
-void
-RBNode::replace_with(self_type *n) {
-  n->_color = _color;
-  if (_parent) {
-    Direction d = _parent->direction_of(this);
-    _parent->set_child(nullptr, d);
-    if (_parent != n) {
-      _parent->set_child(n, d);
-    }
-  } else {
-    n->_parent = nullptr;
-  }
-  n->_left = n->_right = nullptr;
-  if (_left && _left != n) {
-    n->set_child(_left, Direction::LEFT);
-  }
-  if (_right && _right != n) {
-    n->set_child(_right, Direction::RIGHT);
-  }
-  _left = _right = nullptr;
-}
-
-/* Rebalance the tree. This node is the unbalanced node. */
-RBNode *
-RBNode::rebalance_after_insert() {
-  self_type *x(this); // the node with the imbalance
-
-  while (x && x->_parent == Color::RED) {
-    Direction child_dir = Direction::NONE;
-
-    if (x->_parent->_parent) {
-      child_dir = x->_parent->_parent->direction_of(x->_parent);
-    } else {
-      break;
-    }
-    Direction other_dir(flip(child_dir));
-
-    self_type *y = x->_parent->_parent->child_at(other_dir);
-    if (y == Color::RED) {
-      x->_parent->_color = Color::BLACK;
-      y->_color          = Color::BLACK;
-      x                  = x->_parent->_parent;
-      x->_color          = Color::RED;
-    } else {
-      if (x->_parent->child_at(other_dir) == x) {
-        x = x->_parent;
-        x->rotate(child_dir);
-      }
-      // Note setting the parent color to BLACK causes the loop to exit.
-      x->_parent->_color          = Color::BLACK;
-      x->_parent->_parent->_color = Color::RED;
-      x->_parent->_parent->rotate(other_dir);
-    }
-  }
-
-  // every node above this one has a subtree structure change,
-  // so notify it. serendipitously, this makes it easy to return
-  // the new root node.
-  self_type *root = this->ripple_structure_fixup();
-  root->_color    = Color::BLACK;
-
-  return root;
-}
-
-// Returns new root node
-RBNode *
-RBNode::remove() {
-  self_type *root = nullptr; // new root node, returned to caller
-
-  /*  Handle two special cases first.
-      - This is the only node in the tree, return a new root of NIL
-      - This is the root node with only one child, return that child as new root
-  */
-  if (!_parent && !(_left && _right)) {
-    if (_left) {
-      _left->_parent = nullptr;
-      root           = _left;
-      root->_color   = Color::BLACK;
-    } else if (_right) {
-      _right->_parent = nullptr;
-      root            = _right;
-      root->_color    = Color::BLACK;
-    } // else that was the only node, so leave @a root @c NULL.
-    return root;
-  }
-
-  /*  The node to be removed from the tree.
-      If @c this (the target node) has both children, we remove its successor, which cannot have a
-      left child and put that node in place of the target node. Otherwise this node has at most
-      one child, so we can remove it. Note that the successor of a node with a right child is
-      always a right descendant of the node. Therefore, remove_node is an element of the tree
-      rooted at this node. Because of the initial special case checks, we know that remove_node is
-      @b not the root node.
-  */
-  self_type *remove_node(_left && _right ? _right->left_most_descendant() : this);
-
-  // This is the color of the node physically removed from the tree.
-  // Normally this is the color of @a remove_node
-  Color remove_color = remove_node->_color;
-  // Need to remember the direction from @a remove_node to @a splice_node
-  Direction d(Direction::NONE);
-
-  // The child node that will be promoted to replace the removed node.
-  // The choice of left or right is irrelevant, as remove_node has at
-  // most one child (and splice_node may be NIL if remove_node has no
-  // children).
-  self_type *splice_node(remove_node->_left ? remove_node->_left : remove_node->_right);
-
-  if (splice_node) {
-    // @c replace_with copies color so in this case the actual color
-    // lost is that of the splice_node.
-    remove_color = splice_node->_color;
-    remove_node->replace_with(splice_node);
-  } else {
-    // No children on remove node so we can just clip it off the tree
-    // We update splice_node to maintain the invariant that it is
-    // the node where the physical removal occurred.
-    splice_node = remove_node->_parent;
-    // Keep @a d up to date.
-    d = splice_node->direction_of(remove_node);
-    splice_node->set_child(nullptr, d);
-  }
-
-  // If the node to pull out of the tree isn't this one,
-  // then replace this node in the tree with that removed
-  // node in liu of copying the data over.
-  if (remove_node != this) {
-    // Don't leave @a splice_node referring to a removed node
-    if (splice_node == this) {
-      splice_node = remove_node;
-    }
-    this->replace_with(remove_node);
-  }
-
-  root         = splice_node->rebalance_after_remove(remove_color, d);
-  root->_color = Color::BLACK;
-  return root;
-}
-
-/**
- * Rebalance tree after a deletion
- * Called on the spliced in node or its parent, whichever is not NIL.
- * This modifies the tree structure only if @a c is @c BLACK.
- */
-RBNode *
-RBNode::rebalance_after_remove(Color c,    //!< The color of the removed node
-                               Direction d //!< Direction of removed node from its parent
-) {
-  self_type *root = nullptr;
-
-  if (Color::BLACK == c) { // only rebalance if too much black
-    self_type *n      = this;
-    self_type *parent = n->_parent;
-
-    // If @a direction is set, then we need to start at a leaf pseudo-node.
-    // This is why we need @a parent, otherwise we could just use @a n.
-    if (Direction::NONE != d) {
-      parent = n;
-      n      = nullptr;
+    /// Equality.
+    /// @note If @a n is @c NULL it is treated as having the color @c BLACK.
+    /// @return @c true if @a c and the color of @a n are the same.
+    inline bool
+    operator==(RBNode *n, RBNode::Color c)
+    {
+      return c == (n ? n->color() : RBNode::Color::BLACK);
     }
 
-    while (parent) { // @a n is not the root
-      // If the current node is Color::RED, we can just recolor and be done
-      if (n && n == Color::RED) {
-        n->_color = Color::BLACK;
-        break;
-      } else {
-        // Parameterizing the rebalance logic on the directions. We
-        // write for the left child case and flip directions for the
-        // right child case
-        Direction near(Direction::LEFT), far(Direction::RIGHT);
-        if ((Direction::NONE == d && parent->direction_of(n) == Direction::RIGHT) || Direction::RIGHT == d) {
-          near = Direction::RIGHT;
-          far  = Direction::LEFT;
-        }
+    /// Equality.
+    /// @note If @a n is @c NULL it is treated as having the color @c BLACK.
+    /// @return @c true if @a c and the color of @a n are the same.
+    inline bool
+    operator==(RBNode::Color c, RBNode *n)
+    {
+      return n == c;
+    }
 
-        self_type *w = parent->child_at(far); // sibling(n)
+    RBNode *
+    RBNode::child_at(Direction d) const
+    {
+      return d == Direction::RIGHT ? _right : d == Direction::LEFT ? _left : nullptr;
+    }
 
-        if (w->_color == Color::RED) {
-          w->_color      = Color::BLACK;
-          parent->_color = Color::RED;
-          parent->rotate(near);
-          w = parent->child_at(far);
-        }
+    RBNode *
+    RBNode::rotate(Direction dir)
+    {
+      self_type *parent   = _parent; // Cache because it can change before we use it.
+      Direction child_dir = _parent ? _parent->direction_of(this) : Direction::NONE;
+      Direction other_dir = this->flip(dir);
+      self_type *child    = this;
 
-        self_type *wfc = w->child_at(far);
-        if (w->child_at(near) == Color::BLACK && wfc == Color::BLACK) {
-          w->_color = Color::RED;
-          n         = parent;
-          parent    = n->_parent;
-          d         = Direction::NONE; // Cancel any leaf node logic
+      if (dir != Direction::NONE && this->child_at(other_dir)) {
+        child = this->child_at(other_dir);
+        this->clear_child(other_dir);
+        this->set_child(child->child_at(dir), other_dir);
+        child->clear_child(dir);
+        child->set_child(this, dir);
+        child->structure_fixup();
+        this->structure_fixup();
+        if (parent) {
+          parent->clear_child(child_dir);
+          parent->set_child(child, child_dir);
         } else {
-          if (wfc == Color::BLACK) {
-            w->child_at(near)->_color = Color::BLACK;
-            w->_color                 = Color::RED;
-            w->rotate(far);
-            w   = parent->child_at(far);
-            wfc = w->child_at(far); // w changed, update far child cache.
-          }
-          w->_color      = parent->_color;
-          parent->_color = Color::BLACK;
-          wfc->_color    = Color::BLACK;
-          parent->rotate(near);
+          child->_parent = nullptr;
+        }
+      }
+      return child;
+    }
+
+    RBNode *
+    RBNode::set_child(self_type *child, Direction dir)
+    {
+      if (child) {
+        child->_parent = this;
+      }
+      if (dir == Direction::RIGHT) {
+        _right = child;
+      } else if (dir == Direction::LEFT) {
+        _left = child;
+      }
+      return child;
+    }
+
+    RBNode *
+    RBNode::ripple_structure_fixup()
+    {
+      self_type *root = this; // last node seen, root node at the end
+      self_type *p    = this;
+      while (p) {
+        p->structure_fixup();
+        root = p;
+        p    = root->_parent;
+      }
+      return root;
+    }
+
+    void
+    RBNode::replace_with(self_type *n)
+    {
+      n->_color = _color;
+      if (_parent) {
+        Direction d = _parent->direction_of(this);
+        _parent->set_child(nullptr, d);
+        if (_parent != n) {
+          _parent->set_child(n, d);
+        }
+      } else {
+        n->_parent = nullptr;
+      }
+      n->_left = n->_right = nullptr;
+      if (_left && _left != n) {
+        n->set_child(_left, Direction::LEFT);
+      }
+      if (_right && _right != n) {
+        n->set_child(_right, Direction::RIGHT);
+      }
+      _left = _right = nullptr;
+    }
+
+    /* Rebalance the tree. This node is the unbalanced node. */
+    RBNode *
+    RBNode::rebalance_after_insert()
+    {
+      self_type *x(this); // the node with the imbalance
+
+      while (x && x->_parent == Color::RED) {
+        Direction child_dir = Direction::NONE;
+
+        if (x->_parent->_parent) {
+          child_dir = x->_parent->_parent->direction_of(x->_parent);
+        } else {
           break;
         }
-      }
-    }
-  }
-  root = this->ripple_structure_fixup();
-  return root;
-}
+        Direction other_dir(flip(child_dir));
 
-/** Ensure that the local information associated with each node is
-    correct globally This should only be called on debug builds as it
-    breaks any efficiencies we have gained from our tree structure.
-    */
-int
-RBNode::validate() {
+        self_type *y = x->_parent->_parent->child_at(other_dir);
+        if (y == Color::RED) {
+          x->_parent->_color = Color::BLACK;
+          y->_color          = Color::BLACK;
+          x                  = x->_parent->_parent;
+          x->_color          = Color::RED;
+        } else {
+          if (x->_parent->child_at(other_dir) == x) {
+            x = x->_parent;
+            x->rotate(child_dir);
+          }
+          // Note setting the parent color to BLACK causes the loop to exit.
+          x->_parent->_color          = Color::BLACK;
+          x->_parent->_parent->_color = Color::RED;
+          x->_parent->_parent->rotate(other_dir);
+        }
+      }
+
+      // every node above this one has a subtree structure change,
+      // so notify it. serendipitously, this makes it easy to return
+      // the new root node.
+      self_type *root = this->ripple_structure_fixup();
+      root->_color    = Color::BLACK;
+
+      return root;
+    }
+
+    // Returns new root node
+    RBNode *
+    RBNode::remove()
+    {
+      self_type *root = nullptr; // new root node, returned to caller
+
+      /*  Handle two special cases first.
+          - This is the only node in the tree, return a new root of NIL
+          - This is the root node with only one child, return that child as new root
+      */
+      if (!_parent && !(_left && _right)) {
+        if (_left) {
+          _left->_parent = nullptr;
+          root           = _left;
+          root->_color   = Color::BLACK;
+        } else if (_right) {
+          _right->_parent = nullptr;
+          root            = _right;
+          root->_color    = Color::BLACK;
+        } // else that was the only node, so leave @a root @c NULL.
+        return root;
+      }
+
+      /*  The node to be removed from the tree.
+          If @c this (the target node) has both children, we remove its successor, which cannot have a
+          left child and put that node in place of the target node. Otherwise this node has at most
+          one child, so we can remove it. Note that the successor of a node with a right child is
+          always a right descendant of the node. Therefore, remove_node is an element of the tree
+          rooted at this node. Because of the initial special case checks, we know that remove_node is
+          @b not the root node.
+      */
+      self_type *remove_node(_left && _right ? _right->left_most_descendant() : this);
+
+      // This is the color of the node physically removed from the tree.
+      // Normally this is the color of @a remove_node
+      Color remove_color = remove_node->_color;
+      // Need to remember the direction from @a remove_node to @a splice_node
+      Direction d(Direction::NONE);
+
+      // The child node that will be promoted to replace the removed node.
+      // The choice of left or right is irrelevant, as remove_node has at
+      // most one child (and splice_node may be NIL if remove_node has no
+      // children).
+      self_type *splice_node(remove_node->_left ? remove_node->_left : remove_node->_right);
+
+      if (splice_node) {
+        // @c replace_with copies color so in this case the actual color
+        // lost is that of the splice_node.
+        remove_color = splice_node->_color;
+        remove_node->replace_with(splice_node);
+      } else {
+        // No children on remove node so we can just clip it off the tree
+        // We update splice_node to maintain the invariant that it is
+        // the node where the physical removal occurred.
+        splice_node = remove_node->_parent;
+        // Keep @a d up to date.
+        d = splice_node->direction_of(remove_node);
+        splice_node->set_child(nullptr, d);
+      }
+
+      // If the node to pull out of the tree isn't this one,
+      // then replace this node in the tree with that removed
+      // node in liu of copying the data over.
+      if (remove_node != this) {
+        // Don't leave @a splice_node referring to a removed node
+        if (splice_node == this) {
+          splice_node = remove_node;
+        }
+        this->replace_with(remove_node);
+      }
+
+      root         = splice_node->rebalance_after_remove(remove_color, d);
+      root->_color = Color::BLACK;
+      return root;
+    }
+
+    /**
+     * Rebalance tree after a deletion
+     * Called on the spliced in node or its parent, whichever is not NIL.
+     * This modifies the tree structure only if @a c is @c BLACK.
+     */
+    RBNode *
+    RBNode::rebalance_after_remove(Color c,    //!< The color of the removed node
+                                   Direction d //!< Direction of removed node from its parent
+    )
+    {
+      self_type *root = nullptr;
+
+      if (Color::BLACK == c) { // only rebalance if too much black
+        self_type *n      = this;
+        self_type *parent = n->_parent;
+
+        // If @a direction is set, then we need to start at a leaf pseudo-node.
+        // This is why we need @a parent, otherwise we could just use @a n.
+        if (Direction::NONE != d) {
+          parent = n;
+          n      = nullptr;
+        }
+
+        while (parent) { // @a n is not the root
+          // If the current node is Color::RED, we can just recolor and be done
+          if (n && n == Color::RED) {
+            n->_color = Color::BLACK;
+            break;
+          } else {
+            // Parameterizing the rebalance logic on the directions. We
+            // write for the left child case and flip directions for the
+            // right child case
+            Direction near(Direction::LEFT), far(Direction::RIGHT);
+            if ((Direction::NONE == d && parent->direction_of(n) == Direction::RIGHT) || Direction::RIGHT == d) {
+              near = Direction::RIGHT;
+              far  = Direction::LEFT;
+            }
+
+            self_type *w = parent->child_at(far); // sibling(n)
+
+            if (w->_color == Color::RED) {
+              w->_color      = Color::BLACK;
+              parent->_color = Color::RED;
+              parent->rotate(near);
+              w = parent->child_at(far);
+            }
+
+            self_type *wfc = w->child_at(far);
+            if (w->child_at(near) == Color::BLACK && wfc == Color::BLACK) {
+              w->_color = Color::RED;
+              n         = parent;
+              parent    = n->_parent;
+              d         = Direction::NONE; // Cancel any leaf node logic
+            } else {
+              if (wfc == Color::BLACK) {
+                w->child_at(near)->_color = Color::BLACK;
+                w->_color                 = Color::RED;
+                w->rotate(far);
+                w   = parent->child_at(far);
+                wfc = w->child_at(far); // w changed, update far child cache.
+              }
+              w->_color      = parent->_color;
+              parent->_color = Color::BLACK;
+              wfc->_color    = Color::BLACK;
+              parent->rotate(near);
+              break;
+            }
+          }
+        }
+      }
+      root = this->ripple_structure_fixup();
+      return root;
+    }
+
+    /** Ensure that the local information associated with each node is
+        correct globally This should only be called on debug builds as it
+        breaks any efficiencies we have gained from our tree structure.
+        */
+    int
+    RBNode::validate()
+    {
 #if 0
   int black_ht = 0;
   int black_ht1, black_ht2;
@@ -334,20 +350,21 @@ RBNode::validate() {
 
   return black_ht;
 #else
-  return 0;
+      return 0;
 #endif
-}
+    }
 
-auto
-RBNode::left_most_descendant() const -> self_type * {
-  const self_type *n = this;
-  while (n->_left) {
-    n = n->_left;
-}
+    auto
+    RBNode::left_most_descendant() const -> self_type *
+    {
+      const self_type *n = this;
+      while (n->_left) {
+        n = n->_left;
+      }
 
-  return const_cast<self_type *>(n);
-}
+      return const_cast<self_type *>(n);
+    }
 
-}  // namespace detail
-}  // namespace SWOC_VERSION_NS
-}  // namespace swoc
+  } // namespace detail
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/src/TextView.cc
+++ b/code/src/TextView.cc
@@ -15,217 +15,225 @@
 
 using namespace swoc::literals;
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
 
-/// @cond INTERNAL_DETAIL
-const int8_t svtoi_convert[256] = {
-  /* [can't do this nicely because clang format won't allow exdented comments]
-   0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
-  */
-  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 00
-  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 10
-  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 20
-  0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  -1, -1, -1, -1, -1, -1, // 30
-  -1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, // 40
-  25, 26, 27, 28, 20, 30, 31, 32, 33, 34, 35, -1, -1, -1, -1, -1, // 50
-  -1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, // 60
-  25, 26, 27, 28, 20, 30, 31, 32, 33, 34, 35, -1, -1, -1, -1, -1, // 70
-  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 80
-  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 90
-  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // A0
-  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // B0
-  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // C0
-  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // D0
-  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // E0
-  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // F0
-};
-/// @endcond
+  /// @cond INTERNAL_DETAIL
+  const int8_t svtoi_convert[256] = {
+    /* [can't do this nicely because clang format won't allow exdented comments]
+     0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+    */
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 00
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 10
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 20
+    0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  -1, -1, -1, -1, -1, -1, // 30
+    -1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, // 40
+    25, 26, 27, 28, 20, 30, 31, 32, 33, 34, 35, -1, -1, -1, -1, -1, // 50
+    -1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, // 60
+    25, 26, 27, 28, 20, 30, 31, 32, 33, 34, 35, -1, -1, -1, -1, -1, // 70
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 80
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 90
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // A0
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // B0
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // C0
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // D0
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // E0
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // F0
+  };
+  /// @endcond
 
-intmax_t
-svtoi(TextView src, TextView *out, int base) {
-  intmax_t zret = 0;
+  intmax_t
+  svtoi(TextView src, TextView *out, int base)
+  {
+    intmax_t zret = 0;
 
-  if (src.ltrim_if(&isspace)) {
-    TextView parsed;
-    const char *start = src.data();
-    bool neg          = false;
-    if ('-' == *src) {
-      ++src;
-      neg = true;
-    } else if ('+' == *src) {
-      ++src;
-    }
-    zret = intmax_t(svtou(src, &parsed, base));
-    if (!parsed.empty()) {
-      if (out) {
-        out->assign(start, parsed.data_end());
-      }
-      if (neg) {
-        zret = -zret;
-      }
-    }
-  }
-  return zret;
-}
-
-uintmax_t
-svtou(TextView src, TextView *out, int base) {
-  uintmax_t zret = 0;
-
-  if (out) {
-    out->clear();
-  }
-  if (!(0 <= base && base <= 36)) {
-    return 0;
-  }
-  if (src.ltrim_if(&isspace).size()) {
-    auto origin = src.data();
-    int8_t v = 0;
-    // If base is 0, it wasn't specified - check for standard base prefixes
-    if (0 == base) {
-      base = 10;
-      if ('0' == *src) {
+    if (src.ltrim_if(&isspace)) {
+      TextView parsed;
+      const char *start = src.data();
+      bool neg          = false;
+      if ('-' == *src) {
         ++src;
-        base = 8;
-        if (src) {
-          switch (*src) {
-          case 'x':
-          case 'X':
-            ++src;
-            base = 16;
-            break;
-          case 'b':
-          case 'B':
-            ++src;
-            base = 2;
-            break;
+        neg = true;
+      } else if ('+' == *src) {
+        ++src;
+      }
+      zret = intmax_t(svtou(src, &parsed, base));
+      if (!parsed.empty()) {
+        if (out) {
+          out->assign(start, parsed.data_end());
+        }
+        if (neg) {
+          zret = -zret;
+        }
+      }
+    }
+    return zret;
+  }
+
+  uintmax_t
+  svtou(TextView src, TextView *out, int base)
+  {
+    uintmax_t zret = 0;
+
+    if (out) {
+      out->clear();
+    }
+    if (!(0 <= base && base <= 36)) {
+      return 0;
+    }
+    if (src.ltrim_if(&isspace).size()) {
+      auto origin = src.data();
+      int8_t v    = 0;
+      // If base is 0, it wasn't specified - check for standard base prefixes
+      if (0 == base) {
+        base = 10;
+        if ('0' == *src) {
+          ++src;
+          base = 8;
+          if (src) {
+            switch (*src) {
+            case 'x':
+            case 'X':
+              ++src;
+              base = 16;
+              break;
+            case 'b':
+            case 'B':
+              ++src;
+              base = 2;
+              break;
+            }
           }
         }
       }
-    }
 
-    // For performance in common cases, use the templated conversion.
-    switch (base) {
-    case 2:
-      zret = svto_radix<2>(src);
-      break;
-    case 8:
-      zret = svto_radix<8>(src);
-      break;
-    case 10:
-      zret = svto_radix<10>(src);
-      break;
-    case 16:
-      zret = svto_radix<16>(src);
-      break;
-    default:
-      while (src.size() && (0 <= (v = svtoi_convert[static_cast<unsigned char>(*src)])) && v < base) {
-        auto n = zret * base + v;
-        if (n < zret) {
-          zret = std::numeric_limits<uintmax_t>::max();
-          break; // overflow, stop parsing.
+      // For performance in common cases, use the templated conversion.
+      switch (base) {
+      case 2:
+        zret = svto_radix<2>(src);
+        break;
+      case 8:
+        zret = svto_radix<8>(src);
+        break;
+      case 10:
+        zret = svto_radix<10>(src);
+        break;
+      case 16:
+        zret = svto_radix<16>(src);
+        break;
+      default:
+        while (src.size() && (0 <= (v = svtoi_convert[static_cast<unsigned char>(*src)])) && v < base) {
+          auto n = zret * base + v;
+          if (n < zret) {
+            zret = std::numeric_limits<uintmax_t>::max();
+            break; // overflow, stop parsing.
+          }
+          zret = n;
+          ++src;
         }
-        zret = n;
-        ++src;
+        break;
       }
-      break;
-    }
 
-    if (out) {
-      out->assign(origin, src.data());
-    }
-  }
-  return zret;
-}
-
-double
-svtod(swoc::TextView text, swoc::TextView *parsed) {
-  // @return 10^e
-  auto pow10 = [](int e) -> double {
-    double zret  = 1.0;
-    double scale = 10.0;
-    if (e < 0) { // flip the scale and make @a e positive.
-      e     = -e;
-      scale = 0.1;
-    }
-
-    // Walk the bits in the exponent @a e and multiply the scale for set bits.
-    while (e) {
-      if (e & 1) {
-        zret *= scale;
+      if (out) {
+        out->assign(origin, src.data());
       }
-      scale *= scale;
-      e >>= 1;
     }
     return zret;
-  };
-
-  if (text.empty()) {
-    return 0;
   }
 
-  auto org_text = text; // save this to update @a parsed.
-  // Check just once and dump to a local copy if needed.
-  TextView local_parsed;
-  if (!parsed) {
-    parsed = &local_parsed;
-  }
+  double
+  svtod(swoc::TextView text, swoc::TextView *parsed)
+  {
+    // @return 10^e
+    auto pow10 = [](int e) -> double {
+      double zret  = 1.0;
+      double scale = 10.0;
+      if (e < 0) { // flip the scale and make @a e positive.
+        e     = -e;
+        scale = 0.1;
+      }
 
-  // Handle leading sign.
-  int sign = 1;
-  if (*text == '-') {
-    ++text;
-    sign = -1;
-  } else if (*text == '+') {
-    ++text;
-  }
-  // Parse the leading whole part as an integer.
-  intmax_t whole = svto_radix<10>(text);
-  parsed->assign(org_text.data(), text.data());
+      // Walk the bits in the exponent @a e and multiply the scale for set bits.
+      while (e) {
+        if (e & 1) {
+          zret *= scale;
+        }
+        scale  *= scale;
+        e     >>= 1;
+      }
+      return zret;
+    };
 
-  if (text.empty()) {
-    return whole;
-  }
-
-  double frac = 0.0;
-  if (*text == '.') { // fractional part.
-    ++text;
-    double scale = 0.1;
-    while (text && isdigit(*text)) {
-      frac += scale * (*text++ - '0');
-      scale /= 10.0;
+    if (text.empty()) {
+      return 0;
     }
-  }
 
-  double exp = 1.0;
-  if (text.starts_with_nocase("e")) {
-    int exp_sign = 1;
-    ++text;
-    if (text) {
-      if (*text == '+') {
-        ++text;
-      } else if (*text == '-') {
-        ++text;
-        exp_sign = -1;
+    auto org_text = text; // save this to update @a parsed.
+    // Check just once and dump to a local copy if needed.
+    TextView local_parsed;
+    if (!parsed) {
+      parsed = &local_parsed;
+    }
+
+    // Handle leading sign.
+    int sign = 1;
+    if (*text == '-') {
+      ++text;
+      sign = -1;
+    } else if (*text == '+') {
+      ++text;
+    }
+    // Parse the leading whole part as an integer.
+    intmax_t whole = svto_radix<10>(text);
+    parsed->assign(org_text.data(), text.data());
+
+    if (text.empty()) {
+      return whole;
+    }
+
+    double frac = 0.0;
+    if (*text == '.') { // fractional part.
+      ++text;
+      double scale = 0.1;
+      while (text && isdigit(*text)) {
+        frac  += scale * (*text++ - '0');
+        scale /= 10.0;
       }
     }
-    auto exp_part = svto_radix<10>(text);
-    exp           = pow10(exp_part * exp_sign);
+
+    double exp = 1.0;
+    if (text.starts_with_nocase("e")) {
+      int exp_sign = 1;
+      ++text;
+      if (text) {
+        if (*text == '+') {
+          ++text;
+        } else if (*text == '-') {
+          ++text;
+          exp_sign = -1;
+        }
+      }
+      auto exp_part = svto_radix<10>(text);
+      exp           = pow10(exp_part * exp_sign);
+    }
+
+    parsed->assign(org_text.data(), text.data());
+    return sign * (whole + frac) * exp;
   }
 
-  parsed->assign(org_text.data(), text.data());
-  return sign * (whole + frac) * exp;
-}
+  // Do the template instantiations.
+  template std::ostream &TextView::stream_write(std::ostream &, const TextView &) const;
 
-// Do the template instantiations.
-template std::ostream &TextView::stream_write(std::ostream &, const TextView &) const;
+} // namespace SWOC_VERSION_NS
+} // namespace swoc
 
-}  // namespace SWOC_VERSION_NS
-}  // namespace swoc
-
-namespace std {
+namespace std
+{
 ostream &
-operator<<(ostream &os, const swoc::TextView &b) {
+operator<<(ostream &os, const swoc::TextView &b)
+{
   if (os.good()) {
     b.stream_write<ostream>(os, b);
     os.width(0);

--- a/code/src/bw_format.cc
+++ b/code/src/bw_format.cc
@@ -27,982 +27,954 @@ using namespace swoc::literals;
 swoc::bwf::ExternalNames swoc::bwf::Global_Names;
 using swoc::svto_radix;
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
 
-namespace bwf {
+  namespace bwf
+  {
 
-const Spec Spec::DEFAULT;
+    const Spec Spec::DEFAULT;
 
-const Spec::Property Spec::_prop;
+    const Spec::Property Spec::_prop;
 
 #pragma GCC diagnostic ignored "-Wchar-subscripts"
 
-Spec::Property::Property() {
-  memset(_data, 0, sizeof(_data));
-  _data['b'] = TYPE_CHAR | NUMERIC_TYPE_CHAR;
-  _data['B'] = TYPE_CHAR | NUMERIC_TYPE_CHAR | UPPER_TYPE_CHAR;
-  _data['d'] = TYPE_CHAR | NUMERIC_TYPE_CHAR;
-  _data['g'] = TYPE_CHAR;
-  _data['o'] = TYPE_CHAR | NUMERIC_TYPE_CHAR;
-  _data['p'] = TYPE_CHAR;
-  _data['P'] = TYPE_CHAR | UPPER_TYPE_CHAR;
-  _data['s'] = TYPE_CHAR;
-  _data['S'] = TYPE_CHAR | UPPER_TYPE_CHAR;
-  _data['x'] = TYPE_CHAR | NUMERIC_TYPE_CHAR;
-  _data['X'] = TYPE_CHAR | NUMERIC_TYPE_CHAR | UPPER_TYPE_CHAR;
+    Spec::Property::Property()
+    {
+      memset(_data, 0, sizeof(_data));
+      _data['b'] = TYPE_CHAR | NUMERIC_TYPE_CHAR;
+      _data['B'] = TYPE_CHAR | NUMERIC_TYPE_CHAR | UPPER_TYPE_CHAR;
+      _data['d'] = TYPE_CHAR | NUMERIC_TYPE_CHAR;
+      _data['g'] = TYPE_CHAR;
+      _data['o'] = TYPE_CHAR | NUMERIC_TYPE_CHAR;
+      _data['p'] = TYPE_CHAR;
+      _data['P'] = TYPE_CHAR | UPPER_TYPE_CHAR;
+      _data['s'] = TYPE_CHAR;
+      _data['S'] = TYPE_CHAR | UPPER_TYPE_CHAR;
+      _data['x'] = TYPE_CHAR | NUMERIC_TYPE_CHAR;
+      _data['X'] = TYPE_CHAR | NUMERIC_TYPE_CHAR | UPPER_TYPE_CHAR;
 
-  _data[SIGN_NEVER]  = SIGN_CHAR;
-  _data[SIGN_NEG]    = SIGN_CHAR;
-  _data[SIGN_ALWAYS] = SIGN_CHAR;
+      _data[SIGN_NEVER]  = SIGN_CHAR;
+      _data[SIGN_NEG]    = SIGN_CHAR;
+      _data[SIGN_ALWAYS] = SIGN_CHAR;
 
-  _data['<'] = static_cast<uint8_t>(Spec::Align::LEFT);
-  _data['>'] = static_cast<uint8_t>(Spec::Align::RIGHT);
-  _data['^'] = static_cast<uint8_t>(Spec::Align::CENTER);
-  _data['='] = static_cast<uint8_t>(Spec::Align::SIGN);
-}
+      _data['<'] = static_cast<uint8_t>(Spec::Align::LEFT);
+      _data['>'] = static_cast<uint8_t>(Spec::Align::RIGHT);
+      _data['^'] = static_cast<uint8_t>(Spec::Align::CENTER);
+      _data['='] = static_cast<uint8_t>(Spec::Align::SIGN);
+    }
 
-Spec::Spec(const TextView &fmt) {
-  this->parse(fmt);
-}
+    Spec::Spec(const TextView &fmt)
+    {
+      this->parse(fmt);
+    }
 
-/// Parse a format specification.
-bool
-Spec::parse(TextView fmt) {
-  TextView num; // temporary for number parsing.
+    /// Parse a format specification.
+    bool
+    Spec::parse(TextView fmt)
+    {
+      TextView num; // temporary for number parsing.
 
-  _name = fmt.take_prefix_at(':');
-  // if it's parsable as a number, treat it as an index.
-  num    = _name;
-  auto n = svto_radix<10>(num);
-  if (num.empty()) {
-    _idx = static_cast<decltype(_idx)>(n);
-  }
-
-  if (fmt.size()) {
-    TextView sz = fmt.take_prefix_at(':'); // the format specifier.
-    _ext        = fmt;                     // anything past the second ':' is the extension.
-    if (sz.size()) {
-      // fill and alignment
-      if ('%' == *sz) { // enable URI encoding of the fill character so
-        // metasyntactic chars can be used if needed.
-        if (sz.size() < 4) {
-          throw std::invalid_argument("Fill URI encoding without 2 hex characters and align mark");
-        }
-        if (Align::NONE == (_align = align_of(sz[3]))) {
-          throw std::invalid_argument("Fill URI without alignment mark");
-        }
-        char d1 = sz[1], d0 = sz[2];
-        if (!isxdigit(d0) || !isxdigit(d1)) {
-          throw std::invalid_argument("URI encoding with non-hex characters");
-        }
-        _fill = isdigit(d0) ? d0 - '0' : tolower(d0) - 'a' + 10;
-        _fill += (isdigit(d1) ? d1 - '0' : tolower(d1) - 'a' + 10) << 4;
-        sz += 4;
-      } else if (sz.size() > 1 && Align::NONE != (_align = align_of(sz[1]))) {
-        _fill = *sz;
-        sz += 2;
-      } else if (Align::NONE != (_align = align_of(*sz))) {
-        ++sz;
+      _name = fmt.take_prefix_at(':');
+      // if it's parsable as a number, treat it as an index.
+      num    = _name;
+      auto n = svto_radix<10>(num);
+      if (num.empty()) {
+        _idx = static_cast<decltype(_idx)>(n);
       }
-      if (!sz.size()) {
+
+      if (fmt.size()) {
+        TextView sz = fmt.take_prefix_at(':'); // the format specifier.
+        _ext        = fmt;                     // anything past the second ':' is the extension.
+        if (sz.size()) {
+          // fill and alignment
+          if ('%' == *sz) { // enable URI encoding of the fill character so
+            // metasyntactic chars can be used if needed.
+            if (sz.size() < 4) {
+              throw std::invalid_argument("Fill URI encoding without 2 hex characters and align mark");
+            }
+            if (Align::NONE == (_align = align_of(sz[3]))) {
+              throw std::invalid_argument("Fill URI without alignment mark");
+            }
+            char d1 = sz[1], d0 = sz[2];
+            if (!isxdigit(d0) || !isxdigit(d1)) {
+              throw std::invalid_argument("URI encoding with non-hex characters");
+            }
+            _fill  = isdigit(d0) ? d0 - '0' : tolower(d0) - 'a' + 10;
+            _fill += (isdigit(d1) ? d1 - '0' : tolower(d1) - 'a' + 10) << 4;
+            sz    += 4;
+          } else if (sz.size() > 1 && Align::NONE != (_align = align_of(sz[1]))) {
+            _fill  = *sz;
+            sz    += 2;
+          } else if (Align::NONE != (_align = align_of(*sz))) {
+            ++sz;
+          }
+          if (!sz.size()) {
+            return true;
+          }
+          // sign
+          if (is_sign(*sz)) {
+            _sign = *sz;
+            if (!(++sz).size()) {
+              return true;
+            }
+          }
+          // radix prefix
+          if ('#' == *sz) {
+            _radix_lead_p = true;
+            if (!(++sz).size()) {
+              return true;
+            }
+          }
+          // 0 fill for integers
+          if ('0' == *sz) {
+            if (Align::NONE == _align) {
+              _align = Align::SIGN;
+            }
+            _fill = '0';
+            ++sz;
+          }
+          num = sz;
+          n   = svto_radix<10>(num);
+          if (num.size() < sz.size()) {
+            _min = static_cast<decltype(_min)>(n);
+            sz   = num;
+            if (!sz.size()) {
+              return true;
+            }
+          }
+          // precision
+          if ('.' == *sz) {
+            num = ++sz;
+            n   = svto_radix<10>(num);
+            if (num.size() < sz.size()) {
+              _prec = static_cast<decltype(_prec)>(n);
+              sz    = num;
+              if (!sz.size()) {
+                return true;
+              }
+            } else {
+              throw std::invalid_argument("Precision mark without precision");
+            }
+          }
+          // style (type). Hex, octal, etc.
+          if (is_type(*sz)) {
+            _type = *sz;
+            if (!(++sz).size()) {
+              return true;
+            }
+          }
+          // maximum width
+          if (',' == *sz) {
+            num = ++sz;
+            n   = svto_radix<10>(num);
+            if (num.size() < sz.size()) {
+              _max = static_cast<decltype(_max)>(n);
+              sz   = num;
+              if (!sz.size()) {
+                return true;
+              }
+            } else {
+              throw std::invalid_argument("Maximum width mark without width");
+            }
+            // Can only have a type indicator here if there was a max width.
+            if (is_type(*sz)) {
+              _type = *sz;
+              if (!(++sz).size()) {
+                return true;
+              }
+            }
+          }
+        }
+      }
+      return true;
+    }
+
+    /// Parse out the next literal and/or format specifier from the format string.
+    /// Pass the results back in @a literal and @a specifier as appropriate.
+    /// Update @a fmt to strip the parsed text.
+    /// @return @c true if a specifier was parsed, @c false if not.
+    bool
+    Format::TextViewExtractor::parse(TextView &fmt, std::string_view &literal, std::string_view &specifier)
+    {
+      TextView::size_type off = 0;
+
+      // Check for brace delimiters.
+      off = fmt.find_if([](char c) { return '{' == c || '}' == c; });
+      if (off == TextView::npos) {
+        // not found, it's a literal, ship it.
+        literal = fmt;
+        fmt.remove_prefix(literal.size());
+        return false;
+      }
+
+      // Processing for braces that don't enclose specifiers.
+      if (fmt.size() > off + 1) {
+        char c1 = fmt[off];
+        char c2 = fmt[off + 1];
+        if (c1 == c2) {
+          // double braces count as literals, but must tweak to output only 1 brace.
+          literal = fmt.take_prefix(off + 1);
+          return false;
+        } else if ('}' == c1) {
+          throw std::invalid_argument("Unopened } in format string.");
+        } else {
+          literal = std::string_view{fmt.data(), off};
+          fmt.remove_prefix(off + 1);
+        }
+      } else {
+        throw std::invalid_argument("Invalid trailing character in format string.");
+      }
+
+      if (fmt.size()) {
+        // Need to be careful, because an empty format is OK and it's hard to tell
+        // if take_prefix_at failed to find the delimiter or found it as the first
+        // byte.
+        off = fmt.find('}');
+        if (off == TextView::npos) {
+          throw std::invalid_argument("BWFormat: Unclosed { in format string");
+        }
+        specifier = fmt.take_prefix(off);
         return true;
       }
-      // sign
-      if (is_sign(*sz)) {
-        _sign = *sz;
-        if (!(++sz).size()) {
-          return true;
-        }
-      }
-      // radix prefix
-      if ('#' == *sz) {
-        _radix_lead_p = true;
-        if (!(++sz).size()) {
-          return true;
-        }
-      }
-      // 0 fill for integers
-      if ('0' == *sz) {
-        if (Align::NONE == _align) {
-          _align = Align::SIGN;
-        }
-        _fill = '0';
-        ++sz;
-      }
-      num = sz;
-      n   = svto_radix<10>(num);
-      if (num.size() < sz.size()) {
-        _min = static_cast<decltype(_min)>(n);
-        sz   = num;
-        if (!sz.size()) {
-          return true;
-        }
-      }
-      // precision
-      if ('.' == *sz) {
-        num = ++sz;
-        n   = svto_radix<10>(num);
-        if (num.size() < sz.size()) {
-          _prec = static_cast<decltype(_prec)>(n);
-          sz    = num;
-          if (!sz.size()) {
-            return true;
-          }
-        } else {
-          throw std::invalid_argument("Precision mark without precision");
-        }
-      }
-      // style (type). Hex, octal, etc.
-      if (is_type(*sz)) {
-        _type = *sz;
-        if (!(++sz).size()) {
-          return true;
-        }
-      }
-      // maximum width
-      if (',' == *sz) {
-        num = ++sz;
-        n   = svto_radix<10>(num);
-        if (num.size() < sz.size()) {
-          _max = static_cast<decltype(_max)>(n);
-          sz   = num;
-          if (!sz.size()) {
-            return true;
-          }
-        } else {
-          throw std::invalid_argument("Maximum width mark without width");
-        }
-        // Can only have a type indicator here if there was a max width.
-        if (is_type(*sz)) {
-          _type = *sz;
-          if (!(++sz).size()) {
-            return true;
-          }
-        }
-      }
-    }
-  }
-  return true;
-}
-
-/// Parse out the next literal and/or format specifier from the format string.
-/// Pass the results back in @a literal and @a specifier as appropriate.
-/// Update @a fmt to strip the parsed text.
-/// @return @c true if a specifier was parsed, @c false if not.
-bool
-Format::TextViewExtractor::parse(TextView &fmt, std::string_view &literal, std::string_view &specifier) {
-  TextView::size_type off = 0;
-
-  // Check for brace delimiters.
-  off = fmt.find_if([](char c) { return '{' == c || '}' == c; });
-  if (off == TextView::npos) {
-    // not found, it's a literal, ship it.
-    literal = fmt;
-    fmt.remove_prefix(literal.size());
-    return false;
-  }
-
-  // Processing for braces that don't enclose specifiers.
-  if (fmt.size() > off + 1) {
-    char c1 = fmt[off];
-    char c2 = fmt[off + 1];
-    if (c1 == c2) {
-      // double braces count as literals, but must tweak to output only 1 brace.
-      literal = fmt.take_prefix(off + 1);
       return false;
-    } else if ('}' == c1) {
-      throw std::invalid_argument("Unopened } in format string.");
-    } else {
-      literal = std::string_view{fmt.data(), off};
-      fmt.remove_prefix(off + 1);
     }
-  } else {
-    throw std::invalid_argument("Invalid trailing character in format string.");
-  }
 
-  if (fmt.size()) {
-    // Need to be careful, because an empty format is OK and it's hard to tell
-    // if take_prefix_at failed to find the delimiter or found it as the first
-    // byte.
-    off = fmt.find('}');
-    if (off == TextView::npos) {
-      throw std::invalid_argument("BWFormat: Unclosed { in format string");
-    }
-    specifier = fmt.take_prefix(off);
-    return true;
-  }
-  return false;
-}
-
-bool
-Format::TextViewExtractor::operator()(std::string_view &literal_v, Spec &spec) {
-  if (!_fmt.empty()) {
-    std::string_view spec_v;
-    if (parse(_fmt, literal_v, spec_v)) {
-      return spec.parse(spec_v);
-    }
-  }
-  return false;
-}
-
-bool
-Format::FormatExtractor::operator()(std::string_view &literal_v, swoc::bwf::Spec &spec) {
-  literal_v = {};
-  if (_idx < int(_fmt.size()) && _fmt[_idx]._type == Spec::LITERAL_TYPE) {
-    literal_v = _fmt[_idx++]._ext;
-  }
-  if (_idx < int(_fmt.size()) && _fmt[_idx]._type != Spec::LITERAL_TYPE) {
-    spec = _fmt[_idx++];
-    return true;
-  }
-  return false;
-}
-
-void
-Err_Bad_Arg_Index(BufferWriter &w, int i, size_t n) {
-  static const Format fmt{"{{BAD_ARG_INDEX:{} of {}}}"sv};
-  w.print(fmt, i, n);
-}
-
-/** This performs generic alignment operations.
-
-   If a formatter specialization performs this operation instead, that should
-   result in output that is at least @a spec._min characters wide, which will
-   cause this function to make no further adjustments.
- */
-void
-Adjust_Alignment(BufferWriter &aux, Spec const &spec) {
-  size_t extent = aux.extent();
-  size_t min    = spec._min;
-  if (extent < min) {
-    size_t delta      = min - extent;
-    size_t left_delta = 0, right_delta = delta; // left justify values
-    if (Spec::Align::RIGHT == spec._align) {
-      left_delta  = delta;
-      right_delta = 0;
-    } else if (Spec::Align::CENTER == spec._align) {
-      left_delta  = delta / 2;
-      right_delta = (delta + 1) / 2;
-    }
-    if (left_delta > 0) {
-      size_t work_area = extent + left_delta;
-      aux.commit(left_delta);          // cover work area.
-      aux.copy(left_delta, 0, extent); // move to create space for left fill.
-      aux.discard(work_area);          // roll back to write the left fill.
-      for (int i = left_delta; i > 0; --i) {
-        aux.write(spec._fill);
+    bool
+    Format::TextViewExtractor::operator()(std::string_view &literal_v, Spec &spec)
+    {
+      if (!_fmt.empty()) {
+        std::string_view spec_v;
+        if (parse(_fmt, literal_v, spec_v)) {
+          return spec.parse(spec_v);
+        }
       }
-      aux.commit(extent);
-    }
-    for (int i = right_delta; i > 0; --i) {
-      aux.write(spec._fill);
+      return false;
     }
 
-  } else {
-    size_t max = spec._max;
-    if (max < extent) {
-      aux.discard(extent - max);
+    bool
+    Format::FormatExtractor::operator()(std::string_view &literal_v, swoc::bwf::Spec &spec)
+    {
+      literal_v = {};
+      if (_idx < int(_fmt.size()) && _fmt[_idx]._type == Spec::LITERAL_TYPE) {
+        literal_v = _fmt[_idx++]._ext;
+      }
+      if (_idx < int(_fmt.size()) && _fmt[_idx]._type != Spec::LITERAL_TYPE) {
+        spec = _fmt[_idx++];
+        return true;
+      }
+      return false;
     }
-  }
-}
 
-// Conversions from remainder to character, in upper and lower case versions.
-// Really only useful for hexadecimal currently.
-namespace {
-char UPPER_DIGITS[]                                 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-char LOWER_DIGITS[]                                 = "0123456789abcdefghijklmnopqrstuvwxyz";
-static const std::array<uint64_t, 11> POWERS_OF_TEN = {
-  {1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000, 10000000000}};
-} // namespace
+    void
+    Err_Bad_Arg_Index(BufferWriter &w, int i, size_t n)
+    {
+      static const Format fmt{"{{BAD_ARG_INDEX:{} of {}}}"sv};
+      w.print(fmt, i, n);
+    }
 
-/// Templated radix based conversions. Only a small number of radix are
-/// supported and providing a template minimizes cut and paste code while also
-/// enabling compiler optimizations (e.g. for power of 2 radix the modulo /
-/// divide become bit operations).
-template <size_t RADIX>
-size_t
-To_Radix(uintmax_t n, char *buff, size_t width, char *digits) {
-  static_assert(1 < RADIX && RADIX <= 36, "RADIX must be in the range 2..36");
-  char *out = buff + width;
-  if (n) {
-    while (n) {
-      *--out = digits[n % RADIX];
-      n /= RADIX;
-    }
-  } else {
-    *--out = '0';
-  }
-  return (buff + width) - out;
-}
+    /** This performs generic alignment operations.
 
-/** Output a string with a specified alignment.
- *
- * @tparam F Output functor.
- * @param w Output buffer.
- * @param f Functor that generates output.
- * @param align Alignment.
- * @param width Field width.
- * @param fill Fill character.
- * @param neg Character to use for negative (null char means do not output).
- */
-template <typename F>
-void
-Write_Aligned(BufferWriter &w, F const &f, Spec::Align align, int width, char fill, char neg) {
-  switch (align) {
-  case Spec::Align::LEFT:
-    if (neg) {
-      w.write(neg);
-    }
-    f();
-    while (width-- > 0) {
-      w.write(fill);
-    }
-    break;
-  case Spec::Align::RIGHT:
-    while (width-- > 0) {
-      w.write(fill);
-    }
-    if (neg) {
-      w.write(neg);
-    }
-    f();
-    break;
-  case Spec::Align::CENTER:
-    for (int i = width / 2; i > 0; --i) {
-      w.write(fill);
-    }
-    if (neg) {
-      w.write(neg);
-    }
-    f();
-    for (int i = (width + 1) / 2; i > 0; --i) {
-      w.write(fill);
-    }
-    break;
-  case Spec::Align::SIGN:
-    if (neg) {
-      w.write(neg);
-    }
-    while (width-- > 0) {
-      w.write(fill);
-    }
-    f();
-    break;
-  default:
-    if (neg) {
-      w.write(neg);
-    }
-    f();
-    break;
-  }
-}
+       If a formatter specialization performs this operation instead, that should
+       result in output that is at least @a spec._min characters wide, which will
+       cause this function to make no further adjustments.
+     */
+    void
+    Adjust_Alignment(BufferWriter &aux, Spec const &spec)
+    {
+      size_t extent = aux.extent();
+      size_t min    = spec._min;
+      if (extent < min) {
+        size_t delta      = min - extent;
+        size_t left_delta = 0, right_delta = delta; // left justify values
+        if (Spec::Align::RIGHT == spec._align) {
+          left_delta  = delta;
+          right_delta = 0;
+        } else if (Spec::Align::CENTER == spec._align) {
+          left_delta  = delta / 2;
+          right_delta = (delta + 1) / 2;
+        }
+        if (left_delta > 0) {
+          size_t work_area = extent + left_delta;
+          aux.commit(left_delta);          // cover work area.
+          aux.copy(left_delta, 0, extent); // move to create space for left fill.
+          aux.discard(work_area);          // roll back to write the left fill.
+          for (int i = left_delta; i > 0; --i) {
+            aux.write(spec._fill);
+          }
+          aux.commit(extent);
+        }
+        for (int i = right_delta; i > 0; --i) {
+          aux.write(spec._fill);
+        }
 
-BufferWriter &
-Format_Integer(BufferWriter &w, Spec const &spec, uintmax_t i, bool neg_p) {
-  size_t n     = 0;
-  int width    = static_cast<int>(spec._min); // amount left to fill.
-  char neg     = 0;
-  char prefix1 = spec._radix_lead_p ? '0' : 0;
-  char prefix2 = 0;
-  char buff[std::numeric_limits<uintmax_t>::digits + 1];
-
-  if (spec._sign != Spec::SIGN_NEVER) {
-    if (neg_p) {
-      neg = '-';
-    } else if (spec._sign == Spec::SIGN_ALWAYS) {
-      neg = spec._sign;
-    }
-  }
-
-  switch (spec._type) {
-  case 'x':
-    prefix2 = 'x';
-    n       = bwf::To_Radix<16>(i, buff, sizeof(buff), bwf::LOWER_DIGITS);
-    break;
-  case 'X':
-    prefix2 = 'X';
-    n       = bwf::To_Radix<16>(i, buff, sizeof(buff), bwf::UPPER_DIGITS);
-    break;
-  case 'b':
-    prefix2 = 'b';
-    n       = bwf::To_Radix<2>(i, buff, sizeof(buff), bwf::LOWER_DIGITS);
-    break;
-  case 'B':
-    prefix2 = 'B';
-    n       = bwf::To_Radix<2>(i, buff, sizeof(buff), bwf::UPPER_DIGITS);
-    break;
-  case 'o':
-    n = bwf::To_Radix<8>(i, buff, sizeof(buff), bwf::LOWER_DIGITS);
-    break;
-  default:
-    prefix1 = 0;
-    n       = bwf::To_Radix<10>(i, buff, sizeof(buff), bwf::LOWER_DIGITS);
-    break;
-  }
-  // Clip fill width by stuff that's already committed to be written.
-  if (neg) {
-    --width;
-  }
-  if (prefix1) {
-    --width;
-    if (prefix2) {
-      --width;
-    }
-  }
-  width -= static_cast<int>(n);
-  std::string_view digits{buff + sizeof(buff) - n, n};
-
-  if (spec._align == Spec::Align::SIGN) { // custom for signed case because
-    // prefix and digits are seperated.
-    if (neg) {
-      w.write(neg);
-    }
-    if (prefix1) {
-      w.write(prefix1);
-      if (prefix2) {
-        w.write(prefix2);
+      } else {
+        size_t max = spec._max;
+        if (max < extent) {
+          aux.discard(extent - max);
+        }
       }
     }
-    while (width-- > 0) {
-      w.write(spec._fill);
+
+    // Conversions from remainder to character, in upper and lower case versions.
+    // Really only useful for hexadecimal currently.
+    namespace
+    {
+      char UPPER_DIGITS[]                                 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+      char LOWER_DIGITS[]                                 = "0123456789abcdefghijklmnopqrstuvwxyz";
+      static const std::array<uint64_t, 11> POWERS_OF_TEN = {
+        {1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000, 10000000000}
+      };
+    } // namespace
+
+    /// Templated radix based conversions. Only a small number of radix are
+    /// supported and providing a template minimizes cut and paste code while also
+    /// enabling compiler optimizations (e.g. for power of 2 radix the modulo /
+    /// divide become bit operations).
+    template <size_t RADIX>
+    size_t
+    To_Radix(uintmax_t n, char *buff, size_t width, char *digits)
+    {
+      static_assert(1 < RADIX && RADIX <= 36, "RADIX must be in the range 2..36");
+      char *out = buff + width;
+      if (n) {
+        while (n) {
+          *--out  = digits[n % RADIX];
+          n      /= RADIX;
+        }
+      } else {
+        *--out = '0';
+      }
+      return (buff + width) - out;
     }
-    w.write(digits);
-  } else { // use generic Write_Aligned
-    Write_Aligned(
-      w,
-      [&]() {
+
+    /** Output a string with a specified alignment.
+     *
+     * @tparam F Output functor.
+     * @param w Output buffer.
+     * @param f Functor that generates output.
+     * @param align Alignment.
+     * @param width Field width.
+     * @param fill Fill character.
+     * @param neg Character to use for negative (null char means do not output).
+     */
+    template <typename F>
+    void
+    Write_Aligned(BufferWriter &w, F const &f, Spec::Align align, int width, char fill, char neg)
+    {
+      switch (align) {
+      case Spec::Align::LEFT:
+        if (neg) {
+          w.write(neg);
+        }
+        f();
+        while (width-- > 0) {
+          w.write(fill);
+        }
+        break;
+      case Spec::Align::RIGHT:
+        while (width-- > 0) {
+          w.write(fill);
+        }
+        if (neg) {
+          w.write(neg);
+        }
+        f();
+        break;
+      case Spec::Align::CENTER:
+        for (int i = width / 2; i > 0; --i) {
+          w.write(fill);
+        }
+        if (neg) {
+          w.write(neg);
+        }
+        f();
+        for (int i = (width + 1) / 2; i > 0; --i) {
+          w.write(fill);
+        }
+        break;
+      case Spec::Align::SIGN:
+        if (neg) {
+          w.write(neg);
+        }
+        while (width-- > 0) {
+          w.write(fill);
+        }
+        f();
+        break;
+      default:
+        if (neg) {
+          w.write(neg);
+        }
+        f();
+        break;
+      }
+    }
+
+    BufferWriter &
+    Format_Integer(BufferWriter &w, Spec const &spec, uintmax_t i, bool neg_p)
+    {
+      size_t n     = 0;
+      int width    = static_cast<int>(spec._min); // amount left to fill.
+      char neg     = 0;
+      char prefix1 = spec._radix_lead_p ? '0' : 0;
+      char prefix2 = 0;
+      char buff[std::numeric_limits<uintmax_t>::digits + 1];
+
+      if (spec._sign != Spec::SIGN_NEVER) {
+        if (neg_p) {
+          neg = '-';
+        } else if (spec._sign == Spec::SIGN_ALWAYS) {
+          neg = spec._sign;
+        }
+      }
+
+      switch (spec._type) {
+      case 'x':
+        prefix2 = 'x';
+        n       = bwf::To_Radix<16>(i, buff, sizeof(buff), bwf::LOWER_DIGITS);
+        break;
+      case 'X':
+        prefix2 = 'X';
+        n       = bwf::To_Radix<16>(i, buff, sizeof(buff), bwf::UPPER_DIGITS);
+        break;
+      case 'b':
+        prefix2 = 'b';
+        n       = bwf::To_Radix<2>(i, buff, sizeof(buff), bwf::LOWER_DIGITS);
+        break;
+      case 'B':
+        prefix2 = 'B';
+        n       = bwf::To_Radix<2>(i, buff, sizeof(buff), bwf::UPPER_DIGITS);
+        break;
+      case 'o':
+        n = bwf::To_Radix<8>(i, buff, sizeof(buff), bwf::LOWER_DIGITS);
+        break;
+      default:
+        prefix1 = 0;
+        n       = bwf::To_Radix<10>(i, buff, sizeof(buff), bwf::LOWER_DIGITS);
+        break;
+      }
+      // Clip fill width by stuff that's already committed to be written.
+      if (neg) {
+        --width;
+      }
+      if (prefix1) {
+        --width;
+        if (prefix2) {
+          --width;
+        }
+      }
+      width -= static_cast<int>(n);
+      std::string_view digits{buff + sizeof(buff) - n, n};
+
+      if (spec._align == Spec::Align::SIGN) { // custom for signed case because
+        // prefix and digits are seperated.
+        if (neg) {
+          w.write(neg);
+        }
         if (prefix1) {
           w.write(prefix1);
           if (prefix2) {
             w.write(prefix2);
           }
         }
+        while (width-- > 0) {
+          w.write(spec._fill);
+        }
         w.write(digits);
-      },
-      spec._align, width, spec._fill, neg);
-  }
-  return w;
-}
-
-/// Format for floating point values. Seperates floating point into a whole
-/// number and a fraction. The fraction is converted into an unsigned integer
-/// based on the specified precision, spec._prec. ie. 3.1415 with precision two
-/// is seperated into two unsigned integers 3 and 14. The different pieces are
-/// assembled and placed into the BufferWriter. The default is two decimal
-/// places. ie. X.XX. The value is always written in base 10.
-///
-/// format: whole.fraction
-///     or: left.right
-BufferWriter &
-Format_Float(BufferWriter &w, Spec const &spec, double f, bool negative_p) {
-  static const std::string_view infinity_bwf{"Inf"};
-  static const std::string_view nan_bwf{"NaN"};
-  static const std::string_view zero_bwf{"0"};
-  static const std::string_view subnormal_bwf{"subnormal"};
-  static const std::string_view unknown_bwf{"unknown float"};
-
-  // Handle floating values that are not normal
-  if (!std::isnormal(f)) {
-    std::string_view unnormal;
-    switch (std::fpclassify(f)) {
-    case FP_INFINITE:
-      unnormal = infinity_bwf;
-      break;
-    case FP_NAN:
-      unnormal = nan_bwf;
-      break;
-    case FP_ZERO:
-      unnormal = zero_bwf;
-      break;
-    case FP_SUBNORMAL:
-      unnormal = subnormal_bwf;
-      break;
-    default:
-      unnormal = unknown_bwf;
+      } else { // use generic Write_Aligned
+        Write_Aligned(
+          w,
+          [&]() {
+            if (prefix1) {
+              w.write(prefix1);
+              if (prefix2) {
+                w.write(prefix2);
+              }
+            }
+            w.write(digits);
+          },
+          spec._align, width, spec._fill, neg);
+      }
+      return w;
     }
 
-    w.write(unnormal);
+    /// Format for floating point values. Seperates floating point into a whole
+    /// number and a fraction. The fraction is converted into an unsigned integer
+    /// based on the specified precision, spec._prec. ie. 3.1415 with precision two
+    /// is seperated into two unsigned integers 3 and 14. The different pieces are
+    /// assembled and placed into the BufferWriter. The default is two decimal
+    /// places. ie. X.XX. The value is always written in base 10.
+    ///
+    /// format: whole.fraction
+    ///     or: left.right
+    BufferWriter &
+    Format_Float(BufferWriter &w, Spec const &spec, double f, bool negative_p)
+    {
+      static const std::string_view infinity_bwf{"Inf"};
+      static const std::string_view nan_bwf{"NaN"};
+      static const std::string_view zero_bwf{"0"};
+      static const std::string_view subnormal_bwf{"subnormal"};
+      static const std::string_view unknown_bwf{"unknown float"};
+
+      // Handle floating values that are not normal
+      if (!std::isnormal(f)) {
+        std::string_view unnormal;
+        switch (std::fpclassify(f)) {
+        case FP_INFINITE:
+          unnormal = infinity_bwf;
+          break;
+        case FP_NAN:
+          unnormal = nan_bwf;
+          break;
+        case FP_ZERO:
+          unnormal = zero_bwf;
+          break;
+        case FP_SUBNORMAL:
+          unnormal = subnormal_bwf;
+          break;
+        default:
+          unnormal = unknown_bwf;
+        }
+
+        w.write(unnormal);
+        return w;
+      }
+
+      auto whole_part = static_cast<uint64_t>(f);
+      if (whole_part == f || spec._prec == 0) { // integral
+        return Format_Integer(w, spec, whole_part, negative_p);
+      }
+
+      static constexpr char dec = '.';
+      double frac               = NAN;
+      size_t l                  = 0;
+      size_t r                  = 0;
+      char whole[std::numeric_limits<double>::digits10 + 1];
+      char fraction[std::numeric_limits<double>::digits10 + 1];
+      char neg               = 0;
+      int width              = static_cast<int>(spec._min);                          // amount left to fill.
+      unsigned int precision = (spec._prec == Spec::DEFAULT._prec) ? 2 : spec._prec; // default precision 2
+
+      frac = f - whole_part; // split the number
+
+      if (negative_p) {
+        neg = '-';
+      } else if (spec._sign != '-') {
+        neg = spec._sign;
+      }
+
+      // Shift the floating point based on the precision. Used to convert
+      //  trailing fraction into an integer value.
+      uint64_t shift = 0;
+      if (precision < POWERS_OF_TEN.size()) {
+        shift = POWERS_OF_TEN[precision];
+      } else { // not precomputed.
+        shift = POWERS_OF_TEN.back();
+        for (precision -= (POWERS_OF_TEN.size() - 1); precision > 0; --precision) {
+          shift *= 10;
+        }
+      }
+
+      auto frac_part = static_cast<uint64_t>(frac * shift + 0.5 /* rounding */);
+
+      l = bwf::To_Radix<10>(whole_part, whole, sizeof(whole), bwf::LOWER_DIGITS);
+      r = bwf::To_Radix<10>(frac_part, fraction, sizeof(fraction), bwf::LOWER_DIGITS);
+
+      // Clip fill width
+      if (neg) {
+        --width;
+      }
+      width -= static_cast<int>(l);
+      --width; // '.'
+      width -= static_cast<int>(r);
+
+      std::string_view whole_digits{whole + sizeof(whole) - l, l};
+      std::string_view frac_digits{fraction + sizeof(fraction) - r, r};
+
+      Write_Aligned(
+        w,
+        [&]() {
+          w.write(whole_digits);
+          w.write(dec);
+          w.write(frac_digits);
+        },
+        spec._align, width, spec._fill, neg);
+
+      return w;
+    }
+
+    void
+    Format_As_Hex(BufferWriter &w, std::string_view view, const char *digits)
+    {
+      const char *ptr = view.data();
+      for (auto n = view.size(); n > 0; --n) {
+        char c = *ptr++;
+        w.write(digits[(c >> 4) & 0xF]);
+        w.write(digits[c & 0xf]);
+      }
+    }
+
+    /// Preparse format string for later use.
+    Format::Format(TextView fmt)
+    {
+      Spec lit_spec;
+      int arg_idx = 0;
+      auto ex{bind(fmt)};
+      std::string_view literal_v;
+
+      lit_spec._type = Spec::LITERAL_TYPE;
+
+      while (ex) {
+        Spec spec;
+        bool spec_p = ex(literal_v, spec);
+
+        if (literal_v.size()) {
+          lit_spec._ext = literal_v;
+          _items.emplace_back(lit_spec);
+        }
+
+        if (spec_p) {
+          if (spec._name.size() == 0) { // no name provided, use implicit index.
+            spec._idx = arg_idx++;
+          }
+          if (spec._idx >= 0) {
+            ++arg_idx;
+          }
+          _items.emplace_back(spec);
+        }
+      }
+    }
+
+    bool
+    Format::is_literal() const
+    {
+      for (auto const &spec : _items) {
+        if (Spec::LITERAL_TYPE != spec._type) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    NameBinding::~NameBinding() = default;
+
+  } // namespace bwf
+
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, std::string_view sv)
+  {
+    auto width = int(spec._min); // amount to fill.
+    if (spec._prec > 0) {
+      sv = sv.substr(0, spec._prec);
+    }
+    if ('x' == spec._type || 'X' == spec._type) {
+      return bwformat(w, spec, bwf::HexDump(sv.data(), sv.size()));
+    } else if ('s' == spec._type) {
+      bwformat(w, spec, transform_view_of(&tolower, sv));
+    } else if ('S' == spec._type) {
+      bwformat(w, spec, transform_view_of(&toupper, sv));
+    } else {
+      width -= sv.size();
+      bwf::Write_Aligned(
+        w, [&w, &sv]() { w.write(sv); }, spec._align, width, spec._fill, 0);
+    }
     return w;
   }
 
-  auto whole_part = static_cast<uint64_t>(f);
-  if (whole_part == f || spec._prec == 0) { // integral
-    return Format_Integer(w, spec, whole_part, negative_p);
-  }
+  // Generic pointer formatting
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, const void *ptr)
+  {
+    using namespace swoc::literals;
+    bwf::Spec ptr_spec{spec};
+    ptr_spec._radix_lead_p = true;
 
-  static constexpr char dec = '.';
-  double frac = NAN;
-  size_t l = 0;
-  size_t r = 0;
-  char whole[std::numeric_limits<double>::digits10 + 1];
-  char fraction[std::numeric_limits<double>::digits10 + 1];
-  char neg               = 0;
-  int width              = static_cast<int>(spec._min);                          // amount left to fill.
-  unsigned int precision = (spec._prec == Spec::DEFAULT._prec) ? 2 : spec._prec; // default precision 2
-
-  frac = f - whole_part; // split the number
-
-  if (negative_p) {
-    neg = '-';
-  } else if (spec._sign != '-') {
-    neg = spec._sign;
-  }
-
-  // Shift the floating point based on the precision. Used to convert
-  //  trailing fraction into an integer value.
-  uint64_t shift = 0;
-  if (precision < POWERS_OF_TEN.size()) {
-    shift = POWERS_OF_TEN[precision];
-  } else { // not precomputed.
-    shift = POWERS_OF_TEN.back();
-    for (precision -= (POWERS_OF_TEN.size() - 1); precision > 0; --precision) {
-      shift *= 10;
-    }
-  }
-
-  auto frac_part = static_cast<uint64_t>(frac * shift + 0.5 /* rounding */);
-
-  l = bwf::To_Radix<10>(whole_part, whole, sizeof(whole), bwf::LOWER_DIGITS);
-  r = bwf::To_Radix<10>(frac_part, fraction, sizeof(fraction), bwf::LOWER_DIGITS);
-
-  // Clip fill width
-  if (neg) {
-    --width;
-  }
-  width -= static_cast<int>(l);
-  --width; // '.'
-  width -= static_cast<int>(r);
-
-  std::string_view whole_digits{whole + sizeof(whole) - l, l};
-  std::string_view frac_digits{fraction + sizeof(fraction) - r, r};
-
-  Write_Aligned(
-    w,
-    [&]() {
-      w.write(whole_digits);
-      w.write(dec);
-      w.write(frac_digits);
-    },
-    spec._align, width, spec._fill, neg);
-
-  return w;
-}
-
-void
-Format_As_Hex(BufferWriter &w, std::string_view view, const char *digits) {
-  const char *ptr = view.data();
-  for (auto n = view.size(); n > 0; --n) {
-    char c = *ptr++;
-    w.write(digits[(c >> 4) & 0xF]);
-    w.write(digits[c & 0xf]);
-  }
-}
-
-/// Preparse format string for later use.
-Format::Format(TextView fmt) {
-  Spec lit_spec;
-  int arg_idx = 0;
-  auto ex{bind(fmt)};
-  std::string_view literal_v;
-
-  lit_spec._type = Spec::LITERAL_TYPE;
-
-  while (ex) {
-    Spec spec;
-    bool spec_p = ex(literal_v, spec);
-
-    if (literal_v.size()) {
-      lit_spec._ext = literal_v;
-      _items.emplace_back(lit_spec);
-    }
-
-    if (spec_p) {
-      if (spec._name.size() == 0) { // no name provided, use implicit index.
-        spec._idx = arg_idx++;
+    if (ptr == nullptr) {
+      if (spec._type == 's' || spec._type == 'S') {
+        ptr_spec._type = bwf::Spec::DEFAULT_TYPE;
+        ptr_spec._ext  = ""_sv; // clear any extension.
+        return bwformat(w, spec, spec._type == 's' ? "null"_sv : "NULL"_sv);
+      } else if (spec._type == bwf::Spec::DEFAULT_TYPE) {
+        return w; // print nothing if there is no format character override.
       }
-      if (spec._idx >= 0) {
-        ++arg_idx;
-      }
-      _items.emplace_back(spec);
     }
-  }
-}
 
-bool
-Format::is_literal() const {
-  for (auto const& spec : _items) {
-    if (Spec::LITERAL_TYPE != spec._type) {
-      return false;
+    if (ptr_spec._type == bwf::Spec::DEFAULT_TYPE || ptr_spec._type == 'p') {
+      ptr_spec._type = 'x'; // if default or 'p;, switch to lower hex.
+    } else if (ptr_spec._type == 'P') {
+      ptr_spec._type = 'X'; // P means upper hex, overriding other specializations.
     }
+    return bwf::Format_Integer(w, ptr_spec, reinterpret_cast<intptr_t>(ptr), false);
   }
-  return true;
-}
+  // doc end
 
-NameBinding::~NameBinding() = default;
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::HexDump const &hex)
+  {
+    char fmt_type      = spec._type;
+    const char *digits = bwf::UPPER_DIGITS;
 
-} // namespace bwf
+    if ('X' != fmt_type) {
+      fmt_type = 'x';
+      digits   = bwf::LOWER_DIGITS;
+    }
 
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, std::string_view sv) {
-  auto width = int(spec._min); // amount to fill.
-  if (spec._prec > 0) {
-    sv = sv.substr(0, spec._prec);
-  }
-  if ('x' == spec._type || 'X' == spec._type) {
-    return bwformat(w, spec, bwf::HexDump(sv.data(), sv.size()));
-  } else if ('s' == spec._type) {
-    bwformat(w, spec, transform_view_of(&tolower, sv));
-  } else if ('S' == spec._type) {
-    bwformat(w, spec, transform_view_of(&toupper, sv));
-  } else {
-    width -= sv.size();
+    int width = int(spec._min) - hex._view.size() * 2; // amount left to fill.
+    if (spec._radix_lead_p) {
+      w.write('0');
+      w.write(fmt_type);
+      width -= 2;
+    }
     bwf::Write_Aligned(
-      w, [&w, &sv]() { w.write(sv); }, spec._align, width, spec._fill, 0);
-  }
-  return w;
-}
-
-// Generic pointer formatting
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, const void *ptr) {
-  using namespace swoc::literals;
-  bwf::Spec ptr_spec{spec};
-  ptr_spec._radix_lead_p = true;
-
-  if (ptr == nullptr) {
-    if (spec._type == 's' || spec._type == 'S') {
-      ptr_spec._type = bwf::Spec::DEFAULT_TYPE;
-      ptr_spec._ext  = ""_sv; // clear any extension.
-      return bwformat(w, spec, spec._type == 's' ? "null"_sv : "NULL"_sv);
-    } else if (spec._type == bwf::Spec::DEFAULT_TYPE) {
-      return w; // print nothing if there is no format character override.
-    }
+      w, [&w, &hex, digits]() { bwf::Format_As_Hex(w, hex._view, digits); }, spec._align, width, spec._fill, 0);
+    return w;
   }
 
-  if (ptr_spec._type == bwf::Spec::DEFAULT_TYPE || ptr_spec._type == 'p') {
-    ptr_spec._type = 'x'; // if default or 'p;, switch to lower hex.
-  } else if (ptr_spec._type == 'P') {
-    ptr_spec._type = 'X'; // P means upper hex, overriding other specializations.
-  }
-  return bwf::Format_Integer(w, ptr_spec, reinterpret_cast<intptr_t>(ptr), false);
-}
-// doc end
-
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::HexDump const &hex) {
-  char fmt_type      = spec._type;
-  const char *digits = bwf::UPPER_DIGITS;
-
-  if ('X' != fmt_type) {
-    fmt_type = 'x';
-    digits   = bwf::LOWER_DIGITS;
-  }
-
-  int width = int(spec._min) - hex._view.size() * 2; // amount left to fill.
-  if (spec._radix_lead_p) {
-    w.write('0');
-    w.write(fmt_type);
-    width -= 2;
-  }
-  bwf::Write_Aligned(
-    w, [&w, &hex, digits]() { bwf::Format_As_Hex(w, hex._view, digits); }, spec._align, width, spec._fill, 0);
-  return w;
-}
-
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, MemSpan<void const> const &span) {
-  if ('x' == spec._type || 'X' == spec._type) {
-    const char *digits =  ('X' == spec._type) ? bwf::UPPER_DIGITS : bwf::LOWER_DIGITS;
-    size_t block       = spec._prec > 0 ? spec._prec : span.size();
-    TextView view{span.rebind<char const>()};
-    bool space_p = false;
-    while (view) {
-      if (space_p) {
-        w.write(' ');
-}
-      space_p = true;
-      if (spec._radix_lead_p) {
-        w.write('0').write(digits[33]);
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, MemSpan<void const> const &span)
+  {
+    if ('x' == spec._type || 'X' == spec._type) {
+      const char *digits = ('X' == spec._type) ? bwf::UPPER_DIGITS : bwf::LOWER_DIGITS;
+      size_t block       = spec._prec > 0 ? spec._prec : span.size();
+      TextView view{span.rebind<char const>()};
+      bool space_p = false;
+      while (view) {
+        if (space_p) {
+          w.write(' ');
+        }
+        space_p = true;
+        if (spec._radix_lead_p) {
+          w.write('0').write(digits[33]);
+        }
+        bwf::Format_As_Hex(w, view.prefix(block), digits);
+        view.remove_prefix(block);
       }
-      bwf::Format_As_Hex(w, view.prefix(block), digits);
-      view.remove_prefix(block);
+    } else {
+      static const bwf::Format default_fmt{"{:#x}@{:p}"};
+      w.print(default_fmt, span.size(), span.data());
     }
-  } else {
-    static const bwf::Format default_fmt{"{:#x}@{:p}"};
-    w.print(default_fmt, span.size(), span.data());
+    return w;
   }
-  return w;
-}
 
-std::ostream &
-FixedBufferWriter::operator>>(std::ostream &s) const {
-  return s << this->view();
-}
+  std::ostream &
+  FixedBufferWriter::operator>>(std::ostream &s) const
+  {
+    return s << this->view();
+  }
 
-namespace {
-// Hand rolled, might not be totally compliant everywhere, but probably close
-// enough. The long string will be locally accurate. Clang requires the double
-// braces. Why, Turing only knows.
-static const std::array<std::string_view, 134> ERRNO_SHORT_NAME = {{
-  "SUCCESS",
-  "EPERM",
-  "ENOENT",
-  "ESRCH",
-  "EINTR",
-  "EIO",
-  "ENXIO",
-  "E2BIG ",
-  "ENOEXEC",
-  "EBADF",
-  "ECHILD",
-  "EAGAIN",
-  "ENOMEM",
-  "EACCES",
-  "EFAULT",
-  "ENOTBLK",
-  "EBUSY",
-  "EEXIST",
-  "EXDEV",
-  "ENODEV",
-  "ENOTDIR",
-  "EISDIR",
-  "EINVAL",
-  "ENFILE",
-  "EMFILE",
-  "ENOTTY",
-  "ETXTBSY",
-  "EFBIG",
-  "ENOSPC",
-  "ESPIPE",
-  "EROFS",
-  "EMLINK",
-  "EPIPE",
-  "EDOM",
-  "ERANGE",
-  "EDEADLK",
-  "ENAMETOOLONG",
-  "ENOLCK",
-  "ENOSYS",
-  "ENOTEMPTY",
-  "ELOOP",
-  "EWOULDBLOCK",
-  "ENOMSG",
-  "EIDRM",
-  "ECHRNG",
-  "EL2NSYNC",
-  "EL3HLT",
-  "EL3RST",
-  "ELNRNG",
-  "EUNATCH",
-  "ENOCSI",
-  "EL2HTL",
-  "EBADE",
-  "EBADR",
-  "EXFULL",
-  "ENOANO",
-  "EBADRQC",
-  "EBADSLT",
-  "EDEADLOCK",
-  "EBFONT",
-  "ENOSTR",
-  "ENODATA",
-  "ETIME",
-  "ENOSR",
-  "ENONET",
-  "ENOPKG",
-  "EREMOTE",
-  "ENOLINK",
-  "EADV",
-  "ESRMNT",
-  "ECOMM",
-  "EPROTO",
-  "EMULTIHOP",
-  "EDOTDOT",
-  "EBADMSG",
-  "EOVERFLOW",
-  "ENOTUNIQ",
-  "EBADFD",
-  "EREMCHG",
-  "ELIBACC",
-  "ELIBBAD",
-  "ELIBSCN",
-  "ELIBMAX",
-  "ELIBEXEC",
-  "EILSEQ",
-  "ERESTART",
-  "ESTRPIPE",
-  "EUSERS",
-  "ENOTSOCK",
-  "EDESTADDRREQ",
-  "EMSGSIZE",
-  "EPROTOTYPE",
-  "ENOPROTOOPT",
-  "EPROTONOSUPPORT",
-  "ESOCKTNOSUPPORT",
-  "EOPNOTSUPP",
-  "EPFNOSUPPORT",
-  "EAFNOSUPPORT",
-  "EADDRINUSE",
-  "EADDRNOTAVAIL",
-  "ENETDOWN",
-  "ENETUNREACH",
-  "ENETRESET",
-  "ECONNABORTED",
-  "ECONNRESET",
-  "ENOBUFS",
-  "EISCONN",
-  "ENOTCONN",
-  "ESHUTDOWN",
-  "ETOOMANYREFS",
-  "ETIMEDOUT",
-  "ECONNREFUSED",
-  "EHOSTDOWN",
-  "EHOSTUNREACH",
-  "EALREADY",
-  "EINPROGRESS",
-  "ESTALE",
-  "EUCLEAN",
-  "ENOTNAM",
-  "ENAVAIL",
-  "EISNAM",
-  "EREMOTEIO",
-  "EDQUOT",
-  "ENOMEDIUM",
-  "EMEDIUMTYPE",
-  "ECANCELED",
-  "ENOKEY",
-  "EKEYEXPIRED",
-  "EKEYREVOKED",
-  "EKEYREJECTED",
-  "EOWNERDEAD",
-  "ENOTRECOVERABLE",
-  "ERFKILL",
-  "EHWPOISON",
-}};
-static constexpr DiscreteRange<unsigned> ERRNO_RANGE{0, ERRNO_SHORT_NAME.size() - 1};
-// This provides convenient safe access to the errno short name array.
-auto errno_short_name = [](unsigned n) { return ERRNO_RANGE.contains(n) ? ERRNO_SHORT_NAME[n] : "Unknown"sv; };
-} // namespace
+  namespace
+  {
+    // Hand rolled, might not be totally compliant everywhere, but probably close
+    // enough. The long string will be locally accurate. Clang requires the double
+    // braces. Why, Turing only knows.
+    static const std::array<std::string_view, 134> ERRNO_SHORT_NAME = {
+      {
+       "SUCCESS", "EPERM",
+       "ENOENT", "ESRCH",
+       "EINTR", "EIO",
+       "ENXIO", "E2BIG ",
+       "ENOEXEC", "EBADF",
+       "ECHILD", "EAGAIN",
+       "ENOMEM", "EACCES",
+       "EFAULT", "ENOTBLK",
+       "EBUSY", "EEXIST",
+       "EXDEV", "ENODEV",
+       "ENOTDIR", "EISDIR",
+       "EINVAL", "ENFILE",
+       "EMFILE", "ENOTTY",
+       "ETXTBSY", "EFBIG",
+       "ENOSPC", "ESPIPE",
+       "EROFS", "EMLINK",
+       "EPIPE", "EDOM",
+       "ERANGE", "EDEADLK",
+       "ENAMETOOLONG", "ENOLCK",
+       "ENOSYS", "ENOTEMPTY",
+       "ELOOP", "EWOULDBLOCK",
+       "ENOMSG", "EIDRM",
+       "ECHRNG", "EL2NSYNC",
+       "EL3HLT", "EL3RST",
+       "ELNRNG", "EUNATCH",
+       "ENOCSI", "EL2HTL",
+       "EBADE", "EBADR",
+       "EXFULL", "ENOANO",
+       "EBADRQC", "EBADSLT",
+       "EDEADLOCK", "EBFONT",
+       "ENOSTR", "ENODATA",
+       "ETIME", "ENOSR",
+       "ENONET", "ENOPKG",
+       "EREMOTE", "ENOLINK",
+       "EADV", "ESRMNT",
+       "ECOMM", "EPROTO",
+       "EMULTIHOP", "EDOTDOT",
+       "EBADMSG", "EOVERFLOW",
+       "ENOTUNIQ", "EBADFD",
+       "EREMCHG", "ELIBACC",
+       "ELIBBAD", "ELIBSCN",
+       "ELIBMAX", "ELIBEXEC",
+       "EILSEQ", "ERESTART",
+       "ESTRPIPE", "EUSERS",
+       "ENOTSOCK", "EDESTADDRREQ",
+       "EMSGSIZE", "EPROTOTYPE",
+       "ENOPROTOOPT", "EPROTONOSUPPORT",
+       "ESOCKTNOSUPPORT", "EOPNOTSUPP",
+       "EPFNOSUPPORT", "EAFNOSUPPORT",
+       "EADDRINUSE", "EADDRNOTAVAIL",
+       "ENETDOWN", "ENETUNREACH",
+       "ENETRESET", "ECONNABORTED",
+       "ECONNRESET", "ENOBUFS",
+       "EISCONN", "ENOTCONN",
+       "ESHUTDOWN", "ETOOMANYREFS",
+       "ETIMEDOUT", "ECONNREFUSED",
+       "EHOSTDOWN", "EHOSTUNREACH",
+       "EALREADY", "EINPROGRESS",
+       "ESTALE", "EUCLEAN",
+       "ENOTNAM", "ENAVAIL",
+       "EISNAM", "EREMOTEIO",
+       "EDQUOT", "ENOMEDIUM",
+       "EMEDIUMTYPE", "ECANCELED",
+       "ENOKEY", "EKEYEXPIRED",
+       "EKEYREVOKED", "EKEYREJECTED",
+       "EOWNERDEAD", "ENOTRECOVERABLE",
+       "ERFKILL", "EHWPOISON",
+       }
+    };
+    static constexpr DiscreteRange<unsigned> ERRNO_RANGE{0, ERRNO_SHORT_NAME.size() - 1};
+    // This provides convenient safe access to the errno short name array.
+    auto errno_short_name = [](unsigned n) { return ERRNO_RANGE.contains(n) ? ERRNO_SHORT_NAME[n] : "Unknown"sv; };
+  } // namespace
 
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Errno const &e) {
-  static const bwf::Format number_fmt{"[{}]"sv}; // numeric value format.
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Errno const &e)
+  {
+    static const bwf::Format number_fmt{"[{}]"sv}; // numeric value format.
 
-  if (spec.has_numeric_type()) { // if numeric type, print just the numeric part
-    w.print(number_fmt, e._e);
-  } else {
-    TextView ext{spec._ext};
-    bool short_p = false;
-    if (ext.empty() || ext.npos != ext.find('s')) {
-      w.write(errno_short_name(e._e));
-      short_p = true;
-    }
-    if (ext.empty() || ext.npos != ext.find('l')) {
-      if (short_p) {
-        w.write(": ");
-      }
-      w.write(TextView(strerror(e._e), TextView::npos));
-    }
-    if (spec._type != 's' && spec._type != 'S') {
-      w.write(' ');
+    if (spec.has_numeric_type()) { // if numeric type, print just the numeric part
       w.print(number_fmt, e._e);
-    }
-  }
-  return w;
-}
-
-bwf::Date::Date(std::string_view fmt) : _epoch(std::chrono::system_clock::to_time_t(std::chrono::system_clock::now())), _fmt(fmt) {}
-
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Date const &date) {
-  if (spec.has_numeric_type()) {
-    bwformat(w, spec, date._epoch);
-  } else {
-    struct tm t{};
-    auto r = w.remaining();
-    size_t n{0};
-    // Verify @a fmt is null terminated, even outside the bounds of the view.
-    if (date._fmt.data()[date._fmt.size() - 1] != 0 && date._fmt.data()[date._fmt.size()] != 0) {
-      throw(std::invalid_argument{"BWF Date String is not null terminated."});
-    }
-    // Get the time, GMT or local if specified.
-    if (spec._ext == "local"sv) {
-      localtime_r(&date._epoch, &t);
     } else {
-      gmtime_r(&date._epoch, &t);
+      TextView ext{spec._ext};
+      bool short_p = false;
+      if (ext.empty() || ext.npos != ext.find('s')) {
+        w.write(errno_short_name(e._e));
+        short_p = true;
+      }
+      if (ext.empty() || ext.npos != ext.find('l')) {
+        if (short_p) {
+          w.write(": ");
+        }
+        w.write(TextView(strerror(e._e), TextView::npos));
+      }
+      if (spec._type != 's' && spec._type != 'S') {
+        w.write(' ');
+        w.print(number_fmt, e._e);
+      }
     }
-    // Try a direct write, faster if it works.
-    if (r > 0) {
-      n = strftime(w.aux_data(), r, date._fmt.data(), &t);
-    }
-    if (n > 0) {
-      w.commit(n);
-    } else {
-      // Direct write didn't work. Unfortunately need to write to a temporary
-      // buffer or the sizing isn't correct if @a w is clipped because @c
-      // strftime returns 0 if the buffer isn't large enough.
-      char buff[256]; // hope for the best - no real way to resize appropriately on failure.
-      n = strftime(buff, sizeof(buff), date._fmt.data(), &t);
-      w.write(buff, n);
-    }
+    return w;
   }
-  return w;
-}
 
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Pattern const &pattern) {
-  if (! pattern._text.empty()) { // If there's no text, no point in looping.
-    auto limit        = std::min<size_t>(spec._max, pattern._text.size() * pattern._n);
-    decltype(limit) n = 0;
-    while (n < limit) {
-      w.write(pattern._text);
-      n += pattern._text.size();
-    }
+  bwf::Date::Date(std::string_view fmt) : _epoch(std::chrono::system_clock::to_time_t(std::chrono::system_clock::now())), _fmt(fmt)
+  {
   }
-  return w;
-}
 
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, std::error_code const &ec) {
-  static const auto G_CAT = &std::generic_category();
-  static const auto S_CAT  = &std::system_category();
-
-  // This provides convenient safe access to the errno short name array.
-  static const swoc::bwf::Format number_fmt{"[{}]"_sv}; // numeric value format.
-  if (spec.has_numeric_type()) {
-    // if numeric type, print just the numeric part.
-    bwformat(w, spec, ec.value());
-  } else {
-    if ((&ec.category() == G_CAT || &ec.category() == S_CAT) && swoc::ERRNO_RANGE.contains(ec.value())) {
-      bwformat(w, spec, swoc::ERRNO_SHORT_NAME[ec.value()]);
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Date const &date)
+  {
+    if (spec.has_numeric_type()) {
+      bwformat(w, spec, date._epoch);
     } else {
-      w.write(ec.message());
+      struct tm t {
+      };
+      auto r = w.remaining();
+      size_t n{0};
+      // Verify @a fmt is null terminated, even outside the bounds of the view.
+      if (date._fmt.data()[date._fmt.size() - 1] != 0 && date._fmt.data()[date._fmt.size()] != 0) {
+        throw(std::invalid_argument{"BWF Date String is not null terminated."});
+      }
+      // Get the time, GMT or local if specified.
+      if (spec._ext == "local"sv) {
+        localtime_r(&date._epoch, &t);
+      } else {
+        gmtime_r(&date._epoch, &t);
+      }
+      // Try a direct write, faster if it works.
+      if (r > 0) {
+        n = strftime(w.aux_data(), r, date._fmt.data(), &t);
+      }
+      if (n > 0) {
+        w.commit(n);
+      } else {
+        // Direct write didn't work. Unfortunately need to write to a temporary
+        // buffer or the sizing isn't correct if @a w is clipped because @c
+        // strftime returns 0 if the buffer isn't large enough.
+        char buff[256]; // hope for the best - no real way to resize appropriately on failure.
+        n = strftime(buff, sizeof(buff), date._fmt.data(), &t);
+        w.write(buff, n);
+      }
     }
-    if (spec._type != 's' && spec._type != 'S') {
+    return w;
+  }
+
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::Pattern const &pattern)
+  {
+    if (!pattern._text.empty()) { // If there's no text, no point in looping.
+      auto limit        = std::min<size_t>(spec._max, pattern._text.size() * pattern._n);
+      decltype(limit) n = 0;
+      while (n < limit) {
+        w.write(pattern._text);
+        n += pattern._text.size();
+      }
+    }
+    return w;
+  }
+
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, std::error_code const &ec)
+  {
+    static const auto G_CAT = &std::generic_category();
+    static const auto S_CAT = &std::system_category();
+
+    // This provides convenient safe access to the errno short name array.
+    static const swoc::bwf::Format number_fmt{"[{}]"_sv}; // numeric value format.
+    if (spec.has_numeric_type()) {
+      // if numeric type, print just the numeric part.
       bwformat(w, spec, ec.value());
-      w.write(' ').write('[').format(spec, ec.value()).write(']');
+    } else {
+      if ((&ec.category() == G_CAT || &ec.category() == S_CAT) && swoc::ERRNO_RANGE.contains(ec.value())) {
+        bwformat(w, spec, swoc::ERRNO_SHORT_NAME[ec.value()]);
+      } else {
+        w.write(ec.message());
+      }
+      if (spec._type != 's' && spec._type != 'S') {
+        bwformat(w, spec, ec.value());
+        w.write(' ').write('[').format(spec, ec.value()).write(']');
+      }
     }
+    return w;
   }
-  return w;
-}
 
-BufferWriter&
-bwformat(BufferWriter &w, bwf::Spec const& spec, bwf::UnHex const& obj) {
-  auto span { obj._span };
-  size_t limit = spec._max;
-  while (span.size() >= 2 && limit--) {
-    auto b = svto_radix<16>(span.clip_prefix(2).rebind<char const>());
-    w.write(b);
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, bwf::UnHex const &obj)
+  {
+    auto span{obj._span};
+    size_t limit = spec._max;
+    while (span.size() >= 2 && limit--) {
+      auto b = svto_radix<16>(span.clip_prefix(2).rebind<char const>());
+      w.write(b);
+    }
+    return w;
   }
-  return w;
-}
 
-}  // namespace SWOC_VERSION_NS
-}  // namespace swoc
+} // namespace SWOC_VERSION_NS
+} // namespace swoc
 
-namespace std {
+namespace std
+{
 ostream &
-operator<<(ostream &s, swoc::FixedBufferWriter &w) {
+operator<<(ostream &s, swoc::FixedBufferWriter &w)
+{
   return s << w.view();
 }
 

--- a/code/src/bw_ip_format.cc
+++ b/code/src/bw_ip_format.cc
@@ -10,380 +10,402 @@
 
 using namespace swoc::literals;
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
-using bwf::Spec;
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  using bwf::Spec;
 
-BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, in6_addr const &addr) {
-  using QUAD = uint16_t const;
-  Spec local_spec{spec}; // Format for address elements.
-  uint8_t const *ptr   = addr.s6_addr;
-  uint8_t const *limit = ptr + sizeof(addr.s6_addr);
-  QUAD *lower          = nullptr; // the best zero range
-  QUAD *upper          = nullptr;
-  bool align_p         = false;
+  BufferWriter &
+  bwformat(BufferWriter &w, Spec const &spec, in6_addr const &addr)
+  {
+    using QUAD = uint16_t const;
+    Spec local_spec{spec}; // Format for address elements.
+    uint8_t const *ptr   = addr.s6_addr;
+    uint8_t const *limit = ptr + sizeof(addr.s6_addr);
+    QUAD *lower          = nullptr; // the best zero range
+    QUAD *upper          = nullptr;
+    bool align_p         = false;
 
-  if (spec._ext.size()) {
-    if (spec._ext.front() == '=') {
-      align_p          = true;
-      local_spec._fill = '0';
-    } else if (spec._ext.size() > 1 && spec._ext[1] == '=') {
-      align_p          = true;
-      local_spec._fill = spec._ext[0];
+    if (spec._ext.size()) {
+      if (spec._ext.front() == '=') {
+        align_p          = true;
+        local_spec._fill = '0';
+      } else if (spec._ext.size() > 1 && spec._ext[1] == '=') {
+        align_p          = true;
+        local_spec._fill = spec._ext[0];
+      }
     }
-  }
 
-  if (align_p) {
-    local_spec._min   = 4;
-    local_spec._align = Spec::Align::RIGHT;
-  } else {
-    local_spec._min = 0;
-    // do 0 compression if there's no internal fill.
-    for (QUAD *spot = reinterpret_cast<QUAD *>(ptr), *last = reinterpret_cast<QUAD *>(limit), *current = nullptr; spot < last;
-         ++spot) {
-      if (0 == *spot) {
-        if (current) {
-          // If there's no best, or this is better, remember it.
-          if (!lower || (upper - lower < spot - current)) {
-            lower = current;
-            upper = spot;
+    if (align_p) {
+      local_spec._min   = 4;
+      local_spec._align = Spec::Align::RIGHT;
+    } else {
+      local_spec._min = 0;
+      // do 0 compression if there's no internal fill.
+      for (QUAD *spot = reinterpret_cast<QUAD *>(ptr), *last = reinterpret_cast<QUAD *>(limit), *current = nullptr; spot < last;
+           ++spot) {
+        if (0 == *spot) {
+          if (current) {
+            // If there's no best, or this is better, remember it.
+            if (!lower || (upper - lower < spot - current)) {
+              lower = current;
+              upper = spot;
+            }
+          } else {
+            current = spot;
           }
         } else {
-          current = spot;
+          current = nullptr;
+        }
+      }
+    }
+
+    if (!local_spec.has_numeric_type()) {
+      local_spec._type = 'x';
+    }
+
+    for (; ptr < limit; ptr += 2) {
+      if (reinterpret_cast<uint8_t const *>(lower) <= ptr && ptr <= reinterpret_cast<uint8_t const *>(upper)) {
+        if (ptr == addr.s6_addr) {
+          w.write(':'); // only if this is the first quad.
+        }
+        if (ptr == reinterpret_cast<uint8_t const *>(upper)) {
+          w.write(':');
         }
       } else {
-        current = nullptr;
+        uint16_t f = (ptr[0] << 8) + ptr[1];
+        bwformat(w, local_spec, f);
+        if (ptr != limit - 2) {
+          w.write(':');
+        }
       }
     }
-  }
-
-  if (!local_spec.has_numeric_type()) {
-    local_spec._type = 'x';
-  }
-
-  for (; ptr < limit; ptr += 2) {
-    if (reinterpret_cast<uint8_t const *>(lower) <= ptr && ptr <= reinterpret_cast<uint8_t const *>(upper)) {
-      if (ptr == addr.s6_addr) {
-        w.write(':'); // only if this is the first quad.
-      }
-      if (ptr == reinterpret_cast<uint8_t const *>(upper)) {
-        w.write(':');
-      }
-    } else {
-      uint16_t f = (ptr[0] << 8) + ptr[1];
-      bwformat(w, local_spec, f);
-      if (ptr != limit - 2) {
-        w.write(':');
-      }
-    }
-  }
-  return w;
-}
-
-BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, sockaddr const *addr) {
-  Spec local_spec{spec}; // Format for address elements and port.
-  bool port_p{true};
-  bool addr_p{true};
-  bool family_p{false};
-  bool local_numeric_fill_p{false};
-  char local_numeric_fill_char{'0'};
-
-  if (spec._type == 'p' || spec._type == 'P') {
-    bwformat(w, spec, static_cast<void const *>(addr));
     return w;
   }
 
-  if (spec._ext.size()) {
-    if (spec._ext.front() == '=') {
-      local_numeric_fill_p = true;
-      local_spec._ext.remove_prefix(1);
-    } else if (spec._ext.size() > 1 && spec._ext[1] == '=') {
-      local_numeric_fill_p    = true;
-      local_numeric_fill_char = spec._ext.front();
-      local_spec._ext.remove_prefix(2);
+  BufferWriter &
+  bwformat(BufferWriter &w, Spec const &spec, sockaddr const *addr)
+  {
+    Spec local_spec{spec}; // Format for address elements and port.
+    bool port_p{true};
+    bool addr_p{true};
+    bool family_p{false};
+    bool local_numeric_fill_p{false};
+    char local_numeric_fill_char{'0'};
+
+    if (spec._type == 'p' || spec._type == 'P') {
+      bwformat(w, spec, static_cast<void const *>(addr));
+      return w;
     }
-  }
-  if (local_spec._ext.size()) {
-    addr_p = port_p = false;
-    for (char c : local_spec._ext) {
-      switch (c) {
-      case 'a':
-      case 'A':
-        addr_p = true;
-        break;
-      case 'p':
-      case 'P':
-        port_p = true;
-        break;
-      case 'f':
-      case 'F':
-        family_p = true;
-        break;
+
+    if (spec._ext.size()) {
+      if (spec._ext.front() == '=') {
+        local_numeric_fill_p = true;
+        local_spec._ext.remove_prefix(1);
+      } else if (spec._ext.size() > 1 && spec._ext[1] == '=') {
+        local_numeric_fill_p    = true;
+        local_numeric_fill_char = spec._ext.front();
+        local_spec._ext.remove_prefix(2);
       }
     }
+    if (local_spec._ext.size()) {
+      addr_p = port_p = false;
+      for (char c : local_spec._ext) {
+        switch (c) {
+        case 'a':
+        case 'A':
+          addr_p = true;
+          break;
+        case 'p':
+        case 'P':
+          port_p = true;
+          break;
+        case 'f':
+        case 'F':
+          family_p = true;
+          break;
+        }
+      }
+    }
+
+    if (addr_p) {
+      bool bracket_p = false;
+      switch (addr->sa_family) {
+      case AF_INET:
+        bwformat(w, spec, IP4Addr{IP4Addr::reorder(reinterpret_cast<sockaddr_in const *>(addr)->sin_addr.s_addr)});
+        break;
+      case AF_INET6:
+        if (port_p) {
+          w.write('[');
+          bracket_p = true; // take a note - put in the trailing bracket.
+        }
+        bwformat(w, spec, reinterpret_cast<sockaddr_in6 const *>(addr)->sin6_addr);
+        break;
+      default:
+        w.print("*Invalid IP family [{}]*", addr->sa_family);
+        break;
+      }
+      if (bracket_p) {
+        w.write(']');
+      }
+      if (port_p) {
+        w.write(':');
+      }
+    }
+    if (port_p) {
+      if (local_numeric_fill_p) {
+        local_spec._min   = 5;
+        local_spec._fill  = local_numeric_fill_char;
+        local_spec._align = Spec::Align::RIGHT;
+      } else {
+        local_spec._min = 0;
+      }
+      bwformat(w, local_spec, static_cast<uintmax_t>(IPEndpoint::host_order_port(addr)));
+    }
+    if (family_p) {
+      local_spec._min = 0;
+      if (addr_p || port_p) {
+        w.write(' ');
+      }
+      if (spec.has_numeric_type()) {
+        bwformat(w, local_spec, static_cast<uintmax_t>(addr->sa_family));
+      } else {
+        swoc::bwformat(w, local_spec, IPEndpoint::family_name(addr->sa_family));
+      }
+    }
+    return w;
   }
 
-  if (addr_p) {
-    bool bracket_p = false;
-    switch (addr->sa_family) {
-    case AF_INET:
-      bwformat(w, spec, IP4Addr{IP4Addr::reorder(reinterpret_cast<sockaddr_in const *>(addr)->sin_addr.s_addr)});
-      break;
-    case AF_INET6:
-      if (port_p) {
-        w.write('[');
-        bracket_p = true; // take a note - put in the trailing bracket.
+  BufferWriter &
+  bwformat(BufferWriter &w, Spec const &spec, IP4Addr const &addr)
+  {
+    in_addr_t host = addr.host_order();
+    Spec local_spec{spec}; // Format for address elements.
+    bool align_p = false;
+
+    if (spec._ext.size()) {
+      if (spec._ext.front() == '=') {
+        align_p          = true;
+        local_spec._fill = '0';
+      } else if (spec._ext.size() > 1 && spec._ext[1] == '=') {
+        align_p          = true;
+        local_spec._fill = spec._ext[0];
       }
-      bwformat(w, spec, reinterpret_cast<sockaddr_in6 const *>(addr)->sin6_addr);
-      break;
-    default:
-      w.print("*Invalid IP family [{}]*", addr->sa_family);
-      break;
     }
-    if (bracket_p) {
-      w.write(']');
-}
-    if (port_p) {
-      w.write(':');
-}
-  }
-  if (port_p) {
-    if (local_numeric_fill_p) {
-      local_spec._min   = 5;
-      local_spec._fill  = local_numeric_fill_char;
+
+    if (align_p) {
+      local_spec._min   = 3;
       local_spec._align = Spec::Align::RIGHT;
     } else {
       local_spec._min = 0;
     }
-    bwformat(w, local_spec, static_cast<uintmax_t>(IPEndpoint::host_order_port(addr)));
+
+    bwformat(w, local_spec, static_cast<uint8_t>(host >> 24 & 0xFF));
+    w.write('.');
+    bwformat(w, local_spec, static_cast<uint8_t>(host >> 16 & 0xFF));
+    w.write('.');
+    bwformat(w, local_spec, static_cast<uint8_t>(host >> 8 & 0xFF));
+    w.write('.');
+    bwformat(w, local_spec, static_cast<uint8_t>(host & 0xFF));
+    return w;
   }
-  if (family_p) {
-    local_spec._min = 0;
-    if (addr_p || port_p) {
-      w.write(' ');
-}
-    if (spec.has_numeric_type()) {
-      bwformat(w, local_spec, static_cast<uintmax_t>(addr->sa_family));
+
+  BufferWriter &
+  bwformat(BufferWriter &w, Spec const &spec, IP6Addr const &addr)
+  {
+    return bwformat(w, spec, addr.network_order());
+  }
+
+  BufferWriter &
+  bwformat(BufferWriter &w, Spec const &spec, IP4Srv const &srv)
+  {
+    bwformat(w, spec, srv.addr());
+    if (srv.host_order_port()) {
+      w.print(":{}", srv.host_order_port());
+    }
+    return w;
+  }
+
+  BufferWriter &
+  bwformat(BufferWriter &w, Spec const &spec, IP6Srv const &srv)
+  {
+    auto port = srv.host_order_port();
+    if (port) {
+      w.write('[');
+      bwformat(w, spec, srv.addr());
+      w.print("]:{}", port);
     } else {
-      swoc::bwformat(w, local_spec, IPEndpoint::family_name(addr->sa_family));
+      bwformat(w, spec, srv.addr());
     }
+    return w;
   }
-  return w;
-}
 
-BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, IP4Addr const &addr) {
-  in_addr_t host = addr.host_order();
-  Spec local_spec{spec}; // Format for address elements.
-  bool align_p = false;
-
-  if (spec._ext.size()) {
-    if (spec._ext.front() == '=') {
-      align_p          = true;
-      local_spec._fill = '0';
-    } else if (spec._ext.size() > 1 && spec._ext[1] == '=') {
-      align_p          = true;
-      local_spec._fill = spec._ext[0];
+  BufferWriter &
+  bwformat(BufferWriter &w, Spec const &spec, IPSrv const &srv)
+  {
+    if (srv.is_ip4()) {
+      bwformat(w, spec, IP4Srv(srv));
+    } else if (srv.is_ip6()) {
+      bwformat(w, spec, IP6Srv(srv));
     }
+    return w;
   }
 
-  if (align_p) {
-    local_spec._min   = 3;
-    local_spec._align = Spec::Align::RIGHT;
-  } else {
-    local_spec._min = 0;
-  }
+  BufferWriter &
+  bwformat(BufferWriter &w, Spec const &spec, IPAddr const &addr)
+  {
+    Spec local_spec{spec}; // Format for address elements and port.
+    bool addr_p{true};
+    bool family_p{false};
 
-  bwformat(w, local_spec, static_cast<uint8_t>(host >> 24 & 0xFF));
-  w.write('.');
-  bwformat(w, local_spec, static_cast<uint8_t>(host >> 16 & 0xFF));
-  w.write('.');
-  bwformat(w, local_spec, static_cast<uint8_t>(host >> 8 & 0xFF));
-  w.write('.');
-  bwformat(w, local_spec, static_cast<uint8_t>(host & 0xFF));
-  return w;
-}
-
-BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, IP6Addr const &addr) {
-  return bwformat(w, spec, addr.network_order());
-}
-
-BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, IP4Srv const& srv) {
-  bwformat(w, spec, srv.addr());
-  if (srv.host_order_port()) {
-    w.print(":{}", srv.host_order_port());
-  }
-  return w;
-}
-
-BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, IP6Srv const& srv) {
-  auto port = srv.host_order_port();
-  if (port) {
-    w.write('[');
-    bwformat(w, spec, srv.addr());
-    w.print("]:{}", port);
-  } else {
-    bwformat(w, spec, srv.addr());
-  }
-  return w;
-}
-
-BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, IPSrv const& srv) {
-  if (srv.is_ip4()) { bwformat(w, spec, IP4Srv(srv)); }
-  else if (srv.is_ip6()) { bwformat(w, spec, IP6Srv(srv)); }
-  return w;
-}
-
-BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, IPAddr const &addr) {
-  Spec local_spec{spec}; // Format for address elements and port.
-  bool addr_p{true};
-  bool family_p{false};
-
-  if (spec._ext.size()) {
-    if (spec._ext.front() == '=') {
-      local_spec._ext.remove_prefix(1);
-    } else if (spec._ext.size() > 1 && spec._ext[1] == '=') {
-      local_spec._ext.remove_prefix(2);
-    }
-  }
-  if (local_spec._ext.size()) {
-    addr_p = false;
-    for (char c : local_spec._ext) {
-      switch (c) {
-      case 'a':
-      case 'A':
-        addr_p = true;
-        break;
-      case 'f':
-      case 'F':
-        family_p = true;
-        break;
+    if (spec._ext.size()) {
+      if (spec._ext.front() == '=') {
+        local_spec._ext.remove_prefix(1);
+      } else if (spec._ext.size() > 1 && spec._ext[1] == '=') {
+        local_spec._ext.remove_prefix(2);
       }
     }
-  }
-
-  if (addr_p) {
-    if (addr.is_ip4()) {
-      swoc::bwformat(w, spec, addr.ip4());
-    } else if (addr.is_ip6()) {
-      swoc::bwformat(w, spec, addr.ip6().network_order());
-    } else {
-      w.print("*Not IP address [{}]*", addr.family());
+    if (local_spec._ext.size()) {
+      addr_p = false;
+      for (char c : local_spec._ext) {
+        switch (c) {
+        case 'a':
+        case 'A':
+          addr_p = true;
+          break;
+        case 'f':
+        case 'F':
+          family_p = true;
+          break;
+        }
+      }
     }
-  }
 
-  if (family_p) {
-    local_spec._min = 0;
     if (addr_p) {
-      w.write(' ');
+      if (addr.is_ip4()) {
+        swoc::bwformat(w, spec, addr.ip4());
+      } else if (addr.is_ip6()) {
+        swoc::bwformat(w, spec, addr.ip6().network_order());
+      } else {
+        w.print("*Not IP address [{}]*", addr.family());
+      }
     }
-    if (spec.has_numeric_type()) {
-      bwformat(w, local_spec, static_cast<uintmax_t>(addr.family()));
+
+    if (family_p) {
+      local_spec._min = 0;
+      if (addr_p) {
+        w.write(' ');
+      }
+      if (spec.has_numeric_type()) {
+        bwformat(w, local_spec, static_cast<uintmax_t>(addr.family()));
+      } else {
+        swoc::bwformat(w, local_spec, addr.family());
+      }
+    }
+    return w;
+  }
+
+  BufferWriter &
+  bwformat(BufferWriter &w, Spec const &spec, IP4Range const &range)
+  {
+    if (range.empty()) {
+      w.write("*-*"_tv);
     } else {
-      swoc::bwformat(w, local_spec, addr.family());
+      // Compact means output as singleton or CIDR if that's possible.
+      if (spec._ext.find('c') != spec._ext.npos) {
+        if (range.is_singleton()) {
+          return bwformat(w, spec, range.min());
+        }
+        auto mask{range.network_mask()};
+        if (mask.is_valid()) {
+          bwformat(w, spec, range.min());
+          w.write('/');
+          bwformat(w, bwf::Spec::DEFAULT, mask);
+          return w;
+        }
+      }
+      bwformat(w, spec, range.min());
+      w.write('-');
+      bwformat(w, spec, range.max());
     }
+    return w;
   }
-  return w;
-}
 
-BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, IP4Range const &range) {
-  if (range.empty()) {
-    w.write("*-*"_tv);
-  } else {
-    // Compact means output as singleton or CIDR if that's possible.
-    if (spec._ext.find('c') != spec._ext.npos) {
-      if (range.is_singleton()) {
-        return bwformat(w, spec, range.min());
+  BufferWriter &
+  bwformat(BufferWriter &w, Spec const &spec, IP6Range const &range)
+  {
+    if (range.empty()) {
+      w.write("*-*"_tv);
+    } else {
+      // Compact means output as singleton or CIDR if that's possible.
+      if (spec._ext.find('c') != spec._ext.npos) {
+        if (range.is_singleton()) {
+          return bwformat(w, spec, range.min());
+        }
+        auto mask{range.network_mask()};
+        if (mask.is_valid()) {
+          bwformat(w, spec, range.min());
+          w.write('/');
+          bwformat(w, bwf::Spec::DEFAULT, mask);
+          return w;
+        }
       }
-      auto mask{range.network_mask()};
-      if (mask.is_valid()) {
-        bwformat(w, spec, range.min());
-        w.write('/');
-        bwformat(w, bwf::Spec::DEFAULT, mask);
-        return w;
-      }
+      bwformat(w, spec, range.min());
+      w.write('-');
+      bwformat(w, spec, range.max());
     }
-    bwformat(w, spec, range.min());
-    w.write('-');
-    bwformat(w, spec, range.max());
+    return w;
   }
-  return w;
-}
 
-BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, IP6Range const &range) {
-  if (range.empty()) {
-    w.write("*-*"_tv);
-  } else {
-    // Compact means output as singleton or CIDR if that's possible.
-    if (spec._ext.find('c') != spec._ext.npos) {
-      if (range.is_singleton()) {
-        return bwformat(w, spec, range.min());
-      }
-      auto mask{range.network_mask()};
-      if (mask.is_valid()) {
-        bwformat(w, spec, range.min());
-        w.write('/');
-        bwformat(w, bwf::Spec::DEFAULT, mask);
-        return w;
-      }
+  BufferWriter &
+  bwformat(BufferWriter &w, Spec const &spec, IPRange const &range)
+  {
+    return range.is(AF_INET)  ? bwformat(w, spec, range.ip4()) :
+           range.is(AF_INET6) ? bwformat(w, spec, range.ip6()) :
+                                w.write("*-*"_tv);
+  }
+
+  BufferWriter &
+  bwformat(BufferWriter &w, Spec const &spec, IPRangeView const &rv)
+  {
+    return rv.is(AF_INET) ? bwformat(w, spec, rv.ip4()) : rv.is(AF_INET6) ? bwformat(w, spec, rv.ip6()) : w.write("*-*"_tv);
+  }
+
+  BufferWriter &
+  bwformat(BufferWriter &w, Spec const &spec, IP4Net const &net)
+  {
+    bwformat(w, spec, net.min());
+    w.write('/');
+    bwformat(w, Spec{}, net.mask().width());
+    return w;
+  }
+
+  BufferWriter &
+  bwformat(BufferWriter &w, Spec const &spec, IP6Net const &net)
+  {
+    bwformat(w, spec, net.min());
+    w.write('/');
+    bwformat(w, Spec{}, net.mask().width());
+    return w;
+  }
+
+  BufferWriter &
+  bwformat(BufferWriter &w, Spec const &spec, IPNet const &net)
+  {
+    if (net.is_ip6()) {
+      return bwformat(w, spec, net.ip6());
+    } else if (net.is_ip4()) {
+      return bwformat(w, spec, net.ip4());
     }
-    bwformat(w, spec, range.min());
-    w.write('-');
-    bwformat(w, spec, range.max());
+    return w.write("*invalid*");
   }
-  return w;
-}
 
-BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, IPRange const &range) {
-  return range.is(AF_INET) ? bwformat(w, spec, range.ip4()) :
-                             range.is(AF_INET6) ? bwformat(w, spec, range.ip6()) : w.write("*-*"_tv);
-}
-
-BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, IPRangeView const &rv) {
-  return rv.is(AF_INET) ? bwformat(w, spec, rv.ip4()) :
-         rv.is(AF_INET6) ? bwformat(w, spec, rv.ip6()) : w.write("*-*"_tv);
-}
-
-BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, IP4Net const &net) {
-  bwformat(w, spec, net.min());
-  w.write('/');
-  bwformat(w, Spec{}, net.mask().width());
-  return w;
-}
-
-BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, IP6Net const &net) {
-  bwformat(w, spec, net.min());
-  w.write('/');
-  bwformat(w, Spec{}, net.mask().width());
-  return w;
-}
-
-BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, IPNet const &net) {
-  if (net.is_ip6()) {
-    return bwformat(w, spec, net.ip6());
-  } else if (net.is_ip4()) {
-    return bwformat(w, spec, net.ip4());
+  BufferWriter &
+  bwformat(BufferWriter &w, Spec const &spec, IPMask const &mask)
+  {
+    return bwformat(w, spec, mask.width());
   }
-  return w.write("*invalid*");
-}
 
-BufferWriter &
-bwformat(BufferWriter &w, Spec const &spec, IPMask const &mask) {
-  return bwformat(w, spec, mask.width());
-}
-
-}  // namespace SWOC_VERSION_NS
-}  // namespace swoc
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/src/string_view_util.cc
+++ b/code/src/string_view_util.cc
@@ -8,7 +8,8 @@
 #include "swoc/string_view_util.h"
 
 int
-memcmp(std::string_view const &lhs, std::string_view const &rhs) {
+memcmp(std::string_view const &lhs, std::string_view const &rhs)
+{
   int zret = 0;
   size_t n = rhs.size();
 
@@ -27,7 +28,8 @@ memcmp(std::string_view const &lhs, std::string_view const &rhs) {
 }
 
 int
-strcasecmp(const std::string_view &lhs, const std::string_view &rhs) {
+strcasecmp(const std::string_view &lhs, const std::string_view &rhs)
+{
   int zret = 0;
   size_t n = rhs.size();
 

--- a/code/src/swoc_file.cc
+++ b/code/src/swoc_file.cc
@@ -16,453 +16,508 @@
 
 using namespace swoc::literals;
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
-namespace file {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
+  namespace file
+  {
 
-path
-path::parent_path() const {
-  TextView parent{_path};
-  parent.split_suffix_at(SEPARATOR);
-  return parent ? parent : "/"_tv;
-}
+    path
+    path::parent_path() const
+    {
+      TextView parent{_path};
+      parent.split_suffix_at(SEPARATOR);
+      return parent ? parent : "/"_tv;
+    }
 
-path
-path::relative_path() const {
-  if (!_path.empty() && _path.front() == SEPARATOR) {
-    return _path.substr(1);
-  }
-  return *this;
-}
-
-auto path::filename() const -> self_type {
-  auto const idx = _path.find_last_of(SEPARATOR);
-  return idx == std::string::npos ? self_type(_path) : _path.substr(idx + 1);
-}
-
-path &
-path::operator/=(std::string_view that) {
-  if (!that.empty()) { // don't waste time appending nothing.
-    if (that.front() == SEPARATOR || _path.empty()) {
-      _path.assign(that);
-    } else {
-      if (_path.back() == SEPARATOR) {
-        _path.reserve(_path.size() + that.size());
-      } else {
-        _path.reserve(_path.size() + that.size() + 1);
-        _path.push_back(SEPARATOR);
+    path
+    path::relative_path() const
+    {
+      if (!_path.empty() && _path.front() == SEPARATOR) {
+        return _path.substr(1);
       }
-      _path.append(that);
+      return *this;
     }
-  }
-  return *this;
-}
 
-void file_status::init() {
-  switch (_stat.st_mode & S_IFMT) {
-  case S_IFREG : _type = file_type::regular; break;
-  case S_IFDIR : _type = file_type::directory; break;
-  case S_IFLNK : _type = file_type::symlink; break;
-  case S_IFBLK : _type = file_type::block; break;
-  case S_IFCHR : _type = file_type::character; break;
-  case S_IFIFO : _type = file_type::fifo; break;
-  case S_IFSOCK : _type = file_type::socket; break;
-  default: _type = file_type::unknown; break;
-  }
-}
-
-file_status
-status(path const &file, std::error_code &ec) noexcept {
-  file_status zret;
-  if (::stat(file.c_str(), &zret._stat) >= 0) {
-    ec.clear();
-    zret.init();
-  } else {
-    ec = std::error_code(errno, std::system_category());
-    if (errno == ENOENT) {
-      zret._type = file_type::not_found;
+    auto
+    path::filename() const -> self_type
+    {
+      auto const idx = _path.find_last_of(SEPARATOR);
+      return idx == std::string::npos ? self_type(_path) : _path.substr(idx + 1);
     }
-  }
-  return zret;
-}
 
-int
-file_type(const file_status &fs) {
-  return fs._stat.st_mode & S_IFMT;
-}
-
-uintmax_t
-file_size(const file_status &fs) {
-  return fs._stat.st_size;
-}
-
-bool
-exists(const path &p) {
-  std::error_code ec;
-  auto fs = status(p, ec);
-  return exists(fs);
-}
-
-path
-absolute(path const &src, std::error_code &ec) {
-  char buff[4096];
-  ec.clear();
-  if (src.is_absolute()) {
-    return src;
-  }
-  auto s = realpath(src.c_str(), buff);
-  if (s == nullptr) {
-    if (errno == ENAMETOOLONG) {
-      s = realpath(src.c_str(), nullptr);
-      if (s != nullptr) {
-        path zret{s};
-        free(s);
-        return zret;
+    path &
+    path::operator/=(std::string_view that)
+    {
+      if (!that.empty()) { // don't waste time appending nothing.
+        if (that.front() == SEPARATOR || _path.empty()) {
+          _path.assign(that);
+        } else {
+          if (_path.back() == SEPARATOR) {
+            _path.reserve(_path.size() + that.size());
+          } else {
+            _path.reserve(_path.size() + that.size() + 1);
+            _path.push_back(SEPARATOR);
+          }
+          _path.append(that);
+        }
       }
+      return *this;
     }
-    ec = std::error_code(errno, std::system_category());
-    return {};
-  }
-  return path{s};
-}
 
-namespace {
-
-inline file_time_type chrono_cast(timespec const &ts) {
-  using namespace std::chrono;
-  return system_clock::time_point{duration_cast<system_clock::duration>(seconds{ts.tv_sec} + nanoseconds{ts.tv_nsec})};
-}
-
-// Apple has different names for these members, need to have accessors that account for that.
-// Under -O2 these are completely elided.
-template <typename S>
-auto
-a_time(S const &s, meta::CaseTag<0>) -> decltype(S::st_atim) {
-  return s.st_atim;
-}
-
-template <typename S>
-auto
-a_time(S const &s, meta::CaseTag<1>) -> decltype(S::st_atimespec) {
-  return s.st_atimespec;
-}
-
-template <typename S>
-auto
-m_time(S const &s, meta::CaseTag<0>) -> decltype(S::st_mtim) {
-  return s.st_mtim;
-}
-
-template <typename S>
-auto
-m_time(S const &s, meta::CaseTag<1>) -> decltype(S::st_mtimespec) {
-  return s.st_mtimespec;
-}
-
-template <typename S>
-auto
-c_time(S const &s, meta::CaseTag<0>) -> decltype(S::st_ctim) {
-  return s.st_ctim;
-}
-
-template <typename S>
-auto
-c_time(S const &s, meta::CaseTag<1>) -> decltype(S::st_ctimespec) {
-  return s.st_ctimespec;
-}
-
-} // namespace
-
-file_time_type
-last_write_time(file_status const &fs) {
-  return chrono_cast(m_time(fs._stat, meta::CaseArg));
-}
-
-file_time_type
-access_time(file_status const &fs) {
-  return chrono_cast(a_time(fs._stat, meta::CaseArg));
-}
-
-file_time_type
-status_time(file_status const &fs) {
-  return chrono_cast(c_time(fs._stat, meta::CaseArg));
-}
-
-file_time_type
-last_write_time(path const& p, std::error_code &ec) {
-  auto fs = status(p, ec);
-  if (ec) {
-    return file_time_type::min();
-  }
-  return last_write_time(fs);
-}
-
-bool
-is_readable(const path &p) {
-  return 0 == access(p.c_str(), R_OK);
-}
-
-path
-temp_directory_path()
-{
-  /* ISO/IEC 9945 (POSIX): The path supplied by the first environment variable found in the list TMPDIR, TMP, TEMP, TEMPDIR.
-   * If none of these are found, "/tmp"
-   * */
-  for ( char const * tp : { "TMPDIR", "TMP", "TEMPDIR" }) {
-    if (auto v = ::getenv(tp) ; v) {
-      return path(v);
-    }
-  }
-  return path("/tmp");
-}
-
-path
-current_path()
-{
-  char buff[PATH_MAX+1];
-  if (auto p = ::getcwd(buff, sizeof(buff)) ; p) {
-    return path{buff};
-#if !__FreeBSD__ && ! __APPLE__ // Freakin' Apple and FreeBSD.
-  } else if (ERANGE == errno) {
-    swoc::unique_malloc<char> raw{::get_current_dir_name()};
-    return path{ raw.get() };
-#endif
-  }
-  return {};
-}
-
-path
-canonical(const path &p, std::error_code &ec)
-{
-  if (p.empty()) {
-    ec = std::error_code(EINVAL, std::system_category());
-    return {};
-  }
-
-  char buf[PATH_MAX + 1];
-
-  if (auto rp = ::realpath(p.c_str(), buf) ; rp) {
-    return path{rp};
-  }
-
-  if (auto rp = ::realpath(p.c_str(), nullptr) ; rp) {
-    return path{rp};
-  }
-
-  ec = std::error_code(errno, std::system_category());
-  return {};
-}
-
-bool create_directory(const path &path, std::error_code &ec, mode_t mode) noexcept {
-  if (path.empty()) {
-    ec = std::error_code(EINVAL, std::system_category());
-    return false;
-  }
-
-  ec.clear();
-  if (::mkdir(path.c_str(), mode) != 0) {
-    if (EEXIST == errno) {
-      std::error_code local_ec;
-      auto fs = status(path, local_ec);
-      if (!local_ec && is_dir(fs)) {
-        return true;
-      }
-    }
-    ec = std::error_code(errno, std::system_category());
-    return false;
-  }
-  return true;
-}
-
-bool
-create_directories(const path &p, std::error_code &ec, mode_t mode) noexcept
-{
-  TextView text(p.string());
-
-  if (text.empty()) {
-    ec = std::error_code(EINVAL, std::system_category());
-    return false;
-  }
-
-  path path;
-
-  if (text.front() == path::SEPARATOR) {
-    path = text.prefix(1); // copy leading separator.
-    ++text;
-    if (!text) {
-      ec.clear();
-      return true; // Tried to create root directory, it's already tehre.
-    }
-  }
-
-  path.reserve(p.string().size());
-
-  while (text) {
-    auto elt = text.take_prefix_at(path::SEPARATOR);
-    path /= elt;
-    if (!create_directory(path, ec, mode)) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-bool
-copy(const path &from, const path &to, std::error_code &ec)
-{
-  static constexpr size_t BUF_SIZE = 65536;
-  std::error_code local_ec;
-  char buf[BUF_SIZE];
-  swoc::MemSpan span{buf};
-
-  if (from.empty() || to.empty()) {
-    ec = std::error_code(EINVAL, std::system_category());
-    return false;
-  }
-
-  ec.clear();
-
-  unique_fd src_fd{::open(from.c_str(), O_RDONLY)};
-  if (NO_FD == src_fd) {
-    ec = std::error_code(errno, std::system_category());
-    return false;
-  }
-  auto src_fs = file::status(from, local_ec);
-
-  path final_to;
-  if (auto fs = file::status(to, local_ec) ; !(local_ec && ENOENT == local_ec.value()) && is_dir(fs)) {
-    final_to        = to / from.filename();
-  } else {
-    final_to = to;
-  }
-
-  unique_fd dst_fd{::open(final_to.c_str(), O_WRONLY | O_CREAT, src_fs.mode())};
-  if (NO_FD == dst_fd) {
-    ec = std::error_code(errno, std::system_category());
-    return false;
-  }
-
-  while (true) {
-    if ( auto n = read(src_fd, span.data(), span.size()) ; n > 0 ) {
-      if (::write(dst_fd, span.data(), n) < n) {
-        ec = std::error_code(errno, std::system_category());
+    void
+    file_status::init()
+    {
+      switch (_stat.st_mode & S_IFMT) {
+      case S_IFREG:
+        _type = file_type::regular;
+        break;
+      case S_IFDIR:
+        _type = file_type::directory;
+        break;
+      case S_IFLNK:
+        _type = file_type::symlink;
+        break;
+      case S_IFBLK:
+        _type = file_type::block;
+        break;
+      case S_IFCHR:
+        _type = file_type::character;
+        break;
+      case S_IFIFO:
+        _type = file_type::fifo;
+        break;
+      case S_IFSOCK:
+        _type = file_type::socket;
+        break;
+      default:
+        _type = file_type::unknown;
         break;
       }
-    } else {
-      break;
     }
-  }
 
-  return true;
-}
+    file_status
+    status(path const &file, std::error_code &ec) noexcept
+    {
+      file_status zret;
+      if (::stat(file.c_str(), &zret._stat) >= 0) {
+        ec.clear();
+        zret.init();
+      } else {
+        ec = std::error_code(errno, std::system_category());
+        if (errno == ENOENT) {
+          zret._type = file_type::not_found;
+        }
+      }
+      return zret;
+    }
 
-uintmax_t
-remove_all(const path &p, std::error_code &ec)
-{
-  // coverity TOCTOU - issue is doing stat before doing operation. Stupid complaint, ignore.
-  DIR *dir = nullptr;
-  struct dirent *entry = nullptr;
-  std::error_code err;
-  uintmax_t zret = 0;
+    int
+    file_type(const file_status &fs)
+    {
+      return fs._stat.st_mode & S_IFMT;
+    }
 
-  struct ::stat s{};
-  if (p.empty()) {
-    ec = std::error_code(EINVAL, std::system_category());
-    return zret;
-  } else if (::stat(p.c_str(), &s) < 0) {
-    ec = std::error_code(errno, std::system_category());
-    return zret;
-  } else if (S_ISREG(s.st_mode)) { // regular file, try to remove it!
-    //coverity[toctou : SUPPRESS]
-    if (unlink(p.c_str()) != 0) {
+    uintmax_t
+    file_size(const file_status &fs)
+    {
+      return fs._stat.st_size;
+    }
+
+    bool
+    exists(const path &p)
+    {
+      std::error_code ec;
+      auto fs = status(p, ec);
+      return exists(fs);
+    }
+
+    path
+    absolute(path const &src, std::error_code &ec)
+    {
+      char buff[4096];
+      ec.clear();
+      if (src.is_absolute()) {
+        return src;
+      }
+      auto s = realpath(src.c_str(), buff);
+      if (s == nullptr) {
+        if (errno == ENAMETOOLONG) {
+          s = realpath(src.c_str(), nullptr);
+          if (s != nullptr) {
+            path zret{s};
+            free(s);
+            return zret;
+          }
+        }
+        ec = std::error_code(errno, std::system_category());
+        return {};
+      }
+      return path{s};
+    }
+
+    namespace
+    {
+
+      inline file_time_type
+      chrono_cast(timespec const &ts)
+      {
+        using namespace std::chrono;
+        return system_clock::time_point{duration_cast<system_clock::duration>(seconds{ts.tv_sec} + nanoseconds{ts.tv_nsec})};
+      }
+
+      // Apple has different names for these members, need to have accessors that account for that.
+      // Under -O2 these are completely elided.
+      template <typename S>
+      auto
+      a_time(S const &s, meta::CaseTag<0>) -> decltype(S::st_atim)
+      {
+        return s.st_atim;
+      }
+
+      template <typename S>
+      auto
+      a_time(S const &s, meta::CaseTag<1>) -> decltype(S::st_atimespec)
+      {
+        return s.st_atimespec;
+      }
+
+      template <typename S>
+      auto
+      m_time(S const &s, meta::CaseTag<0>) -> decltype(S::st_mtim)
+      {
+        return s.st_mtim;
+      }
+
+      template <typename S>
+      auto
+      m_time(S const &s, meta::CaseTag<1>) -> decltype(S::st_mtimespec)
+      {
+        return s.st_mtimespec;
+      }
+
+      template <typename S>
+      auto
+      c_time(S const &s, meta::CaseTag<0>) -> decltype(S::st_ctim)
+      {
+        return s.st_ctim;
+      }
+
+      template <typename S>
+      auto
+      c_time(S const &s, meta::CaseTag<1>) -> decltype(S::st_ctimespec)
+      {
+        return s.st_ctimespec;
+      }
+
+    } // namespace
+
+    file_time_type
+    last_write_time(file_status const &fs)
+    {
+      return chrono_cast(m_time(fs._stat, meta::CaseArg));
+    }
+
+    file_time_type
+    access_time(file_status const &fs)
+    {
+      return chrono_cast(a_time(fs._stat, meta::CaseArg));
+    }
+
+    file_time_type
+    status_time(file_status const &fs)
+    {
+      return chrono_cast(c_time(fs._stat, meta::CaseArg));
+    }
+
+    file_time_type
+    last_write_time(path const &p, std::error_code &ec)
+    {
+      auto fs = status(p, ec);
+      if (ec) {
+        return file_time_type::min();
+      }
+      return last_write_time(fs);
+    }
+
+    bool
+    is_readable(const path &p)
+    {
+      return 0 == access(p.c_str(), R_OK);
+    }
+
+    path
+    temp_directory_path()
+    {
+      /* ISO/IEC 9945 (POSIX): The path supplied by the first environment variable found in the list TMPDIR, TMP, TEMP, TEMPDIR.
+       * If none of these are found, "/tmp"
+       * */
+      for (char const *tp : {"TMPDIR", "TMP", "TEMPDIR"}) {
+        if (auto v = ::getenv(tp); v) {
+          return path(v);
+        }
+      }
+      return path("/tmp");
+    }
+
+    path
+    current_path()
+    {
+      char buff[PATH_MAX + 1];
+      if (auto p = ::getcwd(buff, sizeof(buff)); p) {
+        return path{buff};
+#if !__FreeBSD__ && !__APPLE__ // Freakin' Apple and FreeBSD.
+      } else if (ERANGE == errno) {
+        swoc::unique_malloc<char> raw{::get_current_dir_name()};
+        return path{raw.get()};
+#endif
+      }
+      return {};
+    }
+
+    path
+    canonical(const path &p, std::error_code &ec)
+    {
+      if (p.empty()) {
+        ec = std::error_code(EINVAL, std::system_category());
+        return {};
+      }
+
+      char buf[PATH_MAX + 1];
+
+      if (auto rp = ::realpath(p.c_str(), buf); rp) {
+        return path{rp};
+      }
+
+      if (auto rp = ::realpath(p.c_str(), nullptr); rp) {
+        return path{rp};
+      }
+
       ec = std::error_code(errno, std::system_category());
-    } else {
-      ++zret;
+      return {};
     }
-    return zret;
-  } else if (!S_ISDIR(s.st_mode)) { // not a directory
-    ec = std::error_code(ENOTDIR, std::system_category());
-    return zret;
-  }
-  // Invariant - @a p is a directory.
 
-  // recursively remove nested files and directories
-  //coverity[toctou : SUPPRESS]
-  if (nullptr == (dir = opendir(p.c_str()))) {
-    ec = std::error_code(errno, std::system_category());
-    return zret;
-  }
+    bool
+    create_directory(const path &path, std::error_code &ec, mode_t mode) noexcept
+    {
+      if (path.empty()) {
+        ec = std::error_code(EINVAL, std::system_category());
+        return false;
+      }
 
-  auto child = p; // Minimize string allocations / re-allocations.
-  while (nullptr != (entry = readdir(dir))) {
-    if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, "..")) {
-      continue;
+      ec.clear();
+      if (::mkdir(path.c_str(), mode) != 0) {
+        if (EEXIST == errno) {
+          std::error_code local_ec;
+          auto fs = status(path, local_ec);
+          if (!local_ec && is_dir(fs)) {
+            return true;
+          }
+        }
+        ec = std::error_code(errno, std::system_category());
+        return false;
+      }
+      return true;
     }
-    child = p;
-    child /= entry->d_name;
-    zret += remove_all(child, ec);
-  }
 
-  if (0 != rmdir(p.c_str())) {
-    ec = std::error_code(errno, std::system_category());
-  }
-  ++zret;
+    bool
+    create_directories(const path &p, std::error_code &ec, mode_t mode) noexcept
+    {
+      TextView text(p.string());
 
-  closedir(dir);
-  return zret;
-}
+      if (text.empty()) {
+        ec = std::error_code(EINVAL, std::system_category());
+        return false;
+      }
 
-bool remove(path const& p, std::error_code &ec) {
-  // coverity TOCTOU - issue is doing stat before doing operation. Stupid complaint, ignore.
-  struct ::stat fs{};
-  if (p.empty()) {
-    ec = std::error_code(EINVAL, std::system_category());
-  } else if (::stat(p.c_str(), &fs) < 0) {
-    ec = std::error_code(errno, std::system_category());
-  } else if (S_ISREG(fs.st_mode)) { // regular file, try to remove it!
-    //coverity[toctou : SUPPRESS]
-    if (unlink(p.c_str()) != 0) {
-      ec = std::error_code(errno, std::system_category());
+      path path;
+
+      if (text.front() == path::SEPARATOR) {
+        path = text.prefix(1); // copy leading separator.
+        ++text;
+        if (!text) {
+          ec.clear();
+          return true; // Tried to create root directory, it's already tehre.
+        }
+      }
+
+      path.reserve(p.string().size());
+
+      while (text) {
+        auto elt  = text.take_prefix_at(path::SEPARATOR);
+        path     /= elt;
+        if (!create_directory(path, ec, mode)) {
+          return false;
+        }
+      }
+
+      return true;
     }
-  } else if (S_ISDIR(fs.st_mode)) { // not a directory
-    //coverity[toctou : SUPPRESS]
-    if (rmdir(p.c_str()) != 0) {
-      ec = std::error_code(errno, std::system_category());
-    }
-  } else {
-    ec = std::error_code(EINVAL, std::system_category());
-  }
-  return !ec;
-}
 
-std::string
-load(const path &p, std::error_code &ec) {
-  std::string zret;
-  ec.clear();
-  if (unique_fd fd(::open(p.c_str(), O_RDONLY)) ; fd < 0) {
-    ec = std::error_code(errno, std::system_category());
-  } else {
-    struct stat info{};
-    if (0 != ::fstat(fd, &info)) {
-      ec = std::error_code(errno, std::system_category());
-    } else {
-      auto n = info.st_size;
-      zret.resize(n);
-      auto read_len = ::read(fd, zret.data(), n);
-      if (read_len < n) {
+    bool
+    copy(const path &from, const path &to, std::error_code &ec)
+    {
+      static constexpr size_t BUF_SIZE = 65536;
+      std::error_code local_ec;
+      char buf[BUF_SIZE];
+      swoc::MemSpan span{buf};
+
+      if (from.empty() || to.empty()) {
+        ec = std::error_code(EINVAL, std::system_category());
+        return false;
+      }
+
+      ec.clear();
+
+      unique_fd src_fd{::open(from.c_str(), O_RDONLY)};
+      if (NO_FD == src_fd) {
+        ec = std::error_code(errno, std::system_category());
+        return false;
+      }
+      auto src_fs = file::status(from, local_ec);
+
+      path final_to;
+      if (auto fs = file::status(to, local_ec); !(local_ec && ENOENT == local_ec.value()) && is_dir(fs)) {
+        final_to = to / from.filename();
+      } else {
+        final_to = to;
+      }
+
+      unique_fd dst_fd{::open(final_to.c_str(), O_WRONLY | O_CREAT, src_fs.mode())};
+      if (NO_FD == dst_fd) {
+        ec = std::error_code(errno, std::system_category());
+        return false;
+      }
+
+      while (true) {
+        if (auto n = read(src_fd, span.data(), span.size()); n > 0) {
+          if (::write(dst_fd, span.data(), n) < n) {
+            ec = std::error_code(errno, std::system_category());
+            break;
+          }
+        } else {
+          break;
+        }
+      }
+
+      return true;
+    }
+
+    uintmax_t
+    remove_all(const path &p, std::error_code &ec)
+    {
+      // coverity TOCTOU - issue is doing stat before doing operation. Stupid complaint, ignore.
+      DIR *dir             = nullptr;
+      struct dirent *entry = nullptr;
+      std::error_code err;
+      uintmax_t zret = 0;
+
+      struct ::stat s {
+      };
+      if (p.empty()) {
+        ec = std::error_code(EINVAL, std::system_category());
+        return zret;
+      } else if (::stat(p.c_str(), &s) < 0) {
+        ec = std::error_code(errno, std::system_category());
+        return zret;
+      } else if (S_ISREG(s.st_mode)) { // regular file, try to remove it!
+        // coverity[toctou : SUPPRESS]
+        if (unlink(p.c_str()) != 0) {
+          ec = std::error_code(errno, std::system_category());
+        } else {
+          ++zret;
+        }
+        return zret;
+      } else if (!S_ISDIR(s.st_mode)) { // not a directory
+        ec = std::error_code(ENOTDIR, std::system_category());
+        return zret;
+      }
+      // Invariant - @a p is a directory.
+
+      // recursively remove nested files and directories
+      // coverity[toctou : SUPPRESS]
+      if (nullptr == (dir = opendir(p.c_str()))) {
+        ec = std::error_code(errno, std::system_category());
+        return zret;
+      }
+
+      auto child = p; // Minimize string allocations / re-allocations.
+      while (nullptr != (entry = readdir(dir))) {
+        if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, "..")) {
+          continue;
+        }
+        child  = p;
+        child /= entry->d_name;
+        zret  += remove_all(child, ec);
+      }
+
+      if (0 != rmdir(p.c_str())) {
         ec = std::error_code(errno, std::system_category());
       }
+      ++zret;
+
+      closedir(dir);
+      return zret;
     }
+
+    bool
+    remove(path const &p, std::error_code &ec)
+    {
+      // coverity TOCTOU - issue is doing stat before doing operation. Stupid complaint, ignore.
+      struct ::stat fs {
+      };
+      if (p.empty()) {
+        ec = std::error_code(EINVAL, std::system_category());
+      } else if (::stat(p.c_str(), &fs) < 0) {
+        ec = std::error_code(errno, std::system_category());
+      } else if (S_ISREG(fs.st_mode)) { // regular file, try to remove it!
+        // coverity[toctou : SUPPRESS]
+        if (unlink(p.c_str()) != 0) {
+          ec = std::error_code(errno, std::system_category());
+        }
+      } else if (S_ISDIR(fs.st_mode)) { // not a directory
+        // coverity[toctou : SUPPRESS]
+        if (rmdir(p.c_str()) != 0) {
+          ec = std::error_code(errno, std::system_category());
+        }
+      } else {
+        ec = std::error_code(EINVAL, std::system_category());
+      }
+      return !ec;
+    }
+
+    std::string
+    load(const path &p, std::error_code &ec)
+    {
+      std::string zret;
+      ec.clear();
+      if (unique_fd fd(::open(p.c_str(), O_RDONLY)); fd < 0) {
+        ec = std::error_code(errno, std::system_category());
+      } else {
+        struct stat info {
+        };
+        if (0 != ::fstat(fd, &info)) {
+          ec = std::error_code(errno, std::system_category());
+        } else {
+          auto n = info.st_size;
+          zret.resize(n);
+          auto read_len = ::read(fd, zret.data(), n);
+          if (read_len < n) {
+            ec = std::error_code(errno, std::system_category());
+          }
+        }
+      }
+      return zret;
+    }
+
+  } // namespace file
+
+  BufferWriter &
+  bwformat(BufferWriter &w, bwf::Spec const &spec, file::path const &p)
+  {
+    return bwformat(w, spec, p.string());
   }
-  return zret;
-}
 
-} // namespace file
-
-BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, file::path const &p) {
-  return bwformat(w, spec, p.string());
-}
-
-}  // namespace SWOC_VERSION_NS
-}  // namespace swoc
+} // namespace SWOC_VERSION_NS
+} // namespace swoc

--- a/code/src/swoc_ip.cc
+++ b/code/src/swoc_ip.cc
@@ -13,1246 +13,1336 @@ using swoc::svtoi;
 using swoc::svtou;
 using namespace swoc::literals;
 
-namespace {
+namespace
+{
 // Handle the @c sin_len member, the presence of which varies across compilation environments.
 template <typename T>
 auto
-Set_Sockaddr_Len_Case(T *, swoc::meta::CaseTag<0>) -> decltype(swoc::meta::TypeFunc<void>()) {}
+Set_Sockaddr_Len_Case(T *, swoc::meta::CaseTag<0>) -> decltype(swoc::meta::TypeFunc<void>())
+{
+}
 
 template <typename T>
 auto
-Set_Sockaddr_Len_Case(T *addr, swoc::meta::CaseTag<1>) -> decltype(T::sin_len, swoc::meta::TypeFunc<void>()) {
+Set_Sockaddr_Len_Case(T *addr, swoc::meta::CaseTag<1>) -> decltype(T::sin_len, swoc::meta::TypeFunc<void>())
+{
   addr->sin_len = sizeof(T);
 }
 
 template <typename T>
 void
-Set_Sockaddr_Len(T *addr) {
+Set_Sockaddr_Len(T *addr)
+{
   Set_Sockaddr_Len_Case(addr, swoc::meta::CaseArg);
 }
 
 } // namespace
 
-namespace swoc { inline namespace SWOC_VERSION_NS {
+namespace swoc
+{
+inline namespace SWOC_VERSION_NS
+{
 
-IPAddr const IPAddr::INVALID;
-IP4Addr const IP4Addr::MIN{INADDR_ANY};
-IP4Addr const IP4Addr::MAX{INADDR_BROADCAST};
-IP6Addr const IP6Addr::MIN{0, 0};
-IP6Addr const IP6Addr::MAX{std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max()};
+  IPAddr const IPAddr::INVALID;
+  IP4Addr const IP4Addr::MIN{INADDR_ANY};
+  IP4Addr const IP4Addr::MAX{INADDR_BROADCAST};
+  IP6Addr const IP6Addr::MIN{0, 0};
+  IP6Addr const IP6Addr::MAX{std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max()};
 
-bool
-IPEndpoint::assign(sockaddr *dst, sockaddr const *src) {
-  size_t n = 0;
-  if (dst != src) {
-    self_type::invalidate(dst);
-    switch (src->sa_family) {
-    case AF_INET:
-      n = sizeof(sockaddr_in);
-      break;
-    case AF_INET6:
-      n = sizeof(sockaddr_in6);
-      break;
+  bool
+  IPEndpoint::assign(sockaddr *dst, sockaddr const *src)
+  {
+    size_t n = 0;
+    if (dst != src) {
+      self_type::invalidate(dst);
+      switch (src->sa_family) {
+      case AF_INET:
+        n = sizeof(sockaddr_in);
+        break;
+      case AF_INET6:
+        n = sizeof(sockaddr_in6);
+        break;
+      }
+      if (n) {
+        memcpy(dst, src, n);
+      }
     }
-    if (n) {
-      memcpy(dst, src, n);
-    }
+    return n != 0;
   }
-  return n != 0;
-}
 
-IPEndpoint &
-IPEndpoint::assign(IP4Addr const &addr) {
-  memset(&sa4, 0, sizeof sa4);
-  sa4.sin_family      = AF_INET;
-  sa4.sin_addr.s_addr = addr.network_order();
-  Set_Sockaddr_Len(&sa4);
-  return *this;
-}
-
-IPEndpoint &
-IPEndpoint::assign(IP6Addr const &addr) {
-  memset(&sa6, 0, sizeof sa6);
-  sa6.sin6_family = AF_INET6;
-  addr.network_order(sa6.sin6_addr);
-  Set_Sockaddr_Len(&sa6);
-  return *this;
-}
-
-IPEndpoint &
-IPEndpoint::assign(IPAddr const &src) {
-  switch (src.family()) {
-  case AF_INET: {
+  IPEndpoint &
+  IPEndpoint::assign(IP4Addr const &addr)
+  {
     memset(&sa4, 0, sizeof sa4);
     sa4.sin_family      = AF_INET;
-    sa4.sin_addr.s_addr = src.ip4().network_order();
+    sa4.sin_addr.s_addr = addr.network_order();
     Set_Sockaddr_Len(&sa4);
-  } break;
-  case AF_INET6: {
+    return *this;
+  }
+
+  IPEndpoint &
+  IPEndpoint::assign(IP6Addr const &addr)
+  {
     memset(&sa6, 0, sizeof sa6);
     sa6.sin6_family = AF_INET6;
-    sa6.sin6_addr   = src.ip6().network_order();
+    addr.network_order(sa6.sin6_addr);
     Set_Sockaddr_Len(&sa6);
-  } break;
-  }
-  return *this;
-}
-
-IPEndpoint &
-IPEndpoint::assign(IPAddr const& addr, in_port_t port) {
-  if (addr.is_ip4()) {
-    this->assign(IP4Srv(addr.ip4(), port));
-  } else if (addr.is_ip6()) {
-    this->assign(IP6Srv(addr.ip6(), port));
-  }
-  return *this;
-}
-
-IPEndpoint &
-IPEndpoint::assign(IP4Srv const &src) {
-  memset(&sa4, 0, sizeof sa4);
-  sa4.sin_family      = AF_INET;
-  sa4.sin_addr.s_addr = src.addr().network_order();
-  sa4.sin_port        = src.network_order_port();
-  Set_Sockaddr_Len(&sa4);
-  return *this;
-}
-
-IPEndpoint &
-IPEndpoint::assign(IP6Srv const &src) {
-  memset(&sa6, 0, sizeof sa6);
-  sa6.sin6_family = AF_INET6;
-  sa6.sin6_addr   = src.addr().network_order();
-  sa6.sin6_port   = src.network_order_port();
-  Set_Sockaddr_Len(&sa6);
-  return *this;
-}
-
-IPEndpoint &
-IPEndpoint::assign(IPSrv const &srv) {
-  if (srv.is_ip4()) {
-    return this->assign(srv.ip4());
-  } else if (srv.is_ip6()) {
-    return this->assign(srv.ip6());
-  }
-  return *this;
-}
-
-bool
-IPEndpoint::tokenize(std::string_view str, std::string_view *addr, std::string_view *port, std::string_view *rest) {
-  TextView src(str); /// Easier to work with for parsing.
-  // In case the incoming arguments are null, set them here and only check for null once.
-  // it doesn't matter if it's all the same, the results will be thrown away.
-  std::string_view local;
-  if (!addr) {
-    addr = &local;
-  }
-  if (!port) {
-    port = &local;
-  }
-  if (!rest) {
-    rest = &local;
+    return *this;
   }
 
-  *addr = std::string_view{};
-  *port = std::string_view{};
-  *rest = std::string_view{};
-
-  // Let's see if we can find out what's in the address string.
-  if (src) {
-    bool colon_p = false;
-    src.ltrim_if(&isspace);
-    // Check for brackets.
-    if ('[' == *src) {
-      ++src; // skip bracket.
-      *addr = src.take_prefix_at(']');
-      if (':' == *src) {
-        colon_p = true;
-        ++src;
-      }
-    } else {
-      TextView::size_type last = src.rfind(':');
-      if (last != TextView::npos && last == src.find(':')) {
-        // Exactly one colon - leave post colon stuff in @a src.
-        *addr   = src.take_prefix(last);
-        colon_p = true;
-      } else { // presume no port, use everything.
-        *addr = src;
-        src.clear();
-      }
+  IPEndpoint &
+  IPEndpoint::assign(IPAddr const &src)
+  {
+    switch (src.family()) {
+    case AF_INET: {
+      memset(&sa4, 0, sizeof sa4);
+      sa4.sin_family      = AF_INET;
+      sa4.sin_addr.s_addr = src.ip4().network_order();
+      Set_Sockaddr_Len(&sa4);
+    } break;
+    case AF_INET6: {
+      memset(&sa6, 0, sizeof sa6);
+      sa6.sin6_family = AF_INET6;
+      sa6.sin6_addr   = src.ip6().network_order();
+      Set_Sockaddr_Len(&sa6);
+    } break;
     }
-    if (colon_p) {
-      TextView tmp{src};
-      src.ltrim_if(&isdigit);
+    return *this;
+  }
 
-      if (tmp.data() == src.data()) {               // no digits at all
-        src.assign(tmp.data() - 1, tmp.size() + 1); // back up to include colon
+  IPEndpoint &
+  IPEndpoint::assign(IPAddr const &addr, in_port_t port)
+  {
+    if (addr.is_ip4()) {
+      this->assign(IP4Srv(addr.ip4(), port));
+    } else if (addr.is_ip6()) {
+      this->assign(IP6Srv(addr.ip6(), port));
+    }
+    return *this;
+  }
+
+  IPEndpoint &
+  IPEndpoint::assign(IP4Srv const &src)
+  {
+    memset(&sa4, 0, sizeof sa4);
+    sa4.sin_family      = AF_INET;
+    sa4.sin_addr.s_addr = src.addr().network_order();
+    sa4.sin_port        = src.network_order_port();
+    Set_Sockaddr_Len(&sa4);
+    return *this;
+  }
+
+  IPEndpoint &
+  IPEndpoint::assign(IP6Srv const &src)
+  {
+    memset(&sa6, 0, sizeof sa6);
+    sa6.sin6_family = AF_INET6;
+    sa6.sin6_addr   = src.addr().network_order();
+    sa6.sin6_port   = src.network_order_port();
+    Set_Sockaddr_Len(&sa6);
+    return *this;
+  }
+
+  IPEndpoint &
+  IPEndpoint::assign(IPSrv const &srv)
+  {
+    if (srv.is_ip4()) {
+      return this->assign(srv.ip4());
+    } else if (srv.is_ip6()) {
+      return this->assign(srv.ip6());
+    }
+    return *this;
+  }
+
+  bool
+  IPEndpoint::tokenize(std::string_view str, std::string_view *addr, std::string_view *port, std::string_view *rest)
+  {
+    TextView src(str); /// Easier to work with for parsing.
+    // In case the incoming arguments are null, set them here and only check for null once.
+    // it doesn't matter if it's all the same, the results will be thrown away.
+    std::string_view local;
+    if (!addr) {
+      addr = &local;
+    }
+    if (!port) {
+      port = &local;
+    }
+    if (!rest) {
+      rest = &local;
+    }
+
+    *addr = std::string_view{};
+    *port = std::string_view{};
+    *rest = std::string_view{};
+
+    // Let's see if we can find out what's in the address string.
+    if (src) {
+      bool colon_p = false;
+      src.ltrim_if(&isspace);
+      // Check for brackets.
+      if ('[' == *src) {
+        ++src; // skip bracket.
+        *addr = src.take_prefix_at(']');
+        if (':' == *src) {
+          colon_p = true;
+          ++src;
+        }
       } else {
-        *port = std::string_view(tmp.data(), src.data() - tmp.data());
+        TextView::size_type last = src.rfind(':');
+        if (last != TextView::npos && last == src.find(':')) {
+          // Exactly one colon - leave post colon stuff in @a src.
+          *addr   = src.take_prefix(last);
+          colon_p = true;
+        } else { // presume no port, use everything.
+          *addr = src;
+          src.clear();
+        }
       }
-    }
-    *rest = src;
-  }
-  return !addr->empty(); // true if we found an address.
-}
+      if (colon_p) {
+        TextView tmp{src};
+        src.ltrim_if(&isdigit);
 
-bool
-IPEndpoint::parse(std::string_view const &str) {
-  if (IPSrv srv; srv.load(TextView(str).trim_if(&isspace))) {
-    this->assign(srv);
+        if (tmp.data() == src.data()) {               // no digits at all
+          src.assign(tmp.data() - 1, tmp.size() + 1); // back up to include colon
+        } else {
+          *port = std::string_view(tmp.data(), src.data() - tmp.data());
+        }
+      }
+      *rest = src;
+    }
+    return !addr->empty(); // true if we found an address.
+  }
+
+  bool
+  IPEndpoint::parse(std::string_view const &str)
+  {
+    if (IPSrv srv; srv.load(TextView(str).trim_if(&isspace))) {
+      this->assign(srv);
+      return true;
+    }
+    return false;
+  }
+
+  socklen_t
+  IPEndpoint::size() const
+  {
+    switch (sa.sa_family) {
+    case AF_INET:
+      return sizeof(sockaddr_in);
+    case AF_INET6:
+      return sizeof(sockaddr_in6);
+    default:
+      return sizeof(sockaddr);
+    }
+  }
+
+  std::string_view
+  IPEndpoint::family_name(sa_family_t family)
+  {
+    switch (family) {
+    case AF_INET:
+      return "ipv4"_sv;
+    case AF_INET6:
+      return "ipv6"_sv;
+    case AF_UNIX:
+      return "unix"_sv;
+    case AF_UNSPEC:
+      return "unspec"_sv;
+    }
+    return "unknown"_sv;
+  }
+
+  IPEndpoint &
+  IPEndpoint::set_to_any(int family)
+  {
+    memset(this, 0, sizeof(*this));
+    if (AF_INET == family) {
+      sa4.sin_family      = family;
+      sa4.sin_addr.s_addr = INADDR_ANY;
+      Set_Sockaddr_Len(&sa4);
+    } else if (AF_INET6 == family) {
+      sa6.sin6_family = family;
+      sa6.sin6_addr   = in6addr_any;
+      Set_Sockaddr_Len(&sa6);
+    }
+    return *this;
+  }
+
+  bool
+  IPEndpoint::is_any() const
+  {
+    bool zret = false;
+    switch (this->family()) {
+    case AF_INET:
+      zret = sa4.sin_addr.s_addr == INADDR_ANY;
+      break;
+    case AF_INET6:
+      zret = IN6_IS_ADDR_UNSPECIFIED(&sa6.sin6_addr);
+      break;
+    }
+    return zret;
+  }
+
+  IPEndpoint &
+  IPEndpoint::set_to_loopback(int family)
+  {
+    memset(this, 0, sizeof(*this));
+    if (AF_INET == family) {
+      sa.sa_family        = family;
+      sa4.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+      Set_Sockaddr_Len(&sa4);
+    } else if (AF_INET6 == family) {
+      sa.sa_family  = family;
+      sa6.sin6_addr = in6addr_loopback;
+      Set_Sockaddr_Len(&sa6);
+    }
+    return *this;
+  }
+
+  bool
+  IPEndpoint::is_loopback() const
+  {
+    bool zret = false;
+    switch (this->family()) {
+    case AF_INET:
+      zret = ((ntohl(sa4.sin_addr.s_addr) & IN_CLASSA_NET) >> IN_CLASSA_NSHIFT) == IN_LOOPBACKNET;
+      break;
+    case AF_INET6:
+      zret = IN6_IS_ADDR_LOOPBACK(&sa6.sin6_addr);
+      break;
+    }
+    return zret;
+  }
+
+  bool
+  IP4Addr::load(std::string_view const &text)
+  {
+    TextView src{text};
+    int n = SIZE; /// # of octets
+
+    _addr = INADDR_ANY; // clear to zero.
+
+    // empty or trailing dot or empty brackets or unmatched brackets.
+    src.trim_if(&isspace);
+    if (src.empty() || src.back() == '.' || ('[' == *src && ((++src).empty() || src.back() != ']'))) {
+      return false;
+    }
+
+    in_addr_t max = std::numeric_limits<in_addr_t>::max();
+    while (n > 0) {
+      TextView parsed;
+      auto token = src.take_prefix_at('.');
+      auto v     = svtou(token, &parsed);
+      if (parsed.size() != token.size()) {
+        break;
+      }
+      if (src.empty()) {
+        if (v <= max) {
+          _addr += v;
+          n      = 0; // signal complete.
+        }
+        break;
+      } else if (v <= std::numeric_limits<uint8_t>::max()) {
+        _addr += v << (--n * 8);
+      } else {
+        break; // invalid.
+      }
+      max >>= 8; // reduce by one octet.
+    }
+
+    // If there's text left, or not all the octets were filled, fail.
+    if (!src.empty() || n != 0) {
+      _addr = INADDR_ANY;
+      return false;
+    }
+
     return true;
   }
-  return false;
-}
 
-socklen_t
-IPEndpoint::size() const {
-  switch (sa.sa_family) {
-  case AF_INET:
-    return sizeof(sockaddr_in);
-  case AF_INET6:
-    return sizeof(sockaddr_in6);
-  default:
-    return sizeof(sockaddr);
-  }
-}
+  IP4Addr::IP4Addr(sockaddr_in const *sa) : _addr(reorder(sa->sin_addr.s_addr)) {}
 
-std::string_view
-IPEndpoint::family_name(sa_family_t family) {
-  switch (family) {
-  case AF_INET:
-    return "ipv4"_sv;
-  case AF_INET6:
-    return "ipv6"_sv;
-  case AF_UNIX:
-    return "unix"_sv;
-  case AF_UNSPEC:
-    return "unspec"_sv;
-  }
-  return "unknown"_sv;
-}
-
-IPEndpoint &
-IPEndpoint::set_to_any(int family) {
-  memset(this, 0, sizeof(*this));
-  if (AF_INET == family) {
-    sa4.sin_family      = family;
-    sa4.sin_addr.s_addr = INADDR_ANY;
-    Set_Sockaddr_Len(&sa4);
-  } else if (AF_INET6 == family) {
-    sa6.sin6_family = family;
-    sa6.sin6_addr   = in6addr_any;
-    Set_Sockaddr_Len(&sa6);
-  }
-  return *this;
-}
-
-bool
-IPEndpoint::is_any() const {
-  bool zret = false;
-  switch (this->family()) {
-  case AF_INET:
-    zret = sa4.sin_addr.s_addr == INADDR_ANY;
-    break;
-  case AF_INET6:
-    zret = IN6_IS_ADDR_UNSPECIFIED(&sa6.sin6_addr);
-    break;
-  }
-  return zret;
-}
-
-IPEndpoint &
-IPEndpoint::set_to_loopback(int family) {
-  memset(this, 0, sizeof(*this));
-  if (AF_INET == family) {
-    sa.sa_family        = family;
-    sa4.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    Set_Sockaddr_Len(&sa4);
-  } else if (AF_INET6 == family) {
-    sa.sa_family  = family;
-    sa6.sin6_addr = in6addr_loopback;
-    Set_Sockaddr_Len(&sa6);
-  }
-  return *this;
-}
-
-bool
-IPEndpoint::is_loopback() const {
-  bool zret = false;
-  switch (this->family()) {
-  case AF_INET:
-    zret = ((ntohl(sa4.sin_addr.s_addr) & IN_CLASSA_NET) >> IN_CLASSA_NSHIFT) == IN_LOOPBACKNET;
-    break;
-  case AF_INET6:
-    zret = IN6_IS_ADDR_LOOPBACK(&sa6.sin6_addr);
-    break;
-  }
-  return zret;
-}
-
-bool
-IP4Addr::load(std::string_view const &text) {
-  TextView src{text};
-  int n = SIZE; /// # of octets
-
-  _addr = INADDR_ANY; // clear to zero.
-
-  // empty or trailing dot or empty brackets or unmatched brackets.
-  src.trim_if(&isspace);
-  if (src.empty() || src.back() == '.' || ('[' == *src && ((++src).empty() || src.back() != ']'))) {
-    return false;
+  auto
+  IP4Addr::operator=(sockaddr_in const *sa) -> self_type &
+  {
+    _addr = reorder(sa->sin_addr.s_addr);
+    return *this;
   }
 
-  in_addr_t max = std::numeric_limits<in_addr_t>::max();
-  while (n > 0) {
-    TextView parsed;
-    auto token = src.take_prefix_at('.');
-    auto v = svtou(token, &parsed);
-    if (parsed.size() != token.size()) {
-      break;
-    }
-    if (src.empty()) {
-      if (v <= max) {
-        _addr += v;
-        n = 0; // signal complete.
-      }
-      break;
-    } else if (v <= std::numeric_limits<uint8_t>::max()){
-      _addr += v << ( --n * 8);
+  sockaddr_in *
+  IP4Addr::copy_to(sockaddr_in *sin) const
+  {
+    sin->sin_family      = AF_INET;
+    sin->sin_addr.s_addr = this->network_order();
+    Set_Sockaddr_Len(sin);
+    return sin;
+  }
+
+  // --- IPv6
+
+  sockaddr_in6 *
+  IP6Addr::copy_to(sockaddr_in6 *sin6) const
+  {
+    sin6->sin6_family = AF_INET6;
+    self_type::reorder(sin6->sin6_addr, _addr._raw);
+    Set_Sockaddr_Len(sin6);
+    return sin6;
+  }
+
+  int
+  IP6Addr::cmp(const self_type &that) const
+  {
+    return *this < that ? -1 : *this > that ? 1 : 0;
+  }
+
+  IP6Addr &
+  IP6Addr::operator<<=(unsigned int n)
+  {
+    static constexpr auto MASK = ~word_type{0};
+    if (n < WORD_WIDTH) {
+      _addr._store[MSW] <<= n;
+      _addr._store[MSW]  |= (_addr._store[LSW] >> (WORD_WIDTH - n)) & ~(MASK << n);
+      _addr._store[LSW] <<= n;
     } else {
-      break; // invalid.
+      n                 -= WORD_WIDTH;
+      _addr._store[MSW]  = _addr._store[LSW] << n;
+      _addr._store[LSW]  = 0;
     }
-    max >>= 8; // reduce by one octet.
+    return *this;
   }
 
-  // If there's text left, or not all the octets were filled, fail.
-  if (! src.empty() || n != 0) {
-    _addr = INADDR_ANY;
-    return false;
-  }
-
-  return true;
-}
-
-IP4Addr::IP4Addr(sockaddr_in const *sa) : _addr(reorder(sa->sin_addr.s_addr)) {}
-
-auto
-IP4Addr::operator=(sockaddr_in const *sa) -> self_type & {
-  _addr = reorder(sa->sin_addr.s_addr);
-  return *this;
-}
-
-sockaddr_in *
-IP4Addr::copy_to(sockaddr_in *sin) const {
-  sin->sin_family = AF_INET;
-  sin->sin_addr.s_addr = this->network_order();
-  Set_Sockaddr_Len(sin);
-  return sin;
-}
-
-// --- IPv6
-
-sockaddr_in6 *
-IP6Addr::copy_to(sockaddr_in6 *sin6) const {
-  sin6->sin6_family = AF_INET6;
-  self_type::reorder(sin6->sin6_addr, _addr._raw);
-  Set_Sockaddr_Len(sin6);
-  return sin6;
-}
-
-int
-IP6Addr::cmp(const self_type &that) const {
-  return *this < that ? -1 : *this > that ? 1 : 0;
-}
-
-IP6Addr &
-IP6Addr::operator<<=(unsigned int n) {
-  static constexpr auto MASK = ~word_type{0};
-  if (n < WORD_WIDTH) {
-    _addr._store[MSW] <<= n;
-    _addr._store[MSW] |= (_addr._store[LSW] >> (WORD_WIDTH - n)) & ~(MASK << n);
-    _addr._store[LSW] <<= n;
-  } else {
-    n -= WORD_WIDTH;
-    _addr._store[MSW] = _addr._store[LSW] << n;
-    _addr._store[LSW] = 0;
-  }
-  return *this;
-}
-
-IP6Addr &
-IP6Addr::operator>>=(unsigned int n) {
-  static constexpr auto MASK = ~word_type{0};
-  if (n < WORD_WIDTH) {
-    _addr._store[LSW] >>= n;
-    _addr._store[LSW] |= (_addr._store[MSW] & ~(MASK << n)) << (WORD_WIDTH - n);
-    _addr._store[MSW] >>= n;
-  } else {
-    n -= WORD_WIDTH;
-    _addr._store[LSW] = _addr._store[MSW] >> n;
-    _addr._store[MSW] = 0;
-  }
-  return *this;
-}
-
-IP6Addr &
-IP6Addr::operator&=(self_type const &that) {
-  _addr._store[MSW] &= that._addr._store[MSW];
-  _addr._store[LSW] &= that._addr._store[LSW];
-  return *this;
-}
-
-IP6Addr &
-IP6Addr::operator|=(self_type const &that) {
-  _addr._store[MSW] |= that._addr._store[MSW];
-  _addr._store[LSW] |= that._addr._store[LSW];
-  return *this;
-}
-
-bool
-IP6Addr::load(std::string_view const &str) {
-  TextView src{str};
-  int n         = 0;
-  int empty_idx = -1;
-  auto quad     = _addr._quad.data();
-
-  src.trim_if(&isspace);
-  if (src && '[' == *src) {
-    ++src;
-    if (src.empty() || src.back() != ']') {
-      return false;
-    }
-    src.remove_suffix(1);
-  }
-
-  if (src.size() < 2) {
-    return false;
-  }
-
-  // If the first character is ':' then it is an error for it not to be followed by another ':'.
-  // Special case the empty address and loopback, otherwise just make a note of the leading '::'.
-  if (src[0] == ':') {
-    if (src[1] == ':') {
-      if (src.size() == 2) {
-        this->clear();
-        return true;
-      } else if (src.size() == 3 && src[2] == '1') {
-        _addr._store[0] = 0;
-        _addr._store[1] = 1;
-        return true;
-      } else {
-        empty_idx = n;
-        src.remove_prefix(2);
-      }
+  IP6Addr &
+  IP6Addr::operator>>=(unsigned int n)
+  {
+    static constexpr auto MASK = ~word_type{0};
+    if (n < WORD_WIDTH) {
+      _addr._store[LSW] >>= n;
+      _addr._store[LSW]  |= (_addr._store[MSW] & ~(MASK << n)) << (WORD_WIDTH - n);
+      _addr._store[MSW] >>= n;
     } else {
-      return false;
+      n                 -= WORD_WIDTH;
+      _addr._store[LSW]  = _addr._store[MSW] >> n;
+      _addr._store[MSW]  = 0;
     }
+    return *this;
   }
 
-  // Sadly the empty quads can't be done in line because it's not possible to know the correct index
-  // of the next present quad until the entire address has been parsed.
-  while (n < static_cast<int>(N_QUADS) && !src.empty()) {
-    TextView token{src.take_prefix_at(':')};
-    if (token.empty()) {
-      if (empty_idx >= 0) { // two instances of "::", fail.
+  IP6Addr &
+  IP6Addr::operator&=(self_type const &that)
+  {
+    _addr._store[MSW] &= that._addr._store[MSW];
+    _addr._store[LSW] &= that._addr._store[LSW];
+    return *this;
+  }
+
+  IP6Addr &
+  IP6Addr::operator|=(self_type const &that)
+  {
+    _addr._store[MSW] |= that._addr._store[MSW];
+    _addr._store[LSW] |= that._addr._store[LSW];
+    return *this;
+  }
+
+  bool
+  IP6Addr::load(std::string_view const &str)
+  {
+    TextView src{str};
+    int n         = 0;
+    int empty_idx = -1;
+    auto quad     = _addr._quad.data();
+
+    src.trim_if(&isspace);
+    if (src && '[' == *src) {
+      ++src;
+      if (src.empty() || src.back() != ']') {
         return false;
       }
-      empty_idx = n;
+      src.remove_suffix(1);
+    }
+
+    if (src.size() < 2) {
+      return false;
+    }
+
+    // If the first character is ':' then it is an error for it not to be followed by another ':'.
+    // Special case the empty address and loopback, otherwise just make a note of the leading '::'.
+    if (src[0] == ':') {
+      if (src[1] == ':') {
+        if (src.size() == 2) {
+          this->clear();
+          return true;
+        } else if (src.size() == 3 && src[2] == '1') {
+          _addr._store[0] = 0;
+          _addr._store[1] = 1;
+          return true;
+        } else {
+          empty_idx = n;
+          src.remove_prefix(2);
+        }
+      } else {
+        return false;
+      }
+    }
+
+    // Sadly the empty quads can't be done in line because it's not possible to know the correct index
+    // of the next present quad until the entire address has been parsed.
+    while (n < static_cast<int>(N_QUADS) && !src.empty()) {
+      TextView token{src.take_prefix_at(':')};
+      if (token.empty()) {
+        if (empty_idx >= 0) { // two instances of "::", fail.
+          return false;
+        }
+        empty_idx = n;
+      } else {
+        TextView r;
+        auto x = svtoi(token, &r, 16);
+        if (r.size() == token.size()) {
+          quad[QUAD_IDX[n++]] = x;
+        } else {
+          break;
+        }
+      }
+    }
+
+    // Handle empty quads - invalid if empty and still had a full set of quads
+    if (empty_idx >= 0) {
+      if (n < static_cast<int>(N_QUADS)) {
+        int nil_idx = N_QUADS - (n - empty_idx);
+        int delta   = N_QUADS - n;
+        for (int k = N_QUADS - 1; k >= empty_idx; --k) {
+          quad[QUAD_IDX[k]] = (k >= nil_idx ? quad[QUAD_IDX[k - delta]] : 0);
+        }
+        n = N_QUADS; // Mark success.
+      } else {
+        return false; // too many quads - full set plus empty.
+      }
+    }
+
+    if (n == N_QUADS && src.empty()) {
+      return true;
+    }
+
+    this->clear();
+    return false;
+  }
+
+  // These are Intel correct, at some point will need to be architecture dependent.
+
+  void
+  IP6Addr::reorder(in6_addr &dst, raw_type const &src)
+  {
+    self_type::reorder(dst.s6_addr, src.data());
+    self_type::reorder(dst.s6_addr + WORD_SIZE, src.data() + WORD_SIZE);
+  }
+
+  void
+  IP6Addr::reorder(raw_type &dst, in6_addr const &src)
+  {
+    self_type::reorder(dst.data(), src.s6_addr);
+    self_type::reorder(dst.data() + WORD_SIZE, src.s6_addr + WORD_SIZE);
+  }
+
+  IPAddr::IPAddr(IPEndpoint const &addr)
+  {
+    this->assign(&addr.sa);
+  }
+
+  IPAddr &
+  IPAddr::operator=(IPEndpoint const &addr)
+  {
+    return this->assign(&addr.sa);
+  }
+
+  sockaddr *
+  IPAddr::copy_to(sockaddr *sa)
+  {
+    if (this->is_ip4()) {
+      _addr._ip4.copy_to(sa);
+    } else if (this->is_ip6()) {
+      _addr._ip6.copy_to(sa);
+    }
+    return sa;
+  }
+
+  bool
+  IPAddr::load(const std::string_view &text)
+  {
+    TextView src{text};
+    src.ltrim_if(&isspace);
+
+    if (TextView::npos != src.prefix(5).find_first_of('.')) {
+      _family = AF_INET;
+    } else if (TextView::npos != src.prefix(6).find_first_of(':')) {
+      _family = AF_INET6;
     } else {
-      TextView r;
-      auto x = svtoi(token, &r, 16);
-      if (r.size() == token.size()) {
-        quad[QUAD_IDX[n++]] = x;
+      _family = AF_UNSPEC;
+    }
+
+    // Do the real parse now
+    switch (_family) {
+    case AF_INET:
+      if (!_addr._ip4.load(src)) {
+        _family = AF_UNSPEC;
+      }
+      break;
+    case AF_INET6:
+      if (!_addr._ip6.load(src)) {
+        _family = AF_UNSPEC;
+      }
+      break;
+    }
+    return this->is_valid();
+  }
+
+  IPAddr &
+  IPAddr::assign(sockaddr const *addr)
+  {
+    if (addr) {
+      switch (addr->sa_family) {
+      case AF_INET:
+        return this->assign(reinterpret_cast<sockaddr_in const *>(addr));
+      case AF_INET6:
+        return this->assign(reinterpret_cast<sockaddr_in6 const *>(addr));
+      default:
+        break;
+      }
+    }
+    _family = AF_UNSPEC;
+    return *this;
+  }
+
+  bool
+  IPAddr::operator<(self_type const &that) const
+  {
+    if (AF_INET == _family) {
+      switch (that._family) {
+      case AF_INET:
+        return _addr._ip4 < that._addr._ip4;
+      case AF_INET6:
+        return true;
+      default:
+        return false;
+      }
+    } else if (AF_INET6 == _family) {
+      switch (that._family) {
+      case AF_INET:
+        return true;
+      case AF_INET6:
+        return _addr._ip6 < that._addr._ip6;
+      default:
+        return false;
+      }
+    }
+    return that.is_valid();
+  }
+
+  int
+  IPAddr::cmp(self_type const &that) const
+  {
+    if (AF_INET == _family) {
+      switch (that._family) {
+      case AF_INET:
+        return _addr._ip4.cmp(that._addr._ip4);
+      case AF_INET6:
+        return -1;
+      default:
+        return 1;
+      }
+    } else if (AF_INET6 == _family) {
+      switch (that._family) {
+      case AF_INET:
+        return 1;
+      case AF_INET6:
+        return _addr._ip6.cmp(that._addr._ip6);
+      default:
+        return 1;
+      }
+    }
+    return that.is_valid() ? -1 : 0;
+  }
+
+  IPAddr::self_type &
+  IPAddr::operator&=(IPMask const &mask)
+  {
+    if (_family == AF_INET) {
+      _addr._ip4 &= mask;
+    } else if (_family == AF_INET6) {
+      _addr._ip6 &= mask;
+    }
+    return *this;
+  }
+
+  IPAddr::self_type &
+  IPAddr::operator|=(IPMask const &mask)
+  {
+    if (_family == AF_INET) {
+      _addr._ip4 |= mask;
+    } else if (_family == AF_INET6) {
+      _addr._ip6 |= mask;
+    }
+    return *this;
+  }
+
+  bool
+  IPAddr::is_multicast() const
+  {
+    return (AF_INET == _family && _addr._ip4.is_multicast()) || (AF_INET6 == _family && _addr._ip6.is_multicast());
+  }
+
+  IPEndpoint::IPEndpoint(string_view const &text)
+  {
+    this->invalidate();
+    this->parse(text);
+  }
+
+  bool
+  IPMask::load(string_view const &text)
+  {
+    TextView parsed;
+    _cidr = swoc::svtou(text, &parsed);
+    if (parsed.size() != text.size()) {
+      _cidr = 0;
+      return false;
+    }
+    return true;
+  }
+
+  IPMask
+  IPMask::mask_for(IPAddr const &addr)
+  {
+    if (addr.is_ip4()) {
+      return self_type::mask_for(addr.ip4());
+    } else if (addr.is_ip6()) {
+      return self_type::mask_for(addr.ip6());
+    }
+    return {};
+  }
+
+  auto
+  IPMask::mask_for_quad(IP6Addr::quad_type q) -> raw_type
+  {
+    raw_type cidr = IP6Addr::QUAD_WIDTH;
+    if (q != 0) {
+      IP6Addr::quad_type mask = IP6Addr::QUAD_MASK;
+      do {
+        mask <<= 1;
+        --cidr;
+      } while ((q & mask) == q);
+      ++cidr; // loop goes exactly 1 too far.
+    }
+    return cidr;
+  }
+
+  IPMask
+  IPMask::mask_for(IP4Addr const &addr)
+  {
+    auto n        = addr.host_order();
+    raw_type cidr = 0;
+    if (auto q = (n & IP6Addr::QUAD_MASK); q != 0) {
+      cidr = IP6Addr::QUAD_WIDTH + self_type::mask_for_quad(q);
+    } else if (q = ((n >> IP6Addr::QUAD_WIDTH) & IP6Addr::QUAD_MASK); q != 0) {
+      cidr = self_type::mask_for_quad(q);
+    }
+    return self_type(cidr);
+  }
+
+  IPMask
+  IPMask::mask_for(IP6Addr const &addr)
+  {
+    auto cidr = IP6Addr::WIDTH;
+    for (unsigned idx = IP6Addr::N_QUADS; idx > 0;) {
+      auto q  = addr._addr._quad[IP6Addr::QUAD_IDX[--idx]];
+      cidr   -= IP6Addr::QUAD_WIDTH;
+      if (q != 0) {
+        cidr += self_type::mask_for_quad(q);
+        break;
+      }
+    }
+    return self_type(cidr);
+  }
+
+  IP6Addr
+  IPMask::as_ip6() const
+  {
+    static constexpr auto MASK = ~IP6Addr::word_type{0};
+    if (_cidr == 0) {
+      return {0, 0};
+    } else if (_cidr <= IP6Addr::WORD_WIDTH) {
+      return {MASK << (IP6Addr::WORD_WIDTH - _cidr), 0};
+    } else if (_cidr < 2 * IP6Addr::WORD_WIDTH) {
+      return {MASK, MASK << (2 * IP6Addr::WORD_WIDTH - _cidr)};
+    }
+    return {MASK, MASK};
+  }
+
+  // --- SRV ---
+
+  IP4Srv::IP4Srv(swoc::TextView text)
+  {
+    this->load(text);
+  }
+
+  bool
+  IP4Srv::load(swoc::TextView text)
+  {
+    TextView addr_text, port_text, rest;
+    if (IPEndpoint::tokenize(text, &addr_text, &port_text, &rest)) {
+      if (rest.empty()) {
+        uintmax_t n = 0;
+        if (!port_text.empty()) {
+          n = swoc::svtou(port_text, &rest);
+          if (rest.size() != port_text.size() || n > std::numeric_limits<in_port_t>::max()) {
+            return false; // bad port.
+          }
+        }
+        IP4Addr addr;
+        if (addr.load(addr_text)) {
+          this->assign(addr, n);
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  IP6Srv::IP6Srv(swoc::TextView text)
+  {
+    this->load(text);
+  }
+
+  bool
+  IP6Srv::load(swoc::TextView text)
+  {
+    TextView addr_text, port_text, rest;
+    if (IPEndpoint::tokenize(text, &addr_text, &port_text, &rest)) {
+      if (rest.empty()) {
+        uintmax_t n = 0;
+        if (!port_text.empty()) {
+          n = swoc::svtou(port_text, &rest);
+          if (rest.size() != port_text.size() || n > std::numeric_limits<in_port_t>::max()) {
+            return false; // bad port.
+          }
+        }
+        IP6Addr addr;
+        if (addr.load(addr_text)) {
+          this->assign(addr, n);
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  IPSrv::IPSrv(swoc::TextView text)
+  {
+    this->load(text);
+  }
+
+  bool
+  IPSrv::load(swoc::TextView text)
+  {
+    TextView addr_text, port_text, rest;
+    if (IPEndpoint::tokenize(text, &addr_text, &port_text, &rest)) {
+      if (rest.empty()) {
+        uintmax_t n = 0;
+        if (!port_text.empty()) {
+          n = swoc::svtou(port_text, &rest);
+          if (rest.size() != port_text.size() || n > std::numeric_limits<in_port_t>::max()) {
+            return false; // bad port.
+          }
+        }
+        IPAddr addr;
+        if (addr.load(addr_text)) {
+          this->assign(addr, n);
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  IPSrv::IPSrv(IPAddr addr, in_port_t port) : _family(addr.family())
+  {
+    if (addr.is_ip4()) {
+      _srv._ip4.assign(addr.ip4(), port);
+    } else if (addr.is_ip6()) {
+      _srv._ip6.assign(addr.ip6(), port);
+    } else {
+      _family = AF_UNSPEC;
+    }
+  }
+
+  IPSrv::IPSrv(IPEndpoint const &ep)
+  {
+    if (ep.is_ip4()) {
+      _family = _srv._ip4.family();
+      _srv._ip4.assign(&ep.sa4);
+    } else if (ep.is_ip6()) {
+      _family = _srv._ip6.family();
+      _srv._ip6.assign(&ep.sa6);
+    }
+  }
+
+  auto
+  IPSrv::assign(const sockaddr *sa) -> self_type &
+  {
+    if (AF_INET == sa->sa_family) {
+      _family = AF_INET;
+      _srv._ip4.assign(reinterpret_cast<sockaddr_in const *>(sa));
+    } else if (AF_INET6 == sa->sa_family) {
+      _family = AF_INET6;
+      _srv._ip6.assign(reinterpret_cast<sockaddr_in6 const *>(sa));
+    }
+    return *this;
+  }
+
+  // ++ IPNet ++
+
+  bool
+  IP4Net::load(TextView text)
+  {
+    if (auto mask_text = text.split_suffix_at('/'); !mask_text.empty()) {
+      IPMask mask;
+      bool mask_p = mask.load(mask_text);
+      if (IP4Addr addr; addr.load(text)) {
+        if (!mask_p) {
+          if (IP4Addr m; m.load(mask_text)) {
+            mask   = IPMask::mask_for(m);
+            mask_p = (m == mask.as_ip4()); // must be an actual mask like address.
+          }
+        }
+        if (mask_p) {
+          this->assign(addr, mask);
+          return true;
+        }
+      }
+    }
+
+    this->clear();
+    return false;
+  }
+
+  bool
+  IP6Net::load(TextView text)
+  {
+    if (auto mask_text = text.split_suffix_at('/'); !mask_text.empty()) {
+      IPMask mask;
+      bool mask_p = mask.load(mask_text);
+      if (IP6Addr addr; addr.load(text)) {
+        if (!mask_p) {
+          if (IP6Addr m; m.load(mask_text)) {
+            mask   = IPMask::mask_for(m);
+            mask_p = (m == mask.as_ip6()); // must be an actual mask like address.
+          }
+        }
+        if (mask_p) {
+          this->assign(addr, mask);
+          return true;
+        }
+      }
+    }
+
+    this->clear();
+    return false;
+  }
+
+  bool
+  IPNet::load(TextView text)
+  {
+    if (auto mask_text = text.split_suffix_at('/'); !mask_text.empty()) {
+      IPMask mask;
+      bool mask_p = mask.load(mask_text);
+
+      if (IP6Addr a6; a6.load(text)) { // load the address
+        if (!mask_p) {
+          if (IP6Addr m; m.load(mask_text)) {
+            mask   = IPMask::mask_for(m);
+            mask_p = (m == mask.as_ip6()); // must be an actual mask like address.
+          }
+        }
+        if (mask_p) {
+          this->assign(a6, mask);
+          return true;
+        }
+      } else if (IP4Addr a4; a4.load(text)) {
+        if (!mask_p) {
+          if (IP4Addr m; m.load(mask_text)) {
+            mask   = IPMask::mask_for(m);
+            mask_p = (m == mask.as_ip4()); // must be an actual mask like address.
+          }
+        }
+        if (mask_p) {
+          this->assign(a4, mask);
+          return true;
+        }
+      }
+    }
+    this->clear();
+    return false;
+  }
+
+  // +++ IP4Range +++
+
+  IP4Range::IP4Range(swoc::IP4Addr const &addr, swoc::IPMask const &mask)
+  {
+    this->assign(addr, mask);
+  }
+
+  IP4Range &
+  IP4Range::assign(swoc::IP4Addr const &addr, swoc::IPMask const &mask)
+  {
+    // Special case the cidr sizes for 0, maximum
+    if (0 == mask.width()) {
+      _min = metric_type::MIN;
+      _max = metric_type::MAX;
+    } else {
+      _min = _max = addr;
+      if (mask.width() < 32) {
+        in_addr_t bits  = INADDR_BROADCAST << (32 - mask.width());
+        _min._addr     &= bits;
+        _max._addr     |= ~bits;
+      }
+    }
+    return *this;
+  }
+
+  bool
+  IP4Range::load(string_view text)
+  {
+    static const string_view SEPARATORS("/-");
+    auto idx = text.find_first_of(SEPARATORS);
+    if (idx != text.npos) {
+      if (idx + 1 < text.size()) { // must have something past the separator or it's bogus.
+        if ('/' == text[idx]) {
+          metric_type addr;
+          if (addr.load(text.substr(0, idx))) { // load the address
+            IPMask mask;
+            text.remove_prefix(idx + 1); // drop address and separator.
+            if (mask.load(text)) {
+              this->assign(addr, mask);
+              return true;
+            }
+          }
+        } else if (_min.load(text.substr(0, idx)) && _max.load(text.substr(idx + 1))) {
+          return true;
+        }
+      }
+    } else if (_min.load(text)) {
+      _max = _min;
+      return true;
+    }
+
+    this->clear();
+    return false;
+  }
+
+  IPMask
+  IP4Range::network_mask() const
+  {
+    NetSource nets{*this};
+    if (!nets.empty() && (*nets).as_range() == *this) {
+      return nets->mask();
+    }
+    return {}; // default constructed (invalid) mask.
+  }
+
+  IP4Range::NetSource::NetSource(IP4Range::NetSource::range_type const &range) : _range(range)
+  {
+    if (!_range.empty()) {
+      this->search_wider();
+    }
+  }
+
+  auto
+  IP4Range::NetSource::operator++() -> self_type &
+  {
+    auto upper(IP4Addr{_range._min._addr | ~_mask._addr});
+    if (upper >= _range.max()) {
+      _range.clear();
+    } else {
+      _range.assign_min(++upper);
+      // @a _range is not empty, because there's at least one address still not covered.
+      if (this->is_valid(_mask)) {
+        this->search_wider();
+      } else {
+        this->search_narrower();
+      }
+    }
+    return *this;
+  }
+
+  auto
+  IP4Range::NetSource::operator++(int) -> self_type
+  {
+    auto zret{*this};
+    ++*this;
+    return zret;
+  }
+
+  void
+  IP4Range::NetSource::search_wider()
+  {
+    while (_cidr > 0) {
+      auto m   = _mask;
+      m      <<= 1;
+      if (this->is_valid(m)) {
+        _mask = m;
+        --_cidr;
       } else {
         break;
       }
     }
   }
 
-  // Handle empty quads - invalid if empty and still had a full set of quads
-  if (empty_idx >= 0) {
-    if (n < static_cast<int>(N_QUADS)) {
-      int nil_idx = N_QUADS - (n - empty_idx);
-      int delta   = N_QUADS - n;
-      for (int k = N_QUADS - 1; k >= empty_idx; --k) {
-        quad[QUAD_IDX[k]] = (k >= nil_idx ? quad[QUAD_IDX[k - delta]] : 0);
+  void
+  IP4Range::NetSource::search_narrower()
+  {
+    while (!this->is_valid(_mask)) {
+      _mask._addr >>= 1;
+      _mask._addr  |= 1U << (IP4Addr::WIDTH - 1); // put top bit back.
+      ++_cidr;
+    }
+  }
+
+  // +++ IP6Range +++
+
+  IP6Range &
+  IP6Range::assign(IP6Addr const &addr, IPMask const &mask)
+  {
+    static constexpr auto FULL_MASK{std::numeric_limits<uint64_t>::max()};
+    auto cidr = mask.width();
+    if (cidr == 0) {
+      _min = metric_type::MIN;
+      _max = metric_type::MAX;
+    } else if (cidr < 64) { // only upper bytes affected, lower bytes are forced.
+      auto bits            = FULL_MASK << (64 - cidr);
+      _min._addr._store[0] = addr._addr._store[0] & bits;
+      _min._addr._store[1] = 0;
+      _max._addr._store[0] = addr._addr._store[0] | ~bits;
+      _max._addr._store[1] = FULL_MASK;
+    } else if (cidr == 64) {
+      _min._addr._store[0] = _max._addr._store[0] = addr._addr._store[0];
+      _min._addr._store[1]                        = 0;
+      _max._addr._store[1]                        = FULL_MASK;
+    } else if (cidr <= 128) { // _min bytes changed, _max bytes unaffected.
+      _min = _max = addr;
+      if (cidr < 128) {
+        auto bits             = FULL_MASK << (128 - cidr);
+        _min._addr._store[1] &= bits;
+        _max._addr._store[1] |= ~bits;
       }
-      n = N_QUADS; // Mark success.
-    } else {
-      return false; // too many quads - full set plus empty.
     }
+    return *this;
   }
 
-  if (n == N_QUADS && src.empty()) {
-    return true;
-  }
-
-  this->clear();
-  return false;
-}
-
-// These are Intel correct, at some point will need to be architecture dependent.
-
-void
-IP6Addr::reorder(in6_addr &dst, raw_type const &src) {
-  self_type::reorder(dst.s6_addr, src.data());
-  self_type::reorder(dst.s6_addr + WORD_SIZE, src.data() + WORD_SIZE);
-}
-
-void
-IP6Addr::reorder(raw_type &dst, in6_addr const &src) {
-  self_type::reorder(dst.data(), src.s6_addr);
-  self_type::reorder(dst.data() + WORD_SIZE, src.s6_addr + WORD_SIZE);
-}
-
-IPAddr::IPAddr(IPEndpoint const &addr) {
-  this->assign(&addr.sa);
-}
-
-IPAddr &
-IPAddr::operator=(IPEndpoint const &addr) {
-  return this->assign(&addr.sa);
-}
-
-sockaddr *
-IPAddr::copy_to(sockaddr *sa) {
-  if (this->is_ip4()) {
-    _addr._ip4.copy_to(sa);
-  } else if (this->is_ip6()) {
-    _addr._ip6.copy_to(sa);
-  }
-  return sa;
-}
-
-bool
-IPAddr::load(const std::string_view &text) {
-  TextView src{text};
-  src.ltrim_if(&isspace);
-
-  if (TextView::npos != src.prefix(5).find_first_of('.')) {
-    _family = AF_INET;
-  } else if (TextView::npos != src.prefix(6).find_first_of(':')) {
-    _family = AF_INET6;
-  } else {
-    _family = AF_UNSPEC;
-  }
-
-  // Do the real parse now
-  switch (_family) {
-  case AF_INET:
-    if (!_addr._ip4.load(src)) {
-      _family = AF_UNSPEC;
-    }
-    break;
-  case AF_INET6:
-    if (!_addr._ip6.load(src)) {
-      _family = AF_UNSPEC;
-    }
-    break;
-  }
-  return this->is_valid();
-}
-
-IPAddr &
-IPAddr::assign(sockaddr const *addr) {
-  if (addr) {
-    switch (addr->sa_family) {
-    case AF_INET:
-      return this->assign(reinterpret_cast<sockaddr_in const *>(addr));
-    case AF_INET6:
-      return this->assign(reinterpret_cast<sockaddr_in6 const *>(addr));
-    default:
-      break;
-    }
-  }
-  _family = AF_UNSPEC;
-  return *this;
-}
-
-bool
-IPAddr::operator<(self_type const &that) const {
-  if (AF_INET == _family) {
-    switch (that._family) {
-    case AF_INET:
-      return _addr._ip4 < that._addr._ip4;
-    case AF_INET6:
+  bool
+  IP6Range::load(std::string_view text)
+  {
+    static const string_view SEPARATORS("/-");
+    auto idx = text.find_first_of(SEPARATORS);
+    if (idx != text.npos) {
+      if (idx + 1 < text.size()) { // must have something past the separator or it's bogus.
+        if ('/' == text[idx]) {
+          metric_type addr;
+          if (addr.load(text.substr(0, idx))) { // load the address
+            IPMask mask;
+            text.remove_prefix(idx + 1); // drop address and separator.
+            if (mask.load(text)) {
+              this->assign(addr, mask);
+              return true;
+            }
+          }
+        } else if (_min.load(text.substr(0, idx)) && _max.load(text.substr(idx + 1))) {
+          return true;
+        }
+      }
+    } else if (_min.load(text)) {
+      _max = _min;
       return true;
-    default:
-      return false;
     }
-  } else if (AF_INET6 == _family) {
-    switch (that._family) {
-    case AF_INET:
-      return true;
-    case AF_INET6:
-      return _addr._ip6 < that._addr._ip6;
-    default:
-      return false;
-    }
-  }
-  return that.is_valid();
-}
-
-int
-IPAddr::cmp(self_type const &that) const {
-  if (AF_INET == _family) {
-    switch (that._family) {
-    case AF_INET:
-      return _addr._ip4.cmp(that._addr._ip4);
-    case AF_INET6:
-      return -1;
-    default:
-      return 1;
-    }
-  } else if (AF_INET6 == _family) {
-    switch (that._family) {
-    case AF_INET:
-      return 1;
-    case AF_INET6:
-      return _addr._ip6.cmp(that._addr._ip6);
-    default:
-      return 1;
-    }
-  }
-  return that.is_valid() ? -1 : 0;
-}
-
-IPAddr::self_type &
-IPAddr::operator&=(IPMask const &mask) {
-  if (_family == AF_INET) {
-    _addr._ip4 &= mask;
-  } else if (_family == AF_INET6) {
-    _addr._ip6 &= mask;
-  }
-  return *this;
-}
-
-IPAddr::self_type &
-IPAddr::operator|=(IPMask const &mask) {
-  if (_family == AF_INET) {
-    _addr._ip4 |= mask;
-  } else if (_family == AF_INET6) {
-    _addr._ip6 |= mask;
-  }
-  return *this;
-}
-
-bool
-IPAddr::is_multicast() const {
-  return (AF_INET == _family && _addr._ip4.is_multicast()) || (AF_INET6 == _family && _addr._ip6.is_multicast());
-}
-
-IPEndpoint::IPEndpoint(string_view const &text) {
-  this->invalidate();
-  this->parse(text);
-}
-
-bool
-IPMask::load(string_view const &text) {
-  TextView parsed;
-  _cidr = swoc::svtou(text, &parsed);
-  if (parsed.size() != text.size()) {
-    _cidr = 0;
+    this->clear();
     return false;
   }
-  return true;
-}
 
-IPMask
-IPMask::mask_for(IPAddr const &addr) {
-  if (addr.is_ip4()) {
-    return self_type::mask_for(addr.ip4());
-  } else if (addr.is_ip6()) {
-    return self_type::mask_for(addr.ip6());
-  }
-  return {};
-}
-
-auto
-IPMask::mask_for_quad(IP6Addr::quad_type q) -> raw_type {
-  raw_type cidr = IP6Addr::QUAD_WIDTH;
-  if (q != 0) {
-    IP6Addr::quad_type mask = IP6Addr::QUAD_MASK;
-    do {
-      mask <<= 1;
-      --cidr;
-    } while ((q & mask) == q);
-    ++cidr; // loop goes exactly 1 too far.
-  }
-  return cidr;
-}
-
-IPMask
-IPMask::mask_for(IP4Addr const &addr) {
-  auto n        = addr.host_order();
-  raw_type cidr = 0;
-  if (auto q = (n & IP6Addr::QUAD_MASK); q != 0) {
-    cidr = IP6Addr::QUAD_WIDTH + self_type::mask_for_quad(q);
-  } else if (q = ((n >> IP6Addr::QUAD_WIDTH) & IP6Addr::QUAD_MASK); q != 0) {
-    cidr = self_type::mask_for_quad(q);
-  }
-  return self_type(cidr);
-}
-
-IPMask
-IPMask::mask_for(IP6Addr const &addr) {
-  auto cidr = IP6Addr::WIDTH;
-  for (unsigned idx = IP6Addr::N_QUADS; idx > 0;) {
-    auto q = addr._addr._quad[IP6Addr::QUAD_IDX[--idx]];
-    cidr -= IP6Addr::QUAD_WIDTH;
-    if (q != 0) {
-      cidr += self_type::mask_for_quad(q);
-      break;
+  IPRange::IPRange(IPAddr const &min, IPAddr const &max)
+  {
+    if (min.is_ip4() && max.is_ip4()) {
+      this->assign(min.ip4(), max.ip4());
+    } else if (min.is_ip6() && max.is_ip6()) {
+      this->assign(min.ip6(), max.ip6());
     }
   }
-  return self_type(cidr);
-}
 
-IP6Addr
-IPMask::as_ip6() const {
-  static constexpr auto MASK = ~IP6Addr::word_type{0};
-  if (_cidr == 0) {
-    return { 0, 0 };
-  } else if (_cidr <= IP6Addr::WORD_WIDTH) {
-    return {MASK << (IP6Addr::WORD_WIDTH - _cidr), 0};
-  } else if (_cidr < 2 * IP6Addr::WORD_WIDTH) {
-    return {MASK, MASK << (2 * IP6Addr::WORD_WIDTH - _cidr)};
-  }
-  return {MASK, MASK};
-}
-
-// --- SRV ---
-
-IP4Srv::IP4Srv(swoc::TextView text) {
-  this->load(text);
-}
-
-bool
-IP4Srv::load(swoc::TextView text) {
-  TextView addr_text, port_text, rest;
-  if (IPEndpoint::tokenize(text, &addr_text, &port_text, &rest)) {
-    if (rest.empty()) {
-      uintmax_t n = 0;
-      if (!port_text.empty()) {
-        n = swoc::svtou(port_text, &rest);
-        if (rest.size() != port_text.size() || n > std::numeric_limits<in_port_t>::max()) {
-          return false; // bad port.
-        }
-      }
-      IP4Addr addr;
-      if (addr.load(addr_text)) {
-        this->assign(addr, n);
+  bool
+  IPRange::load(std::string_view const &text)
+  {
+    if (auto idx = text.find_first_of(':'); idx != text.npos) {
+      if (_range._ip6.load(text)) {
+        _family = AF_INET6;
         return true;
       }
-    }
-  }
-  return false;
-}
-
-IP6Srv::IP6Srv(swoc::TextView text) {
-  this->load(text);
-}
-
-bool
-IP6Srv::load(swoc::TextView text) {
-  TextView addr_text, port_text, rest;
-  if (IPEndpoint::tokenize(text, &addr_text, &port_text, &rest)) {
-    if (rest.empty()) {
-      uintmax_t n = 0;
-      if (!port_text.empty()) {
-        n = swoc::svtou(port_text, &rest);
-        if (rest.size() != port_text.size() || n > std::numeric_limits<in_port_t>::max()) {
-          return false; // bad port.
-        }
-      }
-      IP6Addr addr;
-      if (addr.load(addr_text)) {
-        this->assign(addr, n);
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-IPSrv::IPSrv(swoc::TextView text) {
-  this->load(text);
-}
-
-bool
-IPSrv::load(swoc::TextView text) {
-  TextView addr_text, port_text, rest;
-  if (IPEndpoint::tokenize(text, &addr_text, &port_text, &rest)) {
-    if (rest.empty()) {
-      uintmax_t n = 0;
-      if (!port_text.empty()) {
-        n = swoc::svtou(port_text, &rest);
-        if (rest.size() != port_text.size() || n > std::numeric_limits<in_port_t>::max()) {
-          return false; // bad port.
-        }
-      }
-      IPAddr addr;
-      if (addr.load(addr_text)) {
-        this->assign(addr, n);
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-
-IPSrv::IPSrv(IPAddr addr, in_port_t port) : _family(addr.family()) {
-  
-  if (addr.is_ip4()) {
-    _srv._ip4.assign(addr.ip4(), port);
-  } else if (addr.is_ip6()) {
-    _srv._ip6.assign(addr.ip6(), port);
-  } else {
-    _family = AF_UNSPEC;
-  }
-}
-
-IPSrv::IPSrv(IPEndpoint const& ep) {
-  if (ep.is_ip4()) {
-    _family = _srv._ip4.family();
-    _srv._ip4.assign(&ep.sa4);
-  } else if (ep.is_ip6()) {
-    _family = _srv._ip6.family();
-    _srv._ip6.assign(&ep.sa6);
-  }
-}
-
-auto IPSrv::assign(const sockaddr *sa) -> self_type & {
-  if (AF_INET == sa->sa_family) {
-    _family = AF_INET;
-    _srv._ip4.assign(reinterpret_cast<sockaddr_in const *>(sa));
-  } else if (AF_INET6 == sa->sa_family) {
-    _family = AF_INET6;
-    _srv._ip6.assign(reinterpret_cast<sockaddr_in6 const *>(sa));
-  }
-  return *this;
-}
-
-// ++ IPNet ++
-
-bool
-IP4Net::load(TextView text) {
-  if (auto mask_text = text.split_suffix_at('/') ; !mask_text.empty() ) {
-    IPMask mask;
-    bool mask_p = mask.load(mask_text);
-    if (IP4Addr addr; addr.load(text)) {
-      if (!mask_p) {
-        if (IP4Addr m ; m.load(mask_text)) {
-          mask   = IPMask::mask_for(m);
-          mask_p = (m == mask.as_ip4()); // must be an actual mask like address.
-        }
-      }
-      if (mask_p) {
-        this->assign(addr, mask);
-        return true;
-      }
-    }
-  }
-
-  this->clear();
-  return false;
-}
-
-bool
-IP6Net::load(TextView text) {
-  if (auto mask_text = text.split_suffix_at('/') ; !mask_text.empty() ) {
-    IPMask mask;
-    bool mask_p = mask.load(mask_text);
-    if (IP6Addr addr; addr.load(text)) {
-      if (!mask_p) {
-        if (IP6Addr m ; m.load(mask_text)) {
-          mask   = IPMask::mask_for(m);
-          mask_p = (m == mask.as_ip6()); // must be an actual mask like address.
-        }
-      }
-      if (mask_p) {
-        this->assign(addr, mask);
-        return true;
-      }
-    }
-  }
-
-  this->clear();
-  return false;
-}
-
-bool
-IPNet::load(TextView text) {
-  if ( auto mask_text = text.split_suffix_at('/') ; !mask_text.empty() ) {
-    IPMask mask;
-    bool mask_p = mask.load(mask_text);
-
-    if (IP6Addr a6 ; a6.load(text)) { // load the address
-      if (!mask_p) {
-        if (IP6Addr m ; m.load(mask_text)) {
-          mask   = IPMask::mask_for(m);
-          mask_p = (m == mask.as_ip6()); // must be an actual mask like address.
-        }
-      }
-      if (mask_p) {
-        this->assign(a6, mask);
-        return true;
-      }
-    } else if (IP4Addr a4 ; a4.load(text)) {
-      if (!mask_p) {
-        if (IP4Addr m ; m.load(mask_text)) {
-          mask   = IPMask::mask_for(m);
-          mask_p = (m == mask.as_ip4()); // must be an actual mask like address.
-        }
-      }
-      if (mask_p) {
-        this->assign(a4, mask);
-        return true;
-      }
-    }
-  }
-  this->clear();
-  return false;
-}
-
-// +++ IP4Range +++
-
-IP4Range::IP4Range(swoc::IP4Addr const &addr, swoc::IPMask const &mask) {
-  this->assign(addr, mask);
-}
-
-IP4Range &
-IP4Range::assign(swoc::IP4Addr const &addr, swoc::IPMask const &mask) {
-  // Special case the cidr sizes for 0, maximum
-  if (0 == mask.width()) {
-    _min = metric_type::MIN;
-    _max = metric_type::MAX;
-  } else {
-    _min = _max = addr;
-    if (mask.width() < 32) {
-      in_addr_t bits = INADDR_BROADCAST << (32 - mask.width());
-      _min._addr &= bits;
-      _max._addr |= ~bits;
-    }
-  }
-  return *this;
-}
-
-bool
-IP4Range::load(string_view text) {
-  static const string_view SEPARATORS("/-");
-  auto idx = text.find_first_of(SEPARATORS);
-  if (idx != text.npos) {
-    if (idx + 1 < text.size()) { // must have something past the separator or it's bogus.
-      if ('/' == text[idx]) {
-        metric_type addr;
-        if (addr.load(text.substr(0, idx))) { // load the address
-          IPMask mask;
-          text.remove_prefix(idx + 1); // drop address and separator.
-          if (mask.load(text)) {
-            this->assign(addr, mask);
-            return true;
-          }
-        }
-      } else if (_min.load(text.substr(0, idx)) && _max.load(text.substr(idx + 1))) {
-        return true;
-      }
-    }
-  } else if (_min.load(text)) {
-    _max = _min;
-    return true;
-  }
-
-  this->clear();
-  return false;
-}
-
-IPMask
-IP4Range::network_mask() const {
-  NetSource nets{*this};
-  if (!nets.empty() && (*nets).as_range() == *this) {
-    return nets->mask();
-  }
-  return {}; // default constructed (invalid) mask.
-}
-
-IP4Range::NetSource::NetSource(IP4Range::NetSource::range_type const &range) : _range(range) {
-  if (!_range.empty()) {
-    this->search_wider();
-  }
-}
-
-auto
-IP4Range::NetSource::operator++() -> self_type & {
-  auto upper(IP4Addr{_range._min._addr | ~_mask._addr});
-  if (upper >= _range.max()) {
-    _range.clear();
-  } else {
-    _range.assign_min(++upper);
-    // @a _range is not empty, because there's at least one address still not covered.
-    if (this->is_valid(_mask)) {
-      this->search_wider();
-    } else {
-      this->search_narrower();
-    }
-  }
-  return *this;
-}
-
-auto IP4Range::NetSource::operator++(int) -> self_type {
-  auto zret { *this };
-  ++*this;
-  return zret;
-}
-
-void
-IP4Range::NetSource::search_wider() {
-  while (_cidr > 0) {
-    auto m = _mask;
-    m <<= 1;
-    if (this->is_valid(m)) {
-      _mask = m;
-      --_cidr;
-    } else {
-      break;
-    }
-  }
-}
-
-void
-IP4Range::NetSource::search_narrower() {
-  while (!this->is_valid(_mask)) {
-    _mask._addr >>= 1;
-    _mask._addr |= 1U << (IP4Addr::WIDTH - 1); // put top bit back.
-    ++_cidr;
-  }
-}
-
-// +++ IP6Range +++
-
-IP6Range &
-IP6Range::assign(IP6Addr const &addr, IPMask const &mask) {
-  static constexpr auto FULL_MASK{std::numeric_limits<uint64_t>::max()};
-  auto cidr = mask.width();
-  if (cidr == 0) {
-    _min = metric_type::MIN;
-    _max = metric_type::MAX;
-  } else if (cidr < 64) { // only upper bytes affected, lower bytes are forced.
-    auto bits            = FULL_MASK << (64 - cidr);
-    _min._addr._store[0] = addr._addr._store[0] & bits;
-    _min._addr._store[1] = 0;
-    _max._addr._store[0] = addr._addr._store[0] | ~bits;
-    _max._addr._store[1] = FULL_MASK;
-  } else if (cidr == 64) {
-    _min._addr._store[0] = _max._addr._store[0] = addr._addr._store[0];
-    _min._addr._store[1]                        = 0;
-    _max._addr._store[1]                        = FULL_MASK;
-  } else if (cidr <= 128) { // _min bytes changed, _max bytes unaffected.
-    _min = _max = addr;
-    if (cidr < 128) {
-      auto bits = FULL_MASK << (128 - cidr);
-      _min._addr._store[1] &= bits;
-      _max._addr._store[1] |= ~bits;
-    }
-  }
-  return *this;
-}
-
-bool
-IP6Range::load(std::string_view text) {
-  static const string_view SEPARATORS("/-");
-  auto idx = text.find_first_of(SEPARATORS);
-  if (idx != text.npos) {
-    if (idx + 1 < text.size()) { // must have something past the separator or it's bogus.
-      if ('/' == text[idx]) {
-        metric_type addr;
-        if (addr.load(text.substr(0, idx))) { // load the address
-          IPMask mask;
-          text.remove_prefix(idx + 1); // drop address and separator.
-          if (mask.load(text)) {
-            this->assign(addr, mask);
-            return true;
-          }
-        }
-      } else if (_min.load(text.substr(0, idx)) && _max.load(text.substr(idx + 1))) {
-        return true;
-      }
-    }
-  } else if (_min.load(text)) {
-    _max = _min;
-    return true;
-  }
-  this->clear();
-  return false;
-}
-
-IPRange::IPRange(IPAddr const &min, IPAddr const &max) {
-  if (min.is_ip4() && max.is_ip4()) {
-    this->assign(min.ip4(), max.ip4());
-  } else if (min.is_ip6() && max.is_ip6()) {
-    this->assign(min.ip6(), max.ip6());
-  }
-}
-
-bool
-IPRange::load(std::string_view const &text) {
-  if ( auto idx = text.find_first_of(':') ; idx != text.npos ) {
-    if (_range._ip6.load(text)) {
-      _family = AF_INET6;
+    } else if (_range._ip4.load(text)) {
+      _family = AF_INET;
       return true;
     }
-  } else if (_range._ip4.load(text)) {
-    _family = AF_INET;
-    return true;
-  }
 
-  return false;
-}
-
-IPAddr
-IPRange::min() const {
-  switch (_family) {
-  case AF_INET:
-    return _range._ip4.min();
-  case AF_INET6:
-    return _range._ip6.min();
-  default:
-    break;
-  }
-  return {};
-}
-
-IPAddr
-IPRange::max() const {
-  switch (_family) {
-  case AF_INET:
-    return _range._ip4.max();
-  case AF_INET6:
-    return _range._ip6.max();
-  default:
-    break;
-  }
-  return {};
-}
-
-bool
-IPRange::empty() const {
-  switch (_family) {
-  case AF_INET:
-    return _range._ip4.empty();
-  case AF_INET6:
-    return _range._ip6.empty();
-  default:
-    break;
-  }
-  return true;
-}
-
-IPMask
-IPRange::network_mask() const {
-  switch (_family) {
-  case AF_INET:
-    return _range._ip4.network_mask();
-  case AF_INET6:
-    return _range._ip6.network_mask();
-  default:
-    break;
-  }
-  return {};
-}
-
-bool
-IPRange::operator==(self_type const &that) const {
-  if (_family != that._family) {
     return false;
   }
-  if (this->is_ip4()) {
-    return _range._ip4 == that._range._ip4;
-  }
-  if (this->is_ip6()) {
-    return _range._ip6 == that._range._ip6;
-  }
-  return true;
-}
 
-IPMask
-IP6Range::network_mask() const {
-  NetSource nets{*this};
-  if (!nets.empty() && (*nets).as_range() == *this) {
-    return nets->mask();
-  }
-  return {}; // default constructed (invalid) mask.
-}
-
-IP6Range::NetSource::NetSource(IP6Range::NetSource::range_type const &range) : _range(range) {
-  if (!_range.empty()) {
-    this->search_wider();
-  }
-}
-
-auto
-IP6Range::NetSource::operator++() -> self_type & {
-  auto upper = _range.min() | _mask;
-  if (upper >= _range.max()) {
-    _range.clear();
-  } else {
-    _range.assign_min(++upper);
-    // @a _range is not empty, because there's at least one address still not covered.
-    if (this->is_valid(_mask)) {
-      this->search_wider();
-    } else {
-      this->search_narrower();
-    }
-  }
-  return *this;
-}
-
-void
-IP6Range::NetSource::search_wider() {
-  while (_mask.width() > 0) {
-    auto m = _mask;
-    m <<= 1;
-    if (this->is_valid(m)) {
-      _mask = m;
-    } else {
+  IPAddr
+  IPRange::min() const
+  {
+    switch (_family) {
+    case AF_INET:
+      return _range._ip4.min();
+    case AF_INET6:
+      return _range._ip6.min();
+    default:
       break;
     }
+    return {};
   }
-}
 
-void
-IP6Range::NetSource::search_narrower() {
-  while (!this->is_valid(_mask)) {
-    _mask >>= 1;
+  IPAddr
+  IPRange::max() const
+  {
+    switch (_family) {
+    case AF_INET:
+      return _range._ip4.max();
+    case AF_INET6:
+      return _range._ip6.max();
+    default:
+      break;
+    }
+    return {};
   }
-}
 
-bool
-IPRangeView::operator==(IPRange const &r) const {
-  if (_family == r.family()) {
-    if (AF_INET == _family) {
-      return *_raw._4 == r.ip4();
-    } else if (AF_INET6 == _family) {
-      return *_raw._6 == r.ip6();
+  bool
+  IPRange::empty() const
+  {
+    switch (_family) {
+    case AF_INET:
+      return _range._ip4.empty();
+    case AF_INET6:
+      return _range._ip6.empty();
+    default:
+      break;
     }
     return true;
   }
-  return false;
-}
 
-bool
-IPRangeView::operator==(IPRangeView::self_type const &that) const {
-  if (_family == that._family) { // different families are not equal
-    if (AF_INET == _family) {
-      return (_raw._4 == that._raw._4) || (*_raw._4 == *that._raw._4);
-    } else if (AF_INET6 == _family) {
-      return (_raw._6 == that._raw._6) || (*_raw._6 == *that._raw._6);
+  IPMask
+  IPRange::network_mask() const
+  {
+    switch (_family) {
+    case AF_INET:
+      return _range._ip4.network_mask();
+    case AF_INET6:
+      return _range._ip6.network_mask();
+    default:
+      break;
+    }
+    return {};
+  }
+
+  bool
+  IPRange::operator==(self_type const &that) const
+  {
+    if (_family != that._family) {
+      return false;
+    }
+    if (this->is_ip4()) {
+      return _range._ip4 == that._range._ip4;
+    }
+    if (this->is_ip6()) {
+      return _range._ip6 == that._range._ip6;
     }
     return true;
   }
-  return false;
-}
 
-}  // namespace SWOC_VERSION_NS
-}  // namespace swoc
+  IPMask
+  IP6Range::network_mask() const
+  {
+    NetSource nets{*this};
+    if (!nets.empty() && (*nets).as_range() == *this) {
+      return nets->mask();
+    }
+    return {}; // default constructed (invalid) mask.
+  }
+
+  IP6Range::NetSource::NetSource(IP6Range::NetSource::range_type const &range) : _range(range)
+  {
+    if (!_range.empty()) {
+      this->search_wider();
+    }
+  }
+
+  auto
+  IP6Range::NetSource::operator++() -> self_type &
+  {
+    auto upper = _range.min() | _mask;
+    if (upper >= _range.max()) {
+      _range.clear();
+    } else {
+      _range.assign_min(++upper);
+      // @a _range is not empty, because there's at least one address still not covered.
+      if (this->is_valid(_mask)) {
+        this->search_wider();
+      } else {
+        this->search_narrower();
+      }
+    }
+    return *this;
+  }
+
+  void
+  IP6Range::NetSource::search_wider()
+  {
+    while (_mask.width() > 0) {
+      auto m   = _mask;
+      m      <<= 1;
+      if (this->is_valid(m)) {
+        _mask = m;
+      } else {
+        break;
+      }
+    }
+  }
+
+  void
+  IP6Range::NetSource::search_narrower()
+  {
+    while (!this->is_valid(_mask)) {
+      _mask >>= 1;
+    }
+  }
+
+  bool
+  IPRangeView::operator==(IPRange const &r) const
+  {
+    if (_family == r.family()) {
+      if (AF_INET == _family) {
+        return *_raw._4 == r.ip4();
+      } else if (AF_INET6 == _family) {
+        return *_raw._6 == r.ip6();
+      }
+      return true;
+    }
+    return false;
+  }
+
+  bool
+  IPRangeView::operator==(IPRangeView::self_type const &that) const
+  {
+    if (_family == that._family) { // different families are not equal
+      if (AF_INET == _family) {
+        return (_raw._4 == that._raw._4) || (*_raw._4 == *that._raw._4);
+      } else if (AF_INET6 == _family) {
+        return (_raw._6 == that._raw._6) || (*_raw._6 == *that._raw._6);
+      }
+      return true;
+    }
+    return false;
+  }
+
+} // namespace SWOC_VERSION_NS
+} // namespace swoc


### PR DESCRIPTION
Again, feel free to take what you want here. The big things is the update to .clang-format as well as the update to tools/clang-format.sh. Both are taken from ATS. To run, I just did

```
./tools/clang-format.sh code/include/swoc/*.h code/src/*.cc
```