### PR TITLE
Fix problem with negation in TextView/libswoc

### DIFF
--- a/code/src/TextView.cc
+++ b/code/src/TextView.cc
@@ -63,7 +63,12 @@ svtoi(TextView src, TextView *out, int base) {
         out->assign(start, parsed.data_end());
       }
       if (neg) {
-        zret = -intmax_t(std::min<uintmax_t>(n, ABS_MIN));
+        uintmax_t temp = std::min<uintmax_t>(n, ABS_MIN);
+        if (temp == ABS_MIN) {
+          zret = std::numeric_limits<intmax_t>::min();
+        } else {
+          zret = -intmax_t(temp);
+        }
       } else {
         zret = std::min(n, ABS_MAX);
       }

--- a/unit_tests/test_TextView.cc
+++ b/unit_tests/test_TextView.cc
@@ -459,6 +459,7 @@ TEST_CASE("TextView Conversions", "[libswoc][TextView]") {
   TextView n6 = "0X13f8";
   TextView n7 = "-2345679";
   TextView n8 = "+2345679";
+  TextView n9 = "-9223372036854775808";
   TextView x;
   n2.ltrim_if(&isspace);
 
@@ -482,6 +483,7 @@ TEST_CASE("TextView Conversions", "[libswoc][TextView]") {
   REQUIRE(2345679 == svtoi(n8, &x));
   REQUIRE(x == n8);
   REQUIRE(0b10111 == svtoi("0b10111"_tv));
+  REQUIRE(-9223372036854775808 == svtoi(n9));
 
   x = n4;
   REQUIRE(13 == swoc::svto_radix<10>(x));


### PR DESCRIPTION
ABS_MIN is 9223372036854775808
intmax_t(ABS_MIN) is -9223372036854775808
negation of that is overflow for intmax_t data type with max value of 9223372036854775807
And I think that's not the intention as well.

So I need to make this change.

This is needed for the problem found in oss fuzz - https://oss-fuzz.com/testcase-detail/5196561539530752

Also as suggested in https://github.com/apache/trafficserver/pull/10971, I am creating this PR. 